### PR TITLE
envvca: Correct voltage to frequency mapping

### DIFF
--- a/shared/CoreModules/4ms/core/ENVVCACore.cc
+++ b/shared/CoreModules/4ms/core/ENVVCACore.cc
@@ -19,7 +19,7 @@ inline auto CVToBool = [](float val) -> bool
 
 struct VoltageToFreqTableRange
 {
-	static constexpr float min = -0.1f;
+	static constexpr float min = -0.2f;
 	static constexpr float max = 0.5f;
 };
 constinit auto VoltageToFrequencyTable = Mapping::LookupTable_t<50>::generate<VoltageToFreqTableRange>([](auto voltage)


### PR DESCRIPTION
Adapted the function to generate the lookup table according to the manual.

The frequency ranges without CV now match the ones given in the manual.  
The ranges with CV are larger though. Not sure how important that is. Let me know if I should have another look