### PR TITLE
Fix Befaco Spring Reverb

### DIFF
--- a/firmware/vcv_plugin/export/pffft/CMakeLists.txt
+++ b/firmware/vcv_plugin/export/pffft/CMakeLists.txt
@@ -12,8 +12,9 @@ target_sources(pffft PRIVATE
 # Fixup for pffft compiler warnings
 set_source_files_properties(pffft.c PROPERTIES COMPILE_OPTIONS "-Wno-double-promotion;-Wno-pointer-to-int-cast")
 
-if(NOT DEFINED SIMULATOR)
-	target_compile_definitions(pffft PRIVATE ZCONVOLVE_USING_INLINE_ASM=1)
-endif()
+# Disable inline assembly until we ensure alignment
+# if(NOT DEFINED SIMULATOR)
+# 	target_compile_definitions(pffft PRIVATE ZCONVOLVE_USING_INLINE_ASM=1)
+# endif()
 
 target_include_directories(pffft PUBLIC .)


### PR DESCRIPTION
I had enabled inline assembly (NEON calls) for pffft which greatly improved performance. However, it only works when the buffers used for convolution are aligned properly. So sometimes it works, sometimes it crashes. 
Until I can add in over-alignment to the rack wrapper for pffft, then I'm turning this off.

So Spring Reverb works again. The buffer size has to be set to 512 @ 48kHz or 256 @ 24kHz, or else CPU usage spikes > 100%