### PR TITLE
Fix: LVGL inline hex colors are occasionally rendered as text

### DIFF
--- a/firmware/src/gui/elements/element_name.cc
+++ b/firmware/src/gui/elements/element_name.cc
@@ -53,16 +53,14 @@ static std::string get_mapped_color(Element const &element, uint16_t panel_id) {
 }
 
 void append_panel_name(std::string &opts, Element const &el, uint16_t mapped_panel_id) {
-	auto name = std::visit([=](auto &e) { return get_panel_name<PanelDef>(e, mapped_panel_id); }, el);
-	if (name.size() > 0) {
-		auto color = get_mapped_color(el, mapped_panel_id);
-		opts += color;
-		opts += " ";
-		opts += name;
-		opts += "";
-		if (color[0] != '\0')
-			opts += LV_TXT_COLOR_CMD;
-	}
+	const auto name = std::visit([=](auto &e) { return get_panel_name<PanelDef>(e, mapped_panel_id); }, el);
+	if (name.size() < 0)
+		return;
+	const auto color = get_mapped_color(el, mapped_panel_id);
+	if (color[0] == '\0')
+		return;
+	opts += " ";
+	opts += Gui::color_text(name, color);
 }
 
 void append_connected_jack_name(std::string &opts, GuiElement const &drawn, PatchData const &patch) {
@@ -77,9 +75,9 @@ void append_connected_jack_name(std::string &opts, GuiElement const &drawn, Patc
 
 		if (auto *cable = patch.find_internal_cable_with_injack(in_jack)) {
 			if (auto out_map = patch.find_mapped_outjack(cable->out)) {
-				auto color = get_mapped_color(JackOutput{}, out_map->panel_jack_id);
-				opts = opts + color + " " + get_panel_name<PanelDef>(JackOutput{}, out_map->panel_jack_id) +
-					   LV_TXT_COLOR_CMD + " ";
+				const auto color = get_mapped_color(JackOutput{}, out_map->panel_jack_id);
+				const auto p_name = get_panel_name<PanelDef>(JackOutput{}, out_map->panel_jack_id);
+				opts += " " + Gui::color_text(p_name, color);
 			}
 
 			append(cable->out, ElementType::Output);

--- a/firmware/src/gui/pages/module_view.hh
+++ b/firmware/src/gui/pages/module_view.hh
@@ -288,17 +288,17 @@ struct ModuleViewPage : PageBase {
 
 	bool append_header(std::string &opts, ElementCount::Counts last_type, ElementCount::Counts this_type) {
 		if (last_type.num_params == 0 && this_type.num_params > 0) {
-			opts += Gui::orange_highlight_html_str + "Params:" + LV_TXT_COLOR_CMD + "\n";
+			opts += Gui::orange_highlight_html_str + "Params:" + LV_TXT_COLOR_CMD + " \n";
 			return true;
 
 		} else if ((last_type.num_inputs == 0 && last_type.num_outputs == 0) &&
 				   (this_type.num_inputs > 0 || this_type.num_outputs > 0))
 		{
-			opts += Gui::orange_highlight_html_str + "Jacks:" + LV_TXT_COLOR_CMD + "\n";
+			opts += Gui::orange_highlight_html_str + "Jacks:" + LV_TXT_COLOR_CMD + " \n";
 			return true;
 
 		} else if (last_type.num_lights == 0 && this_type.num_lights > 0 && this_type.num_params == 0) {
-			opts += Gui::orange_highlight_html_str + "Lights:" + LV_TXT_COLOR_CMD + "\n";
+			opts += Gui::orange_highlight_html_str + "Lights:" + LV_TXT_COLOR_CMD + " \n";
 			return true;
 		} else {
 			return false;

--- a/firmware/src/gui/pages/module_view.hh
+++ b/firmware/src/gui/pages/module_view.hh
@@ -288,17 +288,17 @@ struct ModuleViewPage : PageBase {
 
 	bool append_header(std::string &opts, ElementCount::Counts last_type, ElementCount::Counts this_type) {
 		if (last_type.num_params == 0 && this_type.num_params > 0) {
-			opts += Gui::orange_highlight_html_str + "Params:" + LV_TXT_COLOR_CMD + " \n";
+			opts += Gui::orange_text("Params:") + "\n";
 			return true;
 
 		} else if ((last_type.num_inputs == 0 && last_type.num_outputs == 0) &&
 				   (this_type.num_inputs > 0 || this_type.num_outputs > 0))
 		{
-			opts += Gui::orange_highlight_html_str + "Jacks:" + LV_TXT_COLOR_CMD + " \n";
+			opts += Gui::orange_text("Jacks:") + "\n";
 			return true;
 
 		} else if (last_type.num_lights == 0 && this_type.num_lights > 0 && this_type.num_params == 0) {
-			opts += Gui::orange_highlight_html_str + "Lights:" + LV_TXT_COLOR_CMD + " \n";
+			opts += Gui::orange_text("Lights:") + "\n";
 			return true;
 		} else {
 			return false;

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -204,7 +204,7 @@ struct PatchSelectorPage : PageBase {
 	}
 
 	std::string format_volume_name(StaticString<31> const &vol_name, PatchDir &root) {
-		std::string roller_text = Gui::orange_highlight_html + std::string(vol_name) + LV_TXT_COLOR_CMD;
+		std::string roller_text = Gui::orange_text(vol_name);
 
 		// TODO: make a setting to hide/show these?
 		add_file_count(roller_text, root);
@@ -218,7 +218,7 @@ struct PatchSelectorPage : PageBase {
 		std::string roller_text;
 
 		if (subdir.name.size() > 0) {
-			roller_text += Gui::yellow_highlight_html + subdir.name + LV_TXT_COLOR_CMD;
+			roller_text += Gui::yellow_text(subdir.name);
 			add_file_count(roller_text, subdir);
 		}
 		roller_text += "\n";

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -127,10 +127,10 @@ struct PatchSelectorPage : PageBase {
 			auto patch_name = std::string{std::string_view{patch.patch.patch_name}};
 
 			if (patch.modification_count > 0)
-				patch_name = Gui::red_highlight_html_str + "•" + LV_TXT_COLOR_CMD + " " + patch_name;
+				patch_name = Gui::red_text("•") + " " + patch_name;
 
 			if (patch.loc_hash == patches.get_playing_patch_loc_hash())
-				patch_name = Gui::green_highlight_html_str + LV_SYMBOL_PLAY + LV_TXT_COLOR_CMD + " " + patch_name;
+				patch_name = Gui::green_text(LV_SYMBOL_PLAY) + " " + patch_name;
 
 			root.files.emplace_back(
 				patch.loc.filename, 0, patch.modification_count, PatchName{patch_name}, patch.loc.vol);

--- a/firmware/src/gui/styles.hh
+++ b/firmware/src/gui/styles.hh
@@ -59,44 +59,42 @@ struct Gui {
 	static inline lv_style_t focus_style;
 
 	// COLORS
+	static inline std::string color_text(std::string_view txt, std::string_view color) {
+		return std::string{color} + std::string{txt} + LV_TXT_COLOR_CMD + " ";
+	}
 	static inline lv_color_t red_highlight = lv_color_hex(0xea1c25);
 	static inline const char *red_highlight_html = "^ea1c25 ";
-	static inline const std::string red_highlight_html_str{red_highlight_html};
 	static std::string red_text(std::string_view txt) {
-		return red_highlight_html_str + std::string(txt) + LV_TXT_COLOR_CMD;
+		return color_text(txt, red_highlight_html);
 	}
 
 	static inline lv_color_t orange_highlight = lv_color_hex(0xfd8b18);
 	static inline const char *orange_highlight_html = "^fd8b18 ";
-	static inline const std::string orange_highlight_html_str{orange_highlight_html};
 	static std::string orange_text(std::string_view txt) {
-		return orange_highlight_html_str + std::string(txt) + LV_TXT_COLOR_CMD;
+		return color_text(txt, orange_highlight_html);
 	}
 
 	static inline lv_color_t yellow_highlight = lv_color_hex(0x8bfd18);
 	static inline const char *yellow_highlight_html = "^d7ff6a ";
 	static std::string yellow_text(std::string_view txt) {
-		return std::string(yellow_highlight_html) + std::string(txt) + LV_TXT_COLOR_CMD;
+		return color_text(txt, yellow_highlight_html);
 	}
 
 	static inline lv_color_t green_highlight = lv_color_hex(0x00a551);
 	static inline const char *green_highlight_html = "^00a551 ";
-	static inline const std::string green_highlight_html_str{green_highlight_html};
 	static std::string green_text(std::string_view txt) {
-		return green_highlight_html_str + std::string(txt) + LV_TXT_COLOR_CMD;
+		return color_text(txt, green_highlight_html);
 	}
 
 	static inline const char *blue_highlight_html = "^188bfd ";
-	static inline const std::string blue_highlight_html_str{blue_highlight_html};
 	static std::string blue_text(std::string_view txt) {
-		return std::string(blue_highlight_html) + std::string(txt) + LV_TXT_COLOR_CMD;
+		return color_text(txt, blue_highlight_html);
 	}
 
 	static inline lv_color_t grey_highlight = lv_color_hex(0xaaaaaa);
 	static inline const char *grey_highlight_html = "^aaaaaa ";
-	static inline const std::string grey_highlight_html_str{grey_highlight_html};
 	static std::string grey_text(std::string_view txt) {
-		return grey_highlight_html_str + std::string(txt) + LV_TXT_COLOR_CMD;
+		return color_text(txt, grey_highlight_html);
 	}
 
 	static inline const char *brown_highlight_html = "^A26E3E ";

--- a/firmware/src/gui/styles.hh
+++ b/firmware/src/gui/styles.hh
@@ -63,38 +63,32 @@ struct Gui {
 		return std::string{color} + std::string{txt} + LV_TXT_COLOR_CMD + " ";
 	}
 	static inline lv_color_t red_highlight = lv_color_hex(0xea1c25);
-	static inline const char *red_highlight_html = "^ea1c25 ";
 	static std::string red_text(std::string_view txt) {
-		return color_text(txt, red_highlight_html);
+		return color_text(txt, "^ea1c25 ");
 	}
 
 	static inline lv_color_t orange_highlight = lv_color_hex(0xfd8b18);
-	static inline const char *orange_highlight_html = "^fd8b18 ";
 	static std::string orange_text(std::string_view txt) {
-		return color_text(txt, orange_highlight_html);
+		return color_text(txt, "^fd9b18 ");
 	}
 
 	static inline lv_color_t yellow_highlight = lv_color_hex(0x8bfd18);
-	static inline const char *yellow_highlight_html = "^d7ff6a ";
 	static std::string yellow_text(std::string_view txt) {
-		return color_text(txt, yellow_highlight_html);
+		return color_text(txt, "^d7ff6a ");
 	}
 
 	static inline lv_color_t green_highlight = lv_color_hex(0x00a551);
-	static inline const char *green_highlight_html = "^00a551 ";
 	static std::string green_text(std::string_view txt) {
-		return color_text(txt, green_highlight_html);
+		return color_text(txt, "^00a551 ");
 	}
 
-	static inline const char *blue_highlight_html = "^188bfd ";
 	static std::string blue_text(std::string_view txt) {
-		return color_text(txt, blue_highlight_html);
+		return color_text(txt, "^188bfd ");
 	}
 
 	static inline lv_color_t grey_highlight = lv_color_hex(0xaaaaaa);
-	static inline const char *grey_highlight_html = "^aaaaaa ";
 	static std::string grey_text(std::string_view txt) {
-		return color_text(txt, grey_highlight_html);
+		return color_text(txt, "^aaaaaa ");
 	}
 
 	static inline const char *brown_highlight_html = "^A26E3E ";


### PR DESCRIPTION
The bug is fixed by making sure there is a `' '` char after the closing `'^'` in the inline LVGL color command.   
Added text coloring functions that abstract away building raw colored strings