### PR TITLE
Fix USB activity interrupts read of gate jacks

### DIFF
--- a/firmware/src/core_m4/hsem_handler.hh
+++ b/firmware/src/core_m4/hsem_handler.hh
@@ -6,12 +6,11 @@
 namespace MetaModule
 {
 struct HWSemaphoreCoreHandler : public mdrivlib::HWSemaphoreGlobalBase {
-	static void enable_global_ISR(uint32_t pri1, uint32_t pri2)
-	{
+	static void enable_global_ISR(uint32_t pri1, uint32_t pri2) {
 		mdrivlib::InterruptManager::register_and_start_isr(HSEM_IT2_IRQn, pri1, pri2, [&]() {
 			handle_isr<ParamsBuf1Lock>();
 			handle_isr<ParamsBuf2Lock>();
-			handle_isr<ScreenFrameBufLock>();
+			// handle_isr<ScreenFrameBufLock>();
 		});
 	}
 };

--- a/firmware/src/core_m4/main_m4.cc
+++ b/firmware/src/core_m4/main_m4.cc
@@ -75,7 +75,7 @@ void main() {
 	Controls controls{*param_block_base, *auxsignal_buffer, main_gpio_expander, ext_gpio_expander, usb.get_midi_host()};
 	SharedBusQueue i2cqueue{main_gpio_expander, ext_gpio_expander};
 
-	HWSemaphoreCoreHandler::enable_global_ISR(2, 1);
+	HWSemaphoreCoreHandler::enable_global_ISR(0, 1);
 
 	controls.start();
 

--- a/firmware/src/medium/conf/control_conf.hh
+++ b/firmware/src/medium/conf/control_conf.hh
@@ -13,7 +13,7 @@ namespace MetaModule
 const mdrivlib::TimekeeperConfig control_read_tim_conf = {
 	.TIMx = TIM6,
 	.period_ns = 20000, // must be just a hair faster than 48kHz
-	.priority1 = 2,		// same group as global Semaphore unlock, so that
+	.priority1 = 0,		// same group as global Semaphore unlock, so that
 	.priority2 = 3,
 };
 

--- a/firmware/src/medium/conf/i2c_codec_conf.hh
+++ b/firmware/src/medium/conf/i2c_codec_conf.hh
@@ -5,8 +5,6 @@ using mdrivlib::GPIO;
 using mdrivlib::PinAF;
 using mdrivlib::PinNum;
 
-constexpr uint32_t LEDUpdateHz = 100;
-
 // I2C for main (internal) and aux (external/expander) codec, and internal and aux (ext/exp) GPIO Expander
 const mdrivlib::I2CConfig a7m4_shared_i2c_codec_conf = {
 	.I2Cx = I2C5,
@@ -19,7 +17,7 @@ const mdrivlib::I2CConfig a7m4_shared_i2c_codec_conf = {
 		.SCLH = 0x58,
 		.SCLL = 0x74,
 	},
-	.priority1 = 0,
+	.priority1 = 2,
 	.priority2 = 1,
 };
 
@@ -35,6 +33,6 @@ const mdrivlib::I2CConfig aux_i2c_conf = {
 			.SCLH = 0x58,
 			.SCLL = 0x74,
 		},
-	.priority1 = 0,
-	.priority2 = 1,
+	.priority1 = 1,
+	.priority2 = 2,
 };

--- a/firmware/src/usb/usb_host_manager.hh
+++ b/firmware/src/usb/usb_host_manager.hh
@@ -40,7 +40,7 @@ public:
 		midi_host.init();
 		msc_host.init();
 
-		mdrivlib::InterruptManager::register_and_start_isr(OTG_IRQn, 0, 0, [] { HAL_HCD_IRQHandler(&hhcd); });
+		mdrivlib::InterruptManager::register_and_start_isr(OTG_IRQn, 3, 0, [] { HAL_HCD_IRQHandler(&hhcd); });
 		auto err = USBH_Start(&usbhost);
 		if (err != USBH_OK)
 			pr_err("Error starting host\n");


### PR DESCRIPTION
Re-arrange M4 ISR priorities so reading of jacks isn't interrupted by long bouts of USB activity (like scanning the filesystem for patch files). This was causing short pulse-width gates to be missed, or longer gates to be read late.

Needs further testing on hardware to verify there are no side-effects from this (and USB MIDI works well without excessive latency).