### PR TITLE
Firmware updater improvements

### DIFF
--- a/firmware/lib/stm32-hal/stm32mp1/include/stm32mp1xx_ll_sdmmc.h
+++ b/firmware/lib/stm32-hal/stm32mp1/include/stm32mp1xx_ll_sdmmc.h
@@ -298,8 +298,14 @@ typedef struct
 #define SDMMC_SINGLE_BUS_SUPPORT           ((uint32_t)0x00010000U)
 #define SDMMC_CARD_LOCKED                  ((uint32_t)0x02000000U)
 
-//#define SDMMC_DATATIMEOUT                  ((uint32_t)0xFFFFFFFFU)
-#define SDMMC_DATATIMEOUT                  ((uint32_t)5000U) // 5 seconds
+///////////////////
+// See https://github.com/STMicroelectronics/STM32CubeF7/issues/20
+//
+// SDMMC_DATATIMEOUT: units is clock bus periods: max time DPSM can be in Wait_R or Busy before timeout status flag is set
+#define SDMMC_DATATIMEOUT                  ((uint32_t)0x09300000)  // about 200ms
+// SDMMC_DATATIMEOUT_TICKS: units is ticks (1ms by default) 
+#define SDMMC_DATATIMEOUT_TICKS            ((uint32_t)1000U)       // 1 second
+///////////////////
 
 #define SDMMC_0TO7BITS                     ((uint32_t)0x000000FFU)
 #define SDMMC_8TO15BITS                    ((uint32_t)0x0000FF00U)

--- a/firmware/lib/stm32-hal/stm32mp1/src/stm32mp1xx_hal_sd.c
+++ b/firmware/lib/stm32-hal/stm32mp1/src/stm32mp1xx_hal_sd.c
@@ -402,7 +402,7 @@ HAL_StatusTypeDef HAL_SD_Init(SD_HandleTypeDef *hsd)
   tickstart = HAL_GetTick();
   while((HAL_SD_GetCardState(hsd) != HAL_SD_CARD_TRANSFER))
   {
-    if((HAL_GetTick()-tickstart) >=  SDMMC_DATATIMEOUT)
+    if((HAL_GetTick()-tickstart) >=  SDMMC_DATATIMEOUT_TICKS)
     {
       hsd->ErrorCode = HAL_SD_ERROR_TIMEOUT;
       hsd->State= HAL_SD_STATE_READY;
@@ -2724,7 +2724,7 @@ static uint32_t SD_PowerON(SD_HandleTypeDef *hsd)
         /* Check to CKSTOP */
         while(( hsd->Instance->STA & SDMMC_FLAG_CKSTOP) != SDMMC_FLAG_CKSTOP)
         {
-          if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT)
+          if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT_TICKS)
           {
             return HAL_SD_ERROR_TIMEOUT;
           }
@@ -2754,7 +2754,7 @@ static uint32_t SD_PowerON(SD_HandleTypeDef *hsd)
           /* Check VSWEND Flag */
           while(( hsd->Instance->STA & SDMMC_FLAG_VSWEND) != SDMMC_FLAG_VSWEND)
           {
-            if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT)
+            if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT_TICKS)
             {
               return HAL_SD_ERROR_TIMEOUT;
             }
@@ -2864,7 +2864,7 @@ static uint32_t SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus)
       }
     }
     
-    if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT)
+    if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT_TICKS)
     {
       return HAL_SD_ERROR_TIMEOUT;
     }
@@ -2892,7 +2892,7 @@ static uint32_t SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus)
     *pData = SDMMC_ReadFIFO(hsd->Instance);
     pData++;
     
-    if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT)
+    if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT_TICKS)
     {
       return HAL_SD_ERROR_TIMEOUT;
     }
@@ -3082,7 +3082,7 @@ static uint32_t SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
     }
 
     
-    if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT)
+    if((HAL_GetTick() - tickstart) >=  SDMMC_DATATIMEOUT_TICKS)
     {
       return HAL_SD_ERROR_TIMEOUT;
     }
