### PR TITLE
Named element access

### DIFF
--- a/shared/CoreModules/SmartCoreProcessor.h
+++ b/shared/CoreModules/SmartCoreProcessor.h
@@ -14,46 +14,31 @@ public:
 	SmartCoreProcessor() = default;
 
 protected:
-	void setLED(Elem el, float val, size_t color_idx = 0) {
-		if (count(el).num_lights == 0)
-			return;
-		auto idx = index(el);
-		auto led_idx = idx.light_idx + color_idx;
-		if (led_idx < ledValues.size())
-			ledValues[led_idx] = val;
-	}
-
-	void setOutput(Elem el, float val) {
-		if (count(el).num_outputs == 0)
-			return;
-		auto idx = index(el);
+	template<typename INFO::Elem EL>
+	void setOutput(float val) requires(ElementCount::count(INFO::Elements[std::size_t(EL)]).num_outputs == 1)
+	{
+		auto idx = index(EL);
 		outputValues[idx.output_idx] = val;
 	}
 
-	std::optional<float> getInput(Elem el) {
-		if (count(el).num_inputs == 0)
-			return 0;
-		auto idx = index(el);
+	template<typename INFO::Elem EL>
+	std::optional<float> getInput() requires(ElementCount::count(INFO::Elements[std::size_t(EL)]).num_inputs == 1)
+	{
+		auto idx = index(EL);
 		auto result = inputValues[idx.input_idx];
 		inputValues[idx.input_idx].reset();
 		return result;
 	}
 
-	float getParam(Elem el) {
-		if (count(el).num_params == 0)
-			return 0;
-		auto idx = index(el);
-		return paramValues[idx.param_idx];
-	}
-
 	template<typename INFO::Elem EL>
-	auto getState() {
+	auto getState() requires(ElementCount::count(INFO::Elements[std::size_t(EL)]).num_params > 0)
+	{
 		// get back the typed element from the list of elements
 		constexpr auto elementID = element_index(EL);
 		constexpr auto &elementRef = INFO::Elements[elementID];
 
 		// read raw value
-		auto rawValue = getParam(EL);
+		auto rawValue = getParamRaw(EL);
 
 		// construct element of same type as the element the enum points to
 		constexpr auto variantIndex = elementRef.index();
@@ -63,6 +48,38 @@ protected:
 		auto result = MetaModule::StateConversion::convertState(DummyElement, rawValue);
 
 		return result;
+	}
+
+	template<typename INFO::Elem EL, typename VAL>
+	void setLED(const VAL &value) requires(ElementCount::count(INFO::Elements[std::size_t(EL)]).num_lights > 0)
+	{
+		// get back the typed element from the list of elements
+		constexpr auto elementID = static_cast<size_t>(EL);
+		constexpr auto &elementRef = INFO::Elements[elementID];
+
+		// construct element of same type as the element the enum points to
+		constexpr auto variantIndex = elementRef.index();
+		std::variant_alternative_t<variantIndex, MetaModule::Element> DummyElement;
+
+		// call conversion function for that type of element
+		auto rawValues = MetaModule::StateConversion::convertLED(DummyElement, value);
+
+		for (std::size_t i = 0; i < rawValues.size(); i++) {
+			setLEDRaw(EL, rawValues[i], i);
+		}
+	}
+
+private:
+	float getParamRaw(Elem el) {
+		auto idx = index(el);
+		return paramValues[idx.param_idx];
+	}
+
+	void setLEDRaw(Elem el, float val, size_t color_idx = 0) {
+		auto idx = index(el);
+		auto led_idx = idx.light_idx + color_idx;
+		if (led_idx < ledValues.size())
+			ledValues[led_idx] = val;
 	}
 
 protected:

--- a/shared/CoreModules/elements/element_state_conversion.hh
+++ b/shared/CoreModules/elements/element_state_conversion.hh
@@ -59,4 +59,31 @@ constexpr Pot::State_t convertState(const T &, float val) requires(std::derived_
 	return val;
 }
 
+
+//
+// LEDs
+//
+
+// Fallback for single LED elements
+template <typename T>
+constexpr std::array<float,T::NumLights> convertLED(const T&, float value) requires(T::NumLights == 1)
+{
+    return {value};
+}
+
+// Fallback for single LED elements with explicit type conversion
+template <typename T>
+constexpr std::array<float,T::NumLights> convertLED(const T&, bool value) requires(T::NumLights == 1)
+{
+    return {value ? 1.0f : 0.0f};
+}
+
+
+template <typename T>
+constexpr std::array<float,T::NumLights> convertLED(const T&, BipolarColor_t color) requires(std::derived_from<T,DualLight>)
+{
+    return {-std::min(color.value, 0.0f), std::max(color.value, 0.f)};
+}
+
 } // namespace MetaModule::StateConversion
+

--- a/shared/CoreModules/elements/elements.hh
+++ b/shared/CoreModules/elements/elements.hh
@@ -16,6 +16,14 @@
 
 namespace MetaModule
 {
+// Generic
+
+class BipolarColor_t
+{
+public:
+	BipolarColor_t(float val): value(val) {}
+	float value;
+};
 
 // TODO: get rid of idx field once VCV rack modules work without it
 struct BaseElement {
@@ -111,7 +119,6 @@ struct MomentaryButton : Switch {
 };
 struct MomentaryButtonRGB : MomentaryButton {
 	static constexpr size_t NumLights = 3;
-	enum Color { RED, BLUE, GREEN };
 };
 
 struct LatchingButton : Switch {
@@ -119,7 +126,6 @@ struct LatchingButton : Switch {
 };
 struct LatchingButtonMonoLight : LatchingButton {
 	static constexpr size_t NumLights = 1;
-	enum Color { RED, BLUE, GREEN };
 };
 
 struct Toggle2pos : Switch {

--- a/shared/CoreModules/modules/ENVVCACore.cc
+++ b/shared/CoreModules/modules/ENVVCACore.cc
@@ -98,11 +98,11 @@ public:
 
 		// Ignoring input impedance and inverting 400kHz lowpass
 
-		if (auto input = getInput(AudioIn); input) {
+		if (auto input = getInput<AudioIn>(); input) {
 			auto output = vca.process(*input);
-			setOutput(AudioOut, output);
+			setOutput<AudioOut>(output);
 		} else {
-			setOutput(AudioOut, 0.f);
+			setOutput<AudioOut>(0.f);
 		}
 
 		// Ignoring output impedance and inverting 400kHz lowpass
@@ -112,39 +112,39 @@ public:
 	{
 		val = val / VoltageDivider(100e3f, 100e3f);
 		val *= getState<LevelSlider>();
-		setOutput(EnvOut, val);
-		setLED(LevelSlider, val / 8.f);
+		setOutput<EnvOut>(val);
+		setLED<LevelSlider>(val / 8.f);
 		// FIXME: slider lights should show if env is increasing or decreasing in voltage,
 		// even during State_t::FOLLOW
-		setLED(RiseSlider, state == TriangleOscillator::State_t::RISING ? val / 8.f : 0);
-		setLED(FallSlider, state == TriangleOscillator::State_t::FALLING ? val / 8.f : 0);
+		setLED<RiseSlider>(state == TriangleOscillator::State_t::RISING ? val / 8.f : 0);
+		setLED<FallSlider>(state == TriangleOscillator::State_t::FALLING ? val / 8.f : 0);
 	}
 
 	void displayOscillatorState(TriangleOscillator::State_t state)
 	{
 		if (state == TriangleOscillator::State_t::FALLING) {
-			setOutput(Eor, 8.f);
-			setLED(EorLed, 1);
+			setOutput<Eor>(8.f);
+			setLED<EorLed>(true);
 		} else {
-			setOutput(Eor, 0);
-			setLED(EorLed, 0);
+			setOutput<Eor>(0);
+			setLED<EorLed>(false);
 		}
 	}
 
 	void runOscillator() {
-		bool isCycling = (getState<CycleButton>() == MetaModule::LatchingButton::State_t::DOWN) ^ CVToBool(getInput(CycleJack).value_or(0.0f));
+		bool isCycling = (getState<CycleButton>() == MetaModule::LatchingButton::State_t::DOWN) ^ CVToBool(getInput<CycleJack>().value_or(0.0f));
 
 		osc.setCycling(isCycling);
 		if (cycleLED != isCycling){
 			cycleLED = isCycling;
-			setLED(CycleButton, cycleLED);
+			setLED<CycleButton>(cycleLED);
 		}
 
-		if (auto inputFollowValue = getInput(Follow); inputFollowValue) {
+		if (auto inputFollowValue = getInput<Follow>(); inputFollowValue) {
 			osc.setTargetVoltage(*inputFollowValue);
 		}
 
-		if (auto triggerInputValue = getInput(Trigger); triggerInputValue) {
+		if (auto triggerInputValue = getInput<Trigger>(); triggerInputValue) {
 			if (triggerEdgeDetector(triggerDetector(*triggerInputValue))) {
 				osc.doRetrigger();
 			}
@@ -184,7 +184,7 @@ public:
 			return InvertingAmpWithBias(offset, 100e3f, 100e3f, bias);
 		};
 
-		if (auto timeCVValue = getInput(TimeCv); timeCVValue) {
+		if (auto timeCVValue = getInput<TimeCv>(); timeCVValue) {
 			// scale down cv input
 			const auto scaledTimeCV = *timeCVValue * -100e3f / 137e3f;
 
@@ -200,16 +200,8 @@ public:
 		fallCV = -fScaleLEDs - ProcessCVOffset(getState<FallSlider>(), fallRange);
 
 		// TODO: LEDs only need to be updated ~60Hz instead of 48kHz
-		// FIXME: Safer way to select the sub-element of a multi-color LED?
-		auto rise_positive = std::max(rScaleLEDs / 10.f, 0.f);
-		auto rise_negative = -std::min(rScaleLEDs / 10.f, 0.f);
-		setLED(RiseCvLed, rise_negative, 0);
-		setLED(RiseCvLed, rise_positive, 1);
-
-		auto fall_positive = std::max(fScaleLEDs / 10.f, 0.f);
-		auto fall_negative = -std::min(fScaleLEDs / 10.f, 0.f);
-		setLED(FallCvLed, fall_negative, 0);
-		setLED(FallCvLed, fall_positive, 1);
+		setLED<RiseCvLed>(MetaModule::BipolarColor_t{rScaleLEDs / 10.f});
+		setLED<FallCvLed>(MetaModule::BipolarColor_t{fScaleLEDs / 10.f});
 
 		// TODO: low pass filter
 


### PR DESCRIPTION
First shot of named element access

Art this stage we would simplify it by only defining the conversions based on the `State_t` we want to convert to 

```
template <>
constexpr MomentaryButton::State_t convertState<MomentaryButton::State_t>(float val) {
..
}
```
but keeping it like it is allows to add more functionality derived from properties of the element itself (like what you have in `PotElementHelper`)