### PR TITLE
Module custom data Serialization/Deserialization

### DIFF
--- a/firmware/src/VCV_adaptor/engine/Module.cpp
+++ b/firmware/src/VCV_adaptor/engine/Module.cpp
@@ -5,19 +5,5 @@
 namespace rack::engine
 {
 
-void Module::initialize_state(std::string_view state_string) {
-	json_error_t err;
-	json_t *root = json_loadb(state_string.data(), state_string.size(), 0, &err);
-	if (!root) {
-		pr_err("JSON decode error: %d:%d %s\n", err.line, err.column, err.text);
-		return;
-	}
-
-	json_t *data = json_object_get(root, "data");
-	if (data) 
-		this->dataFromJson(data);
-	
-	json_decref(root);
-}
 
 } // namespace rack::engine

--- a/firmware/src/VCV_adaptor/engine/Module.hpp
+++ b/firmware/src/VCV_adaptor/engine/Module.hpp
@@ -356,8 +356,6 @@ struct Module : VCVModuleWrapper {
 	// PRIVATE int meterIndex();
 	// PRIVATE void doProcess(const ProcessArgs &args);
 	// PRIVATE static void jsonStripIds(json_t *rootJ);
-
-	void initialize_state(std::string_view state_string) override;
 };
 
 } // namespace rack::engine


### PR DESCRIPTION
I looked into this but I am not sure what the best way forward would be.  
This is the state of things at the moment in case I was not missing something

- There is `CoreProcessor::initialize_state` that is called from the patch player and takes a string view but the way it is called it's clear that this is supposed to be a json string
- There is also `Module::initialize_state` in VCV_Adaptor that just forwards to `dataFromJson()`. This method is not called by the hardware. Since it is not present in the original rack api and not used anywhere I removed it
- I don't see serialization (`dataToJson`) used anywhere in hardware

I guess the way to go is extend the `CoreProcessor` with serialization/deserialization capabilities. However I am not sure if we want to add json as dependency (requiring modules to parse it) nor adding the dependency on a particular json library. My alternative suggestion would be that modules are given a fixed size (maybe defined via the info file) byte buffer and decide for themselves how to store their data there. To store that buffer in the patch json file we could base64 encode it.

Modules that are close to hardware can just memcpy custom structs there and vcv_adaptor enabled modules can still use json (and would end up with base64 encoded json inside json which is somewhat weird but should work).

I guess I could give it a shot (using https://github.com/tobiaslocker/base64) but I wanted to check this before with you @danngreen 