### PR TITLE
Scroll wide text items in rollers

### DIFF
--- a/firmware/src/gui/helpers/roller_hover_text.hh
+++ b/firmware/src/gui/helpers/roller_hover_text.hh
@@ -1,0 +1,94 @@
+#pragma once
+#include "gui/helpers/lv_helpers.hh"
+#include "lvgl.h"
+
+namespace MetaModule
+{
+class RollerHoverText {
+public:
+	RollerHoverText(lv_obj_t *parent)
+		: label_cont{lv_obj_create(parent)}
+		, label{lv_label_create(label_cont)} {
+	}
+
+	void init(lv_obj_t *roller) {
+		lv_obj_set_align(label_cont, LV_ALIGN_CENTER);
+		lv_obj_set_y(label_cont, lv_obj_get_y(roller) / 2 + 0);
+		lv_obj_set_x(label_cont, 0);
+		lv_obj_set_width(label_cont, lv_pct(109));
+		lv_obj_set_height(label_cont, 19);
+		lv_obj_set_style_pad_all(label_cont, 0, LV_PART_MAIN);
+		lv_obj_set_style_radius(label_cont, 0, LV_PART_MAIN);
+		lv_obj_set_style_bg_opa(label_cont, LV_OPA_0, LV_PART_MAIN);
+		lv_obj_set_style_border_opa(label_cont, LV_OPA_0, LV_PART_MAIN);
+		lv_obj_clear_flag(label_cont, LV_OBJ_FLAG_SCROLLABLE);
+
+		this->roller = roller;
+		lv_obj_set_align(label, LV_ALIGN_CENTER);
+		lv_obj_set_y(label, 0);
+		lv_obj_set_x(label, -1);
+		lv_obj_set_height(label, 19);
+		lv_obj_set_width(label, lv_pct(100));
+		lv_label_set_text(label, "");
+		lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL);
+		lv_obj_set_style_text_color(label, lv_color_hex(0xFFFFFF), LV_PART_MAIN);
+		lv_obj_set_style_text_opa(label, LV_OPA_100, LV_PART_MAIN);
+		lv_obj_set_style_text_letter_space(label, 0, LV_PART_MAIN);
+		lv_obj_set_style_text_line_space(label, 0, LV_PART_MAIN);
+		lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
+		lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+		lv_obj_set_style_radius(label, 0, LV_PART_MAIN);
+		lv_obj_set_style_bg_color(label, lv_color_hex(0xFD8B18), LV_PART_MAIN);
+		// lv_obj_set_style_bg_color(label, lv_color_hex(0x00f0f0), LV_PART_MAIN);
+		lv_obj_set_style_bg_opa(label, LV_OPA_100, LV_PART_MAIN);
+		lv_obj_set_style_border_width(label, 0, LV_PART_MAIN);
+		lv_obj_set_style_pad_top(label, 0, LV_PART_MAIN);
+		lv_obj_set_style_pad_bottom(label, 0, LV_PART_MAIN);
+		lv_obj_set_style_pad_left(label, 15, LV_PART_MAIN);
+		lv_obj_set_style_pad_right(label, 10, LV_PART_MAIN);
+		lv_obj_set_style_radius(label, 0, LV_PART_MAIN);
+		lv_label_set_recolor(label, true);
+		lv_obj_clear_flag(label_cont, LV_OBJ_FLAG_SCROLLABLE);
+		lv_hide(label);
+	}
+
+	void update() {
+		if (display_timer > 0) {
+			if (display_timer == 1) {
+				auto sel_idx = lv_roller_get_selected(roller);
+				if (sel_idx >= 0 && sel_idx < lv_roller_get_option_cnt(roller)) {
+					char sel_buf[64];
+					lv_roller_get_selected_str(roller, sel_buf, 64);
+					lv_label_set_text(label, sel_buf);
+					lv_show(label);
+					display_timer = 0;
+				}
+			} else
+				display_timer--;
+		}
+	}
+
+	void hide() {
+		lv_hide(label);
+		display_timer = 0;
+	}
+
+	void display_in_time(uint32_t tm) {
+		display_timer = tm;
+	}
+
+	void set_width(uint32_t width) {
+		// lv_obj_set_width(label, width - left_pad - 9);
+		// lv_obj_set_x(label, left_pad);
+	}
+
+private:
+	uint32_t display_timer = 0;
+	lv_obj_t *label_cont;
+	lv_obj_t *label;
+	lv_obj_t *roller;
+
+	static constexpr lv_coord_t left_pad = 8;
+};
+
+} // namespace MetaModule

--- a/firmware/src/gui/helpers/roller_hover_text.hh
+++ b/firmware/src/gui/helpers/roller_hover_text.hh
@@ -98,6 +98,10 @@ public:
 		}
 	}
 
+	lv_obj_t *cont() {
+		return label_cont;
+	}
+
 private:
 	uint32_t display_timer = 0;
 	lv_obj_t *label_cont;

--- a/firmware/src/gui/helpers/roller_hover_text.hh
+++ b/firmware/src/gui/helpers/roller_hover_text.hh
@@ -30,6 +30,7 @@ public:
 		lv_obj_set_style_bg_opa(label_cont, LV_OPA_0, LV_PART_MAIN);
 		lv_obj_set_style_border_opa(label_cont, LV_OPA_0, LV_PART_MAIN);
 		lv_obj_clear_flag(label_cont, LV_OBJ_FLAG_SCROLLABLE);
+		lv_obj_clear_flag(label_cont, LV_OBJ_FLAG_SCROLLABLE);
 
 		lv_obj_set_align(label, LV_ALIGN_CENTER);
 		lv_obj_set_y(label, 0);
@@ -54,7 +55,6 @@ public:
 		lv_obj_set_style_pad_right(label, 6, LV_PART_MAIN);
 		lv_obj_set_style_radius(label, 0, LV_PART_MAIN);
 		lv_label_set_recolor(label, true);
-		lv_obj_clear_flag(label_cont, LV_OBJ_FLAG_SCROLLABLE);
 		lv_hide(label);
 	}
 
@@ -98,7 +98,7 @@ public:
 		}
 	}
 
-	lv_obj_t *cont() {
+	lv_obj_t *get_cont() {
 		return label_cont;
 	}
 

--- a/firmware/src/gui/pages/module_list.hh
+++ b/firmware/src/gui/pages/module_list.hh
@@ -23,13 +23,13 @@ struct ModuleListPage : PageBase {
 		lv_obj_add_event_cb(ui_ModuleListRoller, scroll_cb, LV_EVENT_KEY, this);
 		lv_obj_remove_style(ui_ModuleListRoller, nullptr, LV_STATE_EDITED);
 		lv_obj_remove_style(ui_ModuleListRoller, nullptr, LV_STATE_FOCUS_KEY);
-		lv_obj_set_width(ui_ModuleListRollerPanel, 160);
+		lv_obj_set_width(ui_ModuleListRollerPanel, 164);
 
 		auto hov = roller_hover.get_cont();
 		lv_obj_set_align(hov, LV_ALIGN_LEFT_MID);
 		lv_obj_set_x(hov, -2);
 		lv_obj_set_y(hov, 13);
-		lv_obj_set_width(hov, 164);
+		lv_obj_set_width(hov, 172);
 	}
 
 private:
@@ -92,7 +92,7 @@ private:
 	}
 
 	void show_roller() {
-		lv_obj_set_width(ui_ModuleListRollerPanel, 160);
+		lv_obj_set_width(ui_ModuleListRollerPanel, 166);
 		lv_group_focus_obj(ui_ModuleListRoller);
 		lv_group_set_editing(group, true);
 		lv_group_set_wrap(group, false);

--- a/firmware/src/gui/pages/module_list.hh
+++ b/firmware/src/gui/pages/module_list.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include "gui/elements/module_drawer.hh"
 #include "gui/helpers/lv_helpers.hh"
+#include "gui/helpers/roller_hover_text.hh"
 #include "gui/pages/base.hh"
 #include "gui/pages/page_list.hh"
 #include "gui/slsexport/meta5/ui.h"
@@ -13,7 +14,8 @@ namespace MetaModule
 
 struct ModuleListPage : PageBase {
 	ModuleListPage(PatchContext info)
-		: PageBase{info, PageId::ModuleList} {
+		: PageBase{info, PageId::ModuleList}
+		, roller_hover{ui_ModuleListRollerPanel, ui_ModuleListRoller} {
 		init_bg(ui_ModuleListPage);
 
 		lv_group_add_obj(group, ui_ModuleListRoller);
@@ -22,6 +24,12 @@ struct ModuleListPage : PageBase {
 		lv_obj_remove_style(ui_ModuleListRoller, nullptr, LV_STATE_EDITED);
 		lv_obj_remove_style(ui_ModuleListRoller, nullptr, LV_STATE_FOCUS_KEY);
 		lv_obj_set_width(ui_ModuleListRollerPanel, 160);
+
+		auto hov = roller_hover.get_cont();
+		lv_obj_set_align(hov, LV_ALIGN_LEFT_MID);
+		lv_obj_set_x(hov, -2);
+		lv_obj_set_y(hov, 13);
+		lv_obj_set_width(hov, 164);
 	}
 
 private:
@@ -107,10 +115,13 @@ public:
 	void prepare_focus() final {
 		view = View::BrandRoller;
 		roller_brand_list();
+		roller_hover.hide();
 	}
 
 	void update() final {
+		roller_hover.update();
 		if (gui_state.back_button.is_just_released()) {
+			roller_hover.hide();
 
 			if (view == View::BrandRoller) {
 				gui_state.force_redraw_patch = true;
@@ -174,6 +185,8 @@ private:
 		auto page = static_cast<ModuleListPage *>(event->user_data);
 		if (!page)
 			return;
+
+		page->roller_hover.hide();
 
 		if (page->view == View::ModuleOnly || page->view == View::ModuleRoller) {
 			lv_timer_reset(page->draw_timer);
@@ -239,6 +252,9 @@ private:
 	std::string selected_brand{"4msCompany"};
 	std::string selected_brand_slug{"4msCompany"};
 	std::string selected_module_slug;
+
+	RollerHoverText roller_hover;
+	;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/module_view.hh
+++ b/firmware/src/gui/pages/module_view.hh
@@ -29,7 +29,7 @@ struct ModuleViewPage : PageBase {
 		, patch{patches.get_view_patch()}
 		, mapping_pane{patches, module_mods, params, args, page_list, notify_queue, gui_state}
 		, action_menu{module_mods, patches, page_list, patch_playloader, notify_queue}
-		, roller_hover(ui_ElementRollerPanel) {
+		, roller_hover(ui_ElementRollerPanel, ui_ElementRoller) {
 
 		init_bg(ui_MappingMenu);
 
@@ -60,10 +60,6 @@ struct ModuleViewPage : PageBase {
 		lv_obj_add_event_cb(ui_ElementRoller, roller_click_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_ElementRoller, roller_focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(ui_ModuleViewCableCancelBut, cancel_cable_cb, LV_EVENT_CLICKED, this);
-
-		lv_obj_add_event_cb(roller_label, roller_scroll, LV_EVENT_DRAW_POST_END, this);
-
-		roller_hover.init(ui_ElementRoller);
 	}
 
 	void prepare_focus() override {
@@ -223,8 +219,6 @@ struct ModuleViewPage : PageBase {
 		auto roller_width = std::min<lv_coord_t>(320 - display_widthpx, 220); //roller is no more than 220px wide
 		lv_obj_set_size(ui_ElementRollerPanel, roller_width, 240);
 		lv_obj_clear_flag(ui_ElementRollerPanel, LV_OBJ_FLAG_HIDDEN);
-
-		roller_hover.set_width(roller_width);
 
 		// Add text list to roller options
 		lv_roller_set_options(ui_ElementRoller, opts.c_str(), LV_ROLLER_MODE_NORMAL);
@@ -568,11 +562,6 @@ private:
 		page->roller_hover.hide();
 	}
 
-	static void roller_scroll(lv_event_t *event) {
-		auto page = static_cast<ModuleViewPage *>(event->user_data);
-		page->roller_hover.display_in_time(10);
-	}
-
 	void unhighlight_component(uint32_t prev_sel) {
 		if (auto prev_idx = get_drawn_idx(prev_sel)) {
 			lv_obj_remove_style(button[*prev_idx], &Gui::panel_highlight_style, LV_PART_MAIN);
@@ -732,8 +721,6 @@ private:
 
 	enum class ViewMode { List, Mapping } mode{ViewMode::List};
 
-	// lv_obj_t *roller_hover_label = nullptr;
-	// uint32_t roller_hover_timer = 0;
 	RollerHoverText roller_hover;
 };
 

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -24,7 +24,7 @@ struct PatchSelectorPage : PageBase {
 		: PageBase{info, PageId::PatchSel}
 		, subdir_panel{subdir_panel}
 		, patchfiles{patch_storage.get_patch_list()}
-		, roller_hover(ui_PatchSelectorPage, ui_PatchListRoller) {
+		, roller_hover(ui_PatchSelectorPage, ui_PatchListRoller, [this] { redraw_cb(); }) {
 
 		init_bg(ui_PatchSelectorPage);
 
@@ -41,6 +41,11 @@ struct PatchSelectorPage : PageBase {
 		lv_obj_set_y(hov, 13);
 		lv_obj_set_width(hov, 210);
 		lv_obj_set_align(hov, LV_ALIGN_RIGHT_MID);
+	}
+
+	void redraw_cb() {
+		if (!lv_obj_has_state(ui_PatchListRoller, LV_STATE_DISABLED))
+			roller_hover.display_in_time(10);
 	}
 
 	void prepare_focus() override {
@@ -398,12 +403,14 @@ struct PatchSelectorPage : PageBase {
 		// This fixes issues with a patch that's reloaded from disk
 		gui_state.force_redraw_patch = true;
 		page_list.request_new_page(PageId::PatchView, args);
+		roller_hover.hide();
 
 		state = State::Closing;
 	}
 
 	void blur() final {
 		hide_spinner();
+		roller_hover.hide();
 	}
 
 	void show_spinner() {

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -4,6 +4,7 @@
 #include "gui/helpers/lv_helpers.hh"
 #include "gui/helpers/lvgl_mem_helper.hh"
 #include "gui/helpers/lvgl_string_helper.hh"
+#include "gui/helpers/roller_hover_text.hh"
 #include "gui/pages/base.hh"
 #include "gui/pages/make_cable.hh"
 #include "gui/pages/page_list.hh"
@@ -22,7 +23,8 @@ struct PatchSelectorPage : PageBase {
 	PatchSelectorPage(PatchContext info, PatchSelectorSubdirPanel &subdir_panel)
 		: PageBase{info, PageId::PatchSel}
 		, subdir_panel{subdir_panel}
-		, patchfiles{patch_storage.get_patch_list()} {
+		, patchfiles{patch_storage.get_patch_list()}
+		, roller_hover(ui_PatchSelectorPage, ui_PatchListRoller) {
 
 		init_bg(ui_PatchSelectorPage);
 
@@ -32,6 +34,13 @@ struct PatchSelectorPage : PageBase {
 		lv_obj_remove_style(ui_PatchListRoller, nullptr, LV_STATE_EDITED);
 		lv_obj_remove_style(ui_PatchListRoller, nullptr, LV_STATE_FOCUS_KEY);
 		lv_obj_clear_state(ui_Flashbut, LV_STATE_FOCUSED);
+
+		auto hov = roller_hover.cont();
+		lv_obj_add_flag(hov, LV_OBJ_FLAG_FLOATING);
+		lv_obj_set_x(hov, 2);
+		lv_obj_set_y(hov, 13);
+		lv_obj_set_width(hov, 210);
+		lv_obj_set_align(hov, LV_ALIGN_RIGHT_MID);
 	}
 
 	void prepare_focus() override {
@@ -64,6 +73,8 @@ struct PatchSelectorPage : PageBase {
 
 		patchfiles_locked = false;
 		refresh_patchlist();
+
+		roller_hover.hide();
 	}
 
 	void setup_subdir_panel() {
@@ -257,9 +268,13 @@ struct PatchSelectorPage : PageBase {
 			} else {
 				page_list.request_new_page_no_history(PageId::MainMenu, args);
 			}
+
+			roller_hover.hide();
 		}
 
 		update_spinner();
+
+		roller_hover.update();
 
 		switch (state) {
 			case State::Idle: {
@@ -440,12 +455,16 @@ private:
 
 		if (!page->is_populating_subdir_panel)
 			page->refresh_subdir_panel();
+
+		page->roller_hover.hide();
 	}
 
 	static void patchlist_click_cb(lv_event_t *event) {
 		auto page = static_cast<PatchSelectorPage *>(event->user_data);
 
 		auto idx = lv_roller_get_selected(ui_PatchListRoller);
+
+		page->roller_hover.hide();
 
 		auto selected_patch = page->get_roller_item_patchloc(idx);
 		if (selected_patch) {
@@ -507,6 +526,8 @@ private:
 	} state{State::TryingToRequestPatchList};
 
 	uint32_t last_refresh_check_tm = 0;
+
+	RollerHoverText roller_hover;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -35,9 +35,9 @@ struct PatchSelectorPage : PageBase {
 		lv_obj_remove_style(ui_PatchListRoller, nullptr, LV_STATE_FOCUS_KEY);
 		lv_obj_clear_state(ui_Flashbut, LV_STATE_FOCUSED);
 
-		auto hov = roller_hover.cont();
+		auto hov = roller_hover.get_cont();
 		lv_obj_add_flag(hov, LV_OBJ_FLAG_FLOATING);
-		lv_obj_set_x(hov, 2);
+		lv_obj_set_x(hov, 3);
 		lv_obj_set_y(hov, 13);
 		lv_obj_set_width(hov, 210);
 		lv_obj_set_align(hov, LV_ALIGN_RIGHT_MID);

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -19,6 +19,6 @@ run: all
 	build/simulator
 
 debug:
-	cmake --build ${BUILDDIR} --target debug -DLOG_LEVEL=DEBUG
+	cmake --build ${BUILDDIR} --target debug
 	
 .PHONY: all clean warnings run


### PR DESCRIPTION
This PR helps with displaying text in rollers that's too wide for the roller by making the long text scroll horizontally. 
This effects the PatchSelector list of patches, ModuleView list of elements, ModuleList list of brands/modules. 

The way of doing this is to have a single-line label object that's positioned exactly over the selected roller item's position. This label is hidden when the roller is scrolled, loses focus, or is hidden, and then shown when the roller is done being redrawn.

As far as I could tell, there's no way to add a callback on an event for when the roller's inner label is no longer being scrolled/animated. So what I did here was hook a callback onto the roller's `LV_EVENT_DRAW_POST_END` event, and then check if the selected index has changed since the last time. A 160ms timeout is added before the hover label is actually shown in order to compensate for the roller animations.