### PR TITLE
90 add cmake targets to firmware makefile to enable bash completion

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -7,11 +7,11 @@ else
 GEN := Ninja
 endif
 
-configure:
-	cmake --fresh --preset ${PRESET} -G ${GEN}
-
 all:
 	cmake --build --preset ${PRESET} 
+
+configure:
+	cmake --fresh --preset ${PRESET} -G ${GEN}
 
 bootloader tests dep_tests simulate gen_minblep module-infos vcv-images comp-images faceplate-images image-list flash-bootloader-sd flash-app-sd flash-dfu jprog:
 	cmake --build --preset ${PRESET} -- $(MAKECMDGOALS)


### PR DESCRIPTION
Adds all cmake targets to the Makefile so we can do `make boot[TAB]`, etc.
Also I made `make all` the default target since that happens more often than configuration