### PR TITLE
Stop wifi comm also before calculating QSPI checksum

### DIFF
--- a/firmware/src/fw_update/firmware_writer.cc
+++ b/firmware/src/fw_update/firmware_writer.cc
@@ -133,6 +133,12 @@ IntercoreStorageMessage FirmwareWriter::flashWifi(std::span<uint8_t> buffer, uin
 
 IntercoreStorageMessage
 FirmwareWriter::compareChecksumQSPI(uint32_t address, uint32_t length, Checksum_t checksum, uint32_t &bytesChecked) {
+
+	// Stop wifi reception before long running operation
+#ifdef ENABLE_WIFI_BRIDGE
+	WifiInterface::stop();
+#endif
+
 	MD5Processor processor;
 
 	const std::size_t BlockSize = 4096;


### PR DESCRIPTION
fixes #203

Once an update is started, there is no way to go back to normal operation, right? Because in that case wifi comm would have to be enabled again.