### PR TITLE
Patch file improvements

### DIFF
--- a/firmware/src/gui/pages/description_panel.hh
+++ b/firmware/src/gui/pages/description_panel.hh
@@ -18,7 +18,7 @@ struct PatchDescriptionPanel {
 		lv_group_add_obj(group, ui_DescriptionClose);
 
 		lv_hide(ui_DescriptionEditPanel);
-		lv_group_add_obj(group, ui_PatchNameEditTextArea);
+		lv_hide(ui_PatchNameEditTextArea);
 		lv_group_add_obj(group, ui_DescriptionEditTextArea);
 
 		lv_group_add_obj(group, ui_DescriptionEditSaveButton);
@@ -30,7 +30,6 @@ struct PatchDescriptionPanel {
 		lv_obj_add_event_cb(ui_DescriptionEditButton, editbut_cb, LV_EVENT_CLICKED, this);
 
 		lv_obj_add_event_cb(ui_DescriptionEditTextArea, textarea_cb, LV_EVENT_CLICKED, this);
-		lv_obj_add_event_cb(ui_PatchNameEditTextArea, textarea_cb, LV_EVENT_CLICKED, this);
 
 		lv_obj_add_event_cb(ui_DescriptionEditSaveButton, save_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_DescriptionEditCancelButton, cancel_cb, LV_EVENT_CLICKED, this);
@@ -72,6 +71,10 @@ struct PatchDescriptionPanel {
 	void show() {
 		lv_show(ui_DescriptionPanel);
 		lv_hide(ui_DescriptionEditPanel);
+
+		lv_obj_set_parent(ui_DescPanelPatchName, ui_DescriptionPanel);
+		lv_obj_move_background(ui_DescPanelPatchName);
+
 		lv_indev_set_group(lv_indev_get_next(nullptr), group);
 		lv_group_focus_obj(ui_DescriptionClose);
 		lv_group_set_editing(group, false);
@@ -115,9 +118,11 @@ private:
 		auto page = static_cast<PatchDescriptionPanel *>(event->user_data);
 		lv_hide(ui_DescriptionPanel);
 		lv_show(ui_DescriptionEditPanel);
-		lv_textarea_set_text(ui_PatchNameEditTextArea, lv_label_get_text(ui_DescPanelPatchName));
+
+		lv_obj_set_parent(ui_DescPanelPatchName, ui_DescriptionEditPanel);
+		lv_obj_move_background(ui_DescPanelPatchName);
+
 		lv_textarea_set_text(ui_DescriptionEditTextArea, lv_label_get_text(ui_Description));
-		lv_group_focus_obj(ui_PatchNameEditTextArea);
 		lv_group_set_editing(page->group, false);
 
 		set_content_max_height(ui_DescriptionEditPanel, 230);
@@ -132,7 +137,7 @@ private:
 		auto page = static_cast<PatchDescriptionPanel *>(event->user_data);
 		auto kb_hidden = lv_obj_has_flag(ui_Keyboard, LV_OBJ_FLAG_HIDDEN);
 		if (kb_hidden) {
-			if (event->target == ui_PatchNameEditTextArea || event->target == ui_DescriptionEditTextArea) {
+			if (event->target == ui_DescriptionEditTextArea) {
 				page->show_keyboard();
 				lv_keyboard_set_textarea(ui_Keyboard, event->target);
 				lv_obj_add_state(event->target, LV_STATE_USER_1);
@@ -163,7 +168,6 @@ private:
 	}
 
 	void hide_keyboard() {
-		lv_obj_clear_state(ui_PatchNameEditTextArea, LV_STATE_USER_1);
 		lv_obj_clear_state(ui_DescriptionEditTextArea, LV_STATE_USER_1);
 		if (active_ta)
 			lv_group_focus_obj(active_ta);
@@ -182,9 +186,7 @@ private:
 
 		if (page->patch) {
 			page->patch->description = lv_textarea_get_text(ui_DescriptionEditTextArea);
-			page->patch->patch_name = lv_textarea_get_text(ui_PatchNameEditTextArea);
 			lv_label_set_text(ui_Description, lv_textarea_get_text(ui_DescriptionEditTextArea));
-			lv_label_set_text(ui_DescPanelPatchName, lv_textarea_get_text(ui_PatchNameEditTextArea));
 			page->did_save = true;
 		}
 		page->hide();

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -376,9 +376,12 @@ struct PatchSelectorPage : PageBase {
 
 	void view_loaded_patch() {
 		auto patch = patches.get_view_patch();
-		pr_trace("Parsed patch: %.31s\n", patch->patch_name.data());
+		pr_trace("View view_loaded_patch: %.31s\n", patch->patch_name.data());
 
 		args.patch_loc_hash = PatchLocHash{selected_patch};
+		// Anytime you open a patch from PatchSel, force redraw it
+		// This fixes issues with a patch that's reloaded from disk
+		gui_state.force_redraw_patch = true;
 		page_list.request_new_page(PageId::PatchView, args);
 
 		state = State::Closing;

--- a/firmware/src/gui/pages/save_dialog.hh
+++ b/firmware/src/gui/pages/save_dialog.hh
@@ -258,6 +258,11 @@ private:
 			fullpath.append(".yml");
 		}
 
+		std::string patchname = page->file_name;
+		strip_yml(patchname);
+		page->patches.get_view_patch()->patch_name = patchname;
+		pr_dbg("Renaming patch to %s\n", patchname.c_str());
+
 		// if view patch vol is RamDisk, then don't duplicate, just rename
 		if (page->patches.get_view_patch_vol() == Volume::RamDisk) {
 			page->patches.rename_view_patch_file(fullpath, page->file_vol);

--- a/firmware/src/patch_file/open_patch_manager.hh
+++ b/firmware/src/patch_file/open_patch_manager.hh
@@ -233,9 +233,13 @@ public:
 
 	bool duplicate_view_patch(std::string_view filepath, Volume vol) {
 		// Check if filename is already open
-		if (open_patches_.find(PatchLocHash{filepath, vol})) {
-			pr_err("Can't rename to same name as an already open patch: %.*s\n", filepath.size(), filepath.data());
-			return false;
+		if (auto openpatch = open_patches_.find(PatchLocHash{filepath, vol})) {
+			if (openpatch->modification_count > 0) {
+				pr_err("Can't overwrite an open and modified patch: %.*s\n", filepath.size(), filepath.data());
+				return false;
+			} else {
+				close_open_patch(openpatch);
+			}
 		}
 
 		// Create a new patch


### PR DESCRIPTION
- Patches are reloaded from disk and then redrawn if the disk it was on was ejected and re-inserted and the patch is unmodified by MM. This was implemented previously but the patch was not being redrawn (only reloaded). https://forum.4ms.info/t/patch-autosaves/266/9
- Duplicating a patch over an existing patch that's been opened but no modifed, now works:
https://forum.4ms.info/t/firmware-update-did-not-update-patch/306
-  Patch filename and patch name (title) are now in sync. You cannot change the patch name from the "Info" button any longer (you can still edit the Patch Description of course). Changing the patch file name is done via Duplicate, which creates a new file. For now, if you wanted to rename and not make a copy then you have to go back to the old file to delete it. (Issue #187 adds Moving aka Renaming a patch)