### PR TITLE
VCV saves knob mapping alias names to patch file

### DIFF
--- a/vcv/src/hub/hub_knob_mappings.hh
+++ b/vcv/src/hub/hub_knob_mappings.hh
@@ -138,6 +138,9 @@ public:
 	void setMapAliasName(MappableObj paramObj, std::string newname) {
 		if (paramObj.objID < (int)NumKnobs) {
 			aliases[paramObj.objID][activeSetId].copy(newname);
+			auto &knobmultimap = mappings[paramObj.objID];
+			auto &mapset = knobmultimap[0]; //first map per pot
+			mapset.maps[activeSetId].alias_name = newname;
 		}
 	}
 

--- a/vcv/src/mapping/mapping.hh
+++ b/vcv/src/mapping/mapping.hh
@@ -4,7 +4,7 @@
 struct Mapping {
 	int64_t moduleId = -1;
 	int paramId = -1;
-	// std::string text = "";
+	std::string alias_name = "";
 
 	float range_min = 0.f;
 	float range_max = 1.f;

--- a/vcv/src/mapping/patch_writer.cc
+++ b/vcv/src/mapping/patch_writer.cc
@@ -217,7 +217,7 @@ void PatchFileWriter::addKnobMaps(unsigned panelKnobId, unsigned knobSetId, cons
 			.curve_type = 0,
 			.min = m.range_min,
 			.max = m.range_max,
-			.alias_name = "", //TODO
+			.alias_name = m.alias_name.c_str(),
 		});
 	}
 }


### PR DESCRIPTION
Adds the missing piece in knob mapping alias names: you can know set a name from within VCV Rack (right-click on hub knob and type in a name in the Alias field). 
Closes #41 