### PR TITLE
Fix memory leak

### DIFF
--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -99,6 +99,7 @@ add_executable(
   ${FWDIR}/system/libc_stub.c
   ${FWDIR}/system/libcpp_stub.cc
   ${FWDIR}/system/new.cc
+  ${FWDIR}/system/sbrk.cc
   ${FWDIR}/system/mmu_ca7.c
   ${FWDIR}/system/time.cc
   ${FWDIR}/system/startup_ca7.s

--- a/firmware/src/core_m4/CMakeLists.txt
+++ b/firmware/src/core_m4/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(
   ${FWDIR}/system/libc_stub.c
   ${M4DIR}/libcpp_stub.cc
   ${FWDIR}/system/new.cc
+  ${FWDIR}/system/sbrk.cc
   ${FWDIR}/system/startup_stm32mp157cxx_cm4.s
   ${DRIVERLIB}/drivers/hal_handlers.cc
   ${DRIVERLIB}/drivers/i2c.cc

--- a/firmware/src/dynload/autoload_plugins.hh
+++ b/firmware/src/dynload/autoload_plugins.hh
@@ -79,7 +79,7 @@ private:
 			return {autoload_state, "All disks scanned"};
 		}
 
-		if (result.state == PluginFileLoader::State::Success) {
+		if (result.state == PluginFileLoader::State::Idle || result.state == PluginFileLoader::State::Success) {
 			auto &s = plugin_settings.slug[slug_idx];
 			pr_trace("Autoload: Done with plugin: %s\n", s.c_str());
 

--- a/firmware/src/gui/pages/main_menu.hh
+++ b/firmware/src/gui/pages/main_menu.hh
@@ -45,6 +45,8 @@ struct MainMenuPage : PageBase {
 			lv_hide(ui_MainMenuNowPlayingPanel);
 		} else {
 			lv_show(ui_MainMenuNowPlayingPanel);
+			lv_show(ui_MainMenuNowPlaying);
+			lv_show(ui_MainMenuNowPlayingName);
 			lv_label_set_text(ui_MainMenuNowPlaying, "Playing:");
 			lv_label_set_text(ui_MainMenuNowPlayingName, patch->patch_name.c_str());
 		}

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -121,7 +121,6 @@ public:
 		}
 
 		lv_label_set_text(ui_MainMenuNowPlaying, "");
-		lv_hide(ui_MainMenuNowPlaying);
 		page_manager.init();
 	}
 

--- a/firmware/src/medium/debug_raw.h
+++ b/firmware/src/medium/debug_raw.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <stdint.h>
 
 //C and C++

--- a/firmware/system/new.cc
+++ b/firmware/system/new.cc
@@ -55,34 +55,3 @@ void operator delete[](void *p, std::nothrow_t) noexcept
 {
 	operator delete(p);
 }
-
-static char *heap_end = nullptr;
-// Defined by the linker
-extern char _sheap;
-
-size_t get_heap_size()
-{
-	return reinterpret_cast<size_t>(heap_end) - reinterpret_cast<size_t>(&_sheap);
-}
-
-extern "C" size_t _sbrk(int incr)
-{
-	// Defined by the linker
-	extern char _eheap;
-
-	char *prev_heap_end;
-
-	if (heap_end == nullptr) {
-		heap_end = &_sheap;
-	}
-	prev_heap_end = heap_end;
-
-	if (heap_end + incr > &_eheap) {
-		// OOM!!!
-		while (true)
-			;
-	}
-
-	heap_end += incr;
-	return (size_t)prev_heap_end;
-}

--- a/firmware/system/sbrk.cc
+++ b/firmware/system/sbrk.cc
@@ -1,0 +1,32 @@
+#include <cstdio>
+
+static char *heap_end = nullptr;
+// Defined by the linker
+extern char _sheap;
+
+size_t get_heap_size() {
+	return reinterpret_cast<size_t>(heap_end) - reinterpret_cast<size_t>(&_sheap);
+}
+
+extern "C" size_t _sbrk(int incr) {
+	// Defined by the linker
+	extern char _eheap;
+
+	char *prev_heap_end;
+
+	if (heap_end == nullptr) {
+		heap_end = &_sheap;
+	}
+	prev_heap_end = heap_end;
+
+	if (heap_end + incr > &_eheap) {
+		printf("Out of memory\n");
+		return 0;
+		// OOM!!!
+		// while (true)
+		// 	;
+	}
+
+	heap_end += incr;
+	return (size_t)prev_heap_end;
+}

--- a/firmware/vcv_plugin/export/src/engine/Module.cpp
+++ b/firmware/vcv_plugin/export/src/engine/Module.cpp
@@ -10,6 +10,22 @@ Module::Module() {
 }
 
 Module::~Module() {
+	for (auto paramQuantity : paramQuantities) {
+		if (paramQuantity)
+			delete paramQuantity;
+	}
+	for (auto inputInfo : inputInfos) {
+		if (inputInfo)
+			delete inputInfo;
+	}
+	for (auto outputInfo : outputInfos) {
+		if (outputInfo)
+			delete outputInfo;
+	}
+	for (auto lightInfo : lightInfos) {
+		if (lightInfo)
+			delete lightInfo;
+	}
 }
 
 void Module::load_state(std::string_view state_data) {


### PR DESCRIPTION
Fix memory leak in VCV Modules. The VCV wrapper was not cleaning up the non-smart pointer members of the rack::Module class

Also fixes a hang if no auto-loaded plugins were found