### PR TITLE
Enable/Disable LTO via cmake

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.22)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/ccache.cmake)
 
+option(ENABLE_LTO "Enable Link-Time Optimizations" ON)
+
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 
 project(
@@ -10,6 +12,17 @@ project(
   DESCRIPTION "MetaModule"
   LANGUAGES C CXX ASM
 )
+
+if (ENABLE_LTO)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+
+  # This is needed to avoid lto to generate individual functions that are too large
+  # and will fail during linking
+  add_compile_options(-finline-limit=1024)
+else()
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+endif()
+
 
 #
 # LVGL

--- a/firmware/cmake/arch_mp15xa7.cmake
+++ b/firmware/cmake/arch_mp15xa7.cmake
@@ -49,7 +49,6 @@ target_compile_options(
             -Werror=return-type
             -Wsign-compare
             $<$<COMPILE_LANGUAGE:CXX>:
-            -flto=auto
             -ffold-simple-inlines
             -Wno-psabi
             -fno-rtti

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -328,7 +328,6 @@ target_link_script(
   -Wno-psabi
   -ffreestanding
   -nostartfiles
-  -flto=auto
 )
 
 add_bin_hex_command(main)

--- a/firmware/src/core_m4/CMakeLists.txt
+++ b/firmware/src/core_m4/CMakeLists.txt
@@ -137,7 +137,6 @@ target_compile_options(
           -Werror=return-type
           -Wsign-compare
           -Wdouble-promotion
-          -flto=auto
           $<$<COMPILE_LANGUAGE:CXX>:
           -ffold-simple-inlines
           -Wno-psabi
@@ -166,7 +165,6 @@ target_link_script(
   -Wl,--gc-sections
   -ffreestanding
   -nostartfiles
-  -flto=auto
   ${MCU_FLAGS}
 )
 


### PR DESCRIPTION
I was looking into speeding up the compliation/linking process and found that LTO was enabled. It only worked partly though since the a7 sources are not compiled with the LTO option.

This patch allows to disable LTO for faster linking (the effect is not super huge unfortunately) or fully enable it via cmake.

```
                text    data   bss         dec         hex         filename
default         4388376 495984 278256368   283140728   10e06278    /home/user/Code/metamodule/firmware/build/mp1corea7/medium/main.elf
no lto          4388640 509424 278256240   283154304   10e09780    /home/user/Code/metamodule/firmware/build/mp1corea7/medium/main.elf
full lto        4370816 495968 278256368   283123152   10e01dd0    /home/user/Code/metamodule/firmware/build/mp1corea7/medium/main.elf
```

