### PR TITLE
Update VCV Makefile and fix Windows compilation

### DIFF
--- a/vcv/Makefile
+++ b/vcv/Makefile
@@ -1,7 +1,7 @@
 # If RACK_DIR is not defined when calling the Makefile, default to two directories above
 RACK_DIR ?= ../..
 
-SHARED = src/shared
+SHARED = ../shared
 
 ## Cpputil
 INCLUDES += -I$(SHARED)/cpputil


### PR DESCRIPTION
On Windows, the symlink used in `src/shared` doesn't work, but setting SHARED to `../shared` works correctly.