### PR TITLE
Use up-to-date git tag for name of release files

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -141,7 +141,7 @@ add_custom_command(
            "${RELEASE_TARGET_DIR}/${MANIFEST_FILENAME}"
   COMMAND ${CMAKE_COMMAND} -E tar cf ${RELEASE_ARCHIVE_PATH} --format=zip -- ${RELEASE_TARGET_DIR} && rm -rf ${RELEASE_TARGET_DIR}
 
-  DEPENDS ${MAIN_FW_FILENAME} ${ASSET_IMG_PATH} bootloader bootloader-dfu
+  DEPENDS ${MAIN_FW_FILENAME} ${ASSET_IMG_PATH} bootloader bootloader-dfu AlwaysCheckGit
   COMMENT "Creating release at ${RELEASE_ARCHIVE_PATH}"
   VERBATIM USES_TERMINAL
 )


### PR DESCRIPTION
This was happening before (release file has old tag)

```
$ make all
[0/2] Re-checking globbed directories...
[0/11] Creating assets uimg file
[1/11] Building DFU Bootloader
make[1]: Für das Ziel „all“ ist nichts zu tun.
[2/11] cd /home/user/Code/metamodule/firmware/build && /usr/bin/cmake -DRUN_CHECK_GIT_VERSION=1 -Dpre_configure_dir=/home/user/Code/metamodule/firmware/cmake -Dpost_configure_file=/home/user/Code/metamodule/firmware/build/checkgit -DGIT_HASH_CACHE= -P /home/user/Code/metamodule/firmware/cmake/CheckGit.cmake
Git hash: c18d13f19. Commit time: 2024-07-01 13:38:30 +0200. Tag: firmware-v0.13.2-98-gc18d13f19
[3/9] Building MP1-Boot (FSBL)
python3 fsbl_header.py build/fsbl.bin build/fsbl.stm32
-rw-r--r--. 1 user user 35420  1. Jul 13:40 build/fsbl.stm32
[4/9] Generating table of API symbol addresses and installing in firmware binary
All API symbols found in main.elf
[5/9] cd /home/user/Code/metamodule/firmware/build && cd /home/user/Code/metamodule/firmware && make --no-print-directory -f tests/Makefile -j8 && cd /home/user/Code/metamodule/firmware/../shared/patch_convert &&...../shared/CoreModules && make --no-print-directory -f tests/Makefile -j8 && cd /home/user/Code/metamodule/firmware/../shared/CoreModules/4ms/core/axoloti-wrapper && make --no-print-directory -f tests/Makefile -j8
[√] Unit tests passed: firmware
[√] Unit tests passed: patch_convert
[√] Unit tests passed: CoreModules
[√] Unit tests passed: axoloti-wrapper
[6/9] Creating combined uimg file
Creating A7_.symlist at 0xc1f80000 with size 38732
Creating A7_.text+.rodata+.ARM.extab+.ARM+.p at 0xc2000040 with size 5394840
Contains entry point at 0xc2000040
Creating M4_.isr_vector at 0x38000000 with size 1088
Creating M4_.text+.startup_copro_fw.Reset_Ha at 0x30000000 with size 252628
Creating M4_.rodata+.bss at 0xc1fc0000 with size 162448
-rw-r--r--. 1 user user 5850056  1. Jul 13:40 /home/user/Code/metamodule/firmware/build/main.uimg
[7/9] Creating release at /home/user/Code/metamodule/firmware/build/metamodule-firmware-v0.13.2-89-g7fbfe325f-all.zip
```