@@ -3239,7 +3239,7 @@ uint32_t SD_HighSpeed(SD_HandleTypeDef *hsd)
         loop ++;
       }
 
-      if((HAL_GetTick()-Timeout) >=  SDMMC_DATATIMEOUT)
+      if((HAL_GetTick()-Timeout) >=  SDMMC_DATATIMEOUT_TICKS)
       {
         hsd->ErrorCode = HAL_SD_ERROR_TIMEOUT;
         hsd->State= HAL_SD_STATE_READY;
@@ -3354,7 +3354,7 @@ uint32_t SD_UltraHighSpeed(SD_HandleTypeDef *hsd)
         loop ++;
       }
       
-      if((HAL_GetTick()-Timeout) >=  SDMMC_DATATIMEOUT)
+      if((HAL_GetTick()-Timeout) >=  SDMMC_DATATIMEOUT_TICKS)
       {
         hsd->ErrorCode = HAL_SD_ERROR_TIMEOUT;
         hsd->State= HAL_SD_STATE_READY;

--- a/firmware/src/core_intercom/intercore_message.hh
+++ b/firmware/src/core_intercom/intercore_message.hh
@@ -43,7 +43,6 @@ struct IntercoreStorageMessage {
 
 		RequestReadFlash,
 		ReadFlashOk,
-		ReadFlashFailed,
 
 		RequestLoadFileToRam,
 		LoadFileToRamFailed,

--- a/firmware/src/core_intercom/intercore_message.hh
+++ b/firmware/src/core_intercom/intercore_message.hh
@@ -33,6 +33,9 @@ struct IntercoreStorageMessage {
 		ChecksumMatch,
 		ChecksumMismatch,
 		ChecksumFailed,
+		ReadFlashFailed,
+		WifiExpanderNotConnected,
+		WifiExpanderCommError,
 
 		StartFlashing, // write to Flash or WifiExpander
 		FlashingOk,

--- a/firmware/src/flash_loader/flash_loader.cc
+++ b/firmware/src/flash_loader/flash_loader.cc
@@ -14,13 +14,17 @@ bool FlashLoader::check_flash_chip() {
 }
 
 bool FlashLoader::write_sectors(uint32_t base_addr, std::span<uint8_t> buffer) {
+	constexpr bool verbose_log = false;
+
 	//round up to smallest 4kB blocks that contains image
 	unsigned bytes_to_erase = (buffer.size() + 4095) & ~4095;
 
 	uint32_t addr = base_addr;
 
 	while (bytes_to_erase) {
-		pr_trace("Erasing 4k sector at 0x%x\n", (unsigned)addr);
+		if constexpr (verbose_log)
+			pr_dump("Erasing 4k sector at 0x%x\n", (unsigned)addr);
+
 		if (!flash.erase(mdrivlib::QSpiFlash::SECTOR, addr)) {
 			pr_err("ERROR: Flash failed to erase\n");
 			return false;
@@ -29,7 +33,9 @@ bool FlashLoader::write_sectors(uint32_t base_addr, std::span<uint8_t> buffer) {
 		bytes_to_erase -= 4096;
 	}
 
-	pr_trace("Writing 0x%x B to %x\n", buffer.size(), base_addr);
+	if constexpr (verbose_log)
+		pr_dump("Writing 0x%x B to %x\n", buffer.size(), base_addr);
+
 	if (!flash.write(buffer.data(), base_addr, buffer.size())) {
 		pr_err("ERROR: Flash failed to write\n");
 		return false;

--- a/firmware/src/fw_update/firmware_writer.cc
+++ b/firmware/src/fw_update/firmware_writer.cc
@@ -150,7 +150,7 @@ IntercoreStorageMessage FirmwareWriter::flashQSPI(std::span<uint8_t> buffer, uin
 	WifiInterface::stop();
 #endif
 
-	const uint32_t FlashSectorSize = 4096;
+	const uint32_t FlashSectorSize = 64 * 1024;
 	const std::size_t BatchSize = FlashSectorSize;
 	bytesWritten = 0;
 

--- a/firmware/src/fw_update/firmware_writer.cc
+++ b/firmware/src/fw_update/firmware_writer.cc
@@ -62,24 +62,21 @@ IntercoreStorageMessage FirmwareWriter::compareChecksumWifi(uint32_t address, ui
 
 	if (result == ESP_LOADER_SUCCESS) {
 
-		if (result == ESP_LOADER_SUCCESS) {
-			result = Flasher::verify(address, length, checksum);
-			if (result == ESP_LOADER_ERROR_INVALID_MD5) {
-				returnValue = {.message_type = ChecksumMismatch};
-			} else if (result == ESP_LOADER_SUCCESS) {
-				pr_dbg("-> Checksum matches\n");
-				returnValue = {.message_type = ChecksumMatch};
-			} else {
-				pr_dbg("-> Cannot get checksum\n");
-				returnValue = {.message_type = ChecksumFailed};
-			}
+		result = Flasher::verify(address, length, checksum);
+
+		if (result == ESP_LOADER_ERROR_INVALID_MD5) {
+			returnValue = {.message_type = ChecksumMismatch};
+		} else if (result == ESP_LOADER_SUCCESS) {
+			pr_trace("-> Checksum matches\n");
+			returnValue = {.message_type = ChecksumMatch};
+
 		} else {
-			pr_err("Cannot write dummy byte to wifi flash\n");
-			returnValue = {.message_type = ChecksumFailed};
+			pr_trace("-> Cannot get checksum\n");
+			returnValue = {.message_type = WifiExpanderCommError};
 		}
 	} else {
 		pr_err("Cannot connect to wifi bootloader\n");
-		returnValue = {.message_type = ChecksumFailed};
+		returnValue = {.message_type = WifiExpanderNotConnected};
 	}
 
 	Flasher::deinit();

--- a/firmware/src/fw_update/updater_proxy.cc
+++ b/firmware/src/fw_update/updater_proxy.cc
@@ -183,8 +183,15 @@ FirmwareUpdaterProxy::Status FirmwareUpdaterProxy::process() {
 						moveToState(Writing);
 						break;
 
+					case FileStorageProxy::WifiExpanderCommError:
+					case FileStorageProxy::ReadFlashFailed:
 					case FileStorageProxy::ChecksumFailed:
 						abortWithMessage("Error when comparing checksums");
+						break;
+
+					case FileStorageProxy::WifiExpanderNotConnected:
+						proceedWithNextFile();
+						// abortWithMessage("No Wifi expander found.");
 						break;
 
 					default:

--- a/firmware/src/fw_update/updater_proxy.cc
+++ b/firmware/src/fw_update/updater_proxy.cc
@@ -191,10 +191,18 @@ FirmwareUpdaterProxy::Status FirmwareUpdaterProxy::process() {
 						abortWithMessage("Error when comparing checksums");
 						break;
 
-					case FileStorageProxy::WifiExpanderNotConnected:
-						error_message = "No Wifi Expander: skipping " + manifest.files[current_file_idx].filename;
+					case FileStorageProxy::WifiExpanderNotConnected: {
+						error_message = "No Wifi Expander: skipping ";
+
+						auto full_path = manifest.files[current_file_idx].filename;
+						auto slash_pos = full_path.find_first_of("/");
+						if (slash_pos != std::string::npos)
+							error_message += full_path.substr(slash_pos + 1);
+						else
+							error_message += full_path;
+
 						proceedWithNextFile();
-						break;
+					} break;
 
 					default:
 						break;

--- a/firmware/src/fw_update/updater_proxy.cc
+++ b/firmware/src/fw_update/updater_proxy.cc
@@ -210,7 +210,8 @@ FirmwareUpdaterProxy::Status FirmwareUpdaterProxy::process() {
 						*target, thisLoadedFile, thisFile.address, &sharedMem->bytes_processed);
 
 					if (not result) {
-						abortWithMessage("Cannot trigger flashing");
+						// this is not an error, just need to retry
+						justEnteredState = true;
 					}
 				} else {
 					abortWithMessage("Invalid update file type");

--- a/firmware/src/fw_update/updater_proxy.cc
+++ b/firmware/src/fw_update/updater_proxy.cc
@@ -59,6 +59,8 @@ bool FirmwareUpdaterProxy::start(std::string_view manifest_filename,
 }
 
 FirmwareUpdaterProxy::Status FirmwareUpdaterProxy::process() {
+	error_message = "";
+
 	switch (state) {
 		case Idle:
 		case Success:
@@ -190,8 +192,8 @@ FirmwareUpdaterProxy::Status FirmwareUpdaterProxy::process() {
 						break;
 
 					case FileStorageProxy::WifiExpanderNotConnected:
+						error_message = "No Wifi Expander: skipping " + manifest.files[current_file_idx].filename;
 						proceedWithNextFile();
-						// abortWithMessage("No Wifi expander found.");
 						break;
 
 					default:
@@ -245,9 +247,7 @@ FirmwareUpdaterProxy::Status FirmwareUpdaterProxy::process() {
 			abortWithMessage("Internal Error");
 	}
 
-	return state == State::Error ?
-			   Status{state, current_file_name, current_file_size, sharedMem->bytes_processed, error_message} :
-			   Status{state, current_file_name, current_file_size, sharedMem->bytes_processed};
+	return Status{state, current_file_name, current_file_size, sharedMem->bytes_processed, error_message};
 }
 
 void FirmwareUpdaterProxy::abortWithMessage(const char *message) {

--- a/firmware/src/fw_update/updater_proxy.hh
+++ b/firmware/src/fw_update/updater_proxy.hh
@@ -18,7 +18,7 @@ public:
 		std::string name;
 		std::size_t file_size{0};
 		std::size_t bytes_completed{0};
-		std::string error_message{};
+		std::string message{};
 	};
 
 	FirmwareUpdaterProxy(FileStorageProxy &file_storage);

--- a/firmware/src/gui/pages/firmware_update_tab.hh
+++ b/firmware/src/gui/pages/firmware_update_tab.hh
@@ -31,6 +31,8 @@ struct FirmwareUpdateTab : SystemMenuTab {
 		display_file_not_found();
 
 		confirm_popup.init(ui_SystemMenu, group);
+		lv_label_set_text(ui_SystemMenuUpdateLog, "");
+		lv_hide(ui_SystemMenUpdateProgressBar);
 	}
 
 	// Returns true if this pages uses the back event
@@ -84,8 +86,11 @@ struct FirmwareUpdateTab : SystemMenuTab {
 			case State::Updating: {
 				auto status = updater.process();
 
+				if (status.state != FirmwareUpdaterProxy::Error && status.message.length())
+					append_log_message(status.message);
+
 				if (status.state == FirmwareUpdaterProxy::Error) {
-					display_update_failed(status.error_message);
+					display_update_failed(status.message);
 					state = State::Failed;
 
 				} else if (status.state == FirmwareUpdaterProxy::LoadingUpdateFiles) {
@@ -200,6 +205,13 @@ private:
 		lv_obj_set_style_text_color(ui_SystemMenuUpdateMessage, lv_palette_lighten(LV_PALETTE_RED, 1), LV_PART_MAIN);
 		lv_label_set_text_fmt(
 			ui_SystemMenuUpdateMessage, "Updating firmware failed!\n%.*s", (int)message.length(), message.data());
+		lv_hide(ui_FWUpdateSpinner);
+		lv_hide(ui_SystemMenUpdateProgressBar);
+	}
+
+	void append_log_message(std::string_view message) {
+		std::string log = lv_label_get_text(ui_SystemMenuUpdateLog);
+		lv_label_set_text_fmt(ui_SystemMenuUpdateLog, "%s\n%.*s", log.c_str(), (int)message.length(), message.data());
 		lv_hide(ui_FWUpdateSpinner);
 		lv_hide(ui_SystemMenUpdateProgressBar);
 	}

--- a/firmware/src/gui/slsexport/meta5/screens/ui_SystemMenu.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_SystemMenu.c
@@ -1047,4 +1047,13 @@ lv_obj_set_style_text_color(ui_SystemMenuUpdateLog, lv_color_hex(0xFFFFFF), LV_P
 lv_obj_set_style_text_opa(ui_SystemMenuUpdateLog, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_font(ui_SystemMenuUpdateLog, &ui_font_MuseoSansRounded50012, LV_PART_MAIN| LV_STATE_DEFAULT);
 
+ui_SystemMenuUpdateLog = lv_label_create(ui_SystemMenuUpdateTab);
+lv_obj_set_width( ui_SystemMenuUpdateLog, lv_pct(100));
+lv_obj_set_height( ui_SystemMenuUpdateLog, LV_SIZE_CONTENT);   /// 1
+lv_obj_set_align( ui_SystemMenuUpdateLog, LV_ALIGN_CENTER );
+lv_label_set_text(ui_SystemMenuUpdateLog,"");
+lv_obj_set_style_text_color(ui_SystemMenuUpdateLog, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
+lv_obj_set_style_text_opa(ui_SystemMenuUpdateLog, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_font(ui_SystemMenuUpdateLog, &ui_font_MuseoSansRounded50012, LV_PART_MAIN| LV_STATE_DEFAULT);
+
 }

--- a/firmware/src/wifi/comm/wifi_interface.cc
+++ b/firmware/src/wifi/comm/wifi_interface.cc
@@ -86,18 +86,18 @@ void sendBroadcast(std::span<uint8_t> payload) {
 ////////////////////////////////7
 
 void init(PatchStorage *storage) {
-	printf("Initializing Wifi\n");
+	pr_info("Initializing Wifi\n");
 
 	patchStorage = storage;
 }
 
 void start() {
-	pr_dbg("Wifi: Starting RX\n");
+	pr_trace("Wifi: Starting RX\n");
 	BufferedUSART2::init();
 }
 
 void stop() {
-	pr_dbg("Wifi: Stopping RX\n");
+	pr_trace("Wifi: Stopping RX\n");
 	BufferedUSART2::deinit();
 }
 
@@ -127,10 +127,10 @@ void handle_received_frame(uint8_t destination, std::span<uint8_t> payload) {
 
 				sendResponse(fbb.GetBufferSpan());
 			} else {
-				printf("Unexpected detection\n");
+				pr_err("Unexpected detection\n");
 			}
 		} else if (auto switchMessage = message->content_as_Switch(); switchMessage) {
-			printf("State: %u\n", switchMessage->state());
+			pr_trace("State: %u\n", switchMessage->state());
 
 			// Just echo back raw
 			sendResponse(payload);
@@ -149,7 +149,7 @@ void handle_received_frame(uint8_t destination, std::span<uint8_t> payload) {
 
 			auto filename = flatbuffers::GetStringView(uploadPatchMessage->filename());
 
-			printf("Received Patch of %u bytes for location %u\n", receivedPatchData.size(), destination);
+			pr_info("Received Patch of %u bytes for location %u\n", receivedPatchData.size(), destination);
 
 			auto LocationToVolume = [](auto location) -> std::optional<Volume> {
 				switch (location) {
@@ -199,10 +199,10 @@ void handle_received_frame(uint8_t destination, std::span<uint8_t> payload) {
 				sendBroadcast(fbb.GetBufferSpan());
 			}
 		} else {
-			printf("Other option\n");
+			pr_trace("Other option\n");
 		}
 	} else {
-		printf("Invalid message\n");
+		pr_err("Invalid message\n");
 	}
 }
 


### PR DESCRIPTION
Various improvements to UX of firmware updating, some from #204
- [x] Faster update of QSPI flash: only erase/write changed sectors. This makes the checksum of whole image redundant, so we skip that
- [ ]  Show name/description of file being processed
- [ ]  Show overall progress (file id and total number of files or log of previous actions like a terminal)
- [ ] Show release version in gui before actual update processes starts
- [x] Allow skipping wifi update files if failed to connect (notify/confirm with user). Not an error, message at the bottom of screen displays what was skipped
