### PR TITLE
Set VCV module sample rate properly

### DIFF
--- a/firmware/vcv_plugin/export/src/VCV_module_wrapper.cc
+++ b/firmware/vcv_plugin/export/src/VCV_module_wrapper.cc
@@ -11,6 +11,7 @@ void VCVModuleWrapper::update() {
 	process(args);
 }
 
+// This is called by SDK v1.3 and earlier: (later will call Module::set_samplerate)
 void VCVModuleWrapper::set_samplerate(float rate) {
 	args.sampleRate = rate;
 	args.sampleTime = 1.f / rate;

--- a/firmware/vcv_plugin/export/src/VCV_module_wrapper.cc
+++ b/firmware/vcv_plugin/export/src/VCV_module_wrapper.cc
@@ -13,8 +13,7 @@ void VCVModuleWrapper::update() {
 
 // This is called by SDK v1.3 and earlier: (later will call Module::set_samplerate)
 void VCVModuleWrapper::set_samplerate(float rate) {
-	args.sampleRate = rate;
-	args.sampleTime = 1.f / rate;
+	// Keep for future use, and backwards compatibility with API v1.3 and earlier
 }
 
 void VCVModuleWrapper::set_param(int id, float val) {

--- a/firmware/vcv_plugin/export/src/engine/Module.cpp
+++ b/firmware/vcv_plugin/export/src/engine/Module.cpp
@@ -91,4 +91,10 @@ void Module::config(int num_params, int num_inputs, int num_outputs, int num_lig
 	lightInfos.resize(num_lights);
 }
 
+void Module::set_samplerate(float sr) {
+	args.sampleRate = sr;
+	args.sampleTime = 1.f / sr;
+	onSampleRateChange(SampleRateChangeEvent{.sampleRate = args.sampleRate, .sampleTime = args.sampleTime});
+}
+
 } // namespace rack::engine

--- a/firmware/vcv_plugin/export/src/engine/Module.cpp
+++ b/firmware/vcv_plugin/export/src/engine/Module.cpp
@@ -1,6 +1,8 @@
 #include "engine/Module.hpp"
 #include "console/pr_dbg.hh"
 #include "jansson.h"
+#include <context.hpp>
+#include <engine/Engine.hpp>
 
 namespace rack::engine
 {
@@ -91,10 +93,11 @@ void Module::config(int num_params, int num_inputs, int num_outputs, int num_lig
 	lightInfos.resize(num_lights);
 }
 
-void Module::set_samplerate(float sr) {
-	args.sampleRate = sr;
-	args.sampleTime = 1.f / sr;
-	onSampleRateChange(SampleRateChangeEvent{.sampleRate = args.sampleRate, .sampleTime = args.sampleTime});
+void Module::set_samplerate(float rate) {
+	APP->engine->sample_rate = rate;
+	args.sampleRate = rate;
+	args.sampleTime = 1.f / rate;
+	onSampleRateChange({.sampleRate = rate, .sampleTime = 1.f / rate});
 }
 
 } // namespace rack::engine


### PR DESCRIPTION
Firmware was not calling all paths for setting a VCV Module's sample rate (the virtual function rack::Module::setSampleRate() was not being called. Though, rack engine's samplerate and the args passed to Module::process() were getting the latest sample rate). 
Fixing this fixed various bugs, including Plateau size parameter < 18% stopping the audio, and HetrickCV PhasorGen having a fast speed when not clocked externally.
There are probably other VCV-ported modules with issues that are now fixed.

This changes the API to v1.4 (since it adds the `rack::engine::Module::set_samplerate()` symbol)