### PR TITLE
#350 Fix bug when mapping midi cc and panel knob to a single virtual knob

### DIFF
--- a/firmware/src/gui/pages/module_view.hh
+++ b/firmware/src/gui/pages/module_view.hh
@@ -283,6 +283,10 @@ struct ModuleViewPage : PageBase {
 		}
 	}
 
+	bool is_creating_map() const {
+		return mapping_pane.is_creating_map();
+	}
+
 	void update() override {
 		if (gui_state.back_button.is_just_released()) {
 

--- a/firmware/src/gui/pages/module_view_mapping_pane.hh
+++ b/firmware/src/gui/pages/module_view_mapping_pane.hh
@@ -172,6 +172,10 @@ struct ModuleViewMappingPane {
 		}
 	}
 
+	bool is_creating_map() const {
+		return add_map_popup.visible;
+	}
+
 	bool wants_to_close() {
 		return should_close;
 	}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -137,6 +137,9 @@ public:
 		if (active_knobset >= patch->knob_sets.size())
 			return;
 
+		if (page_module.is_creating_map())
+			return;
+
 		// Iterate all panel knobs
 		for (auto panel_knob_i = 0u; panel_knob_i < info.params.knobs.size(); panel_knob_i++) {
 

--- a/firmware/src/params/params_state.hh
+++ b/firmware/src/params/params_state.hh
@@ -90,18 +90,18 @@ struct ParamsMidiState : ParamsState {
 			cc = 0;
 	}
 
-	std::optional<float> panel_knob_new_value(uint16_t mapped_panel_id) const {
+	std::optional<float> panel_knob_new_value(uint16_t mapped_panel_id) {
 
 		auto mk = MappedKnob{.panel_knob_id = mapped_panel_id};
 
 		if (mk.is_panel_knob()) {
-			auto latched = knobs[mapped_panel_id];
+			auto &latched = knobs[mapped_panel_id];
 			return latched.did_change() ? std::optional<float>{latched.val} : std::nullopt;
 		}
 
 		else if (mk.is_midi_cc())
 		{
-			auto latched = midi_ccs[mk.cc_num()];
+			auto &latched = midi_ccs[mk.cc_num()];
 			return latched.did_change() ? std::optional<float>{latched.val} : std::nullopt;
 		}
 


### PR DESCRIPTION
When testing `latched.did_change()` the variable `latched` was a copy instead of a reference. So `did_change()` returned true every time after the first time