### PR TITLE
Fix cables not drawn past 6 rows of modules

### DIFF
--- a/firmware/src/gui/pages/base.hh
+++ b/firmware/src/gui/pages/base.hh
@@ -70,13 +70,11 @@ struct PageBase {
 
 	PageId id;
 
-	static constexpr uint32_t MaxBufferWidth = 320 * 4;
-	static constexpr uint32_t MaxBufferHeight = 240 * 4;
-	static inline std::array<lv_color_t, MaxBufferHeight * MaxBufferWidth> page_pixel_buffer;
+	static constexpr uint32_t MaxBufferWidth = 320;
+	//Note: LVGL cannot deal with canvas larger than 2047 because there are only 11 bits for the height. 2047 / 180 = 11.4
+	static constexpr uint32_t MaxBufferHeight = 11 * 180;
 
-	// Why doesn't this work?
-	// uint8_t *buffer = StaticBuffers::gui_scratch_buffer;
-	// uint8_t *cable_buf = StaticBuffers::gui_scratch_screen;
+	static inline std::array<lv_color_t, MaxBufferHeight * MaxBufferWidth> page_pixel_buffer;
 
 	lv_group_t *group = nullptr;
 	lv_obj_t *screen = nullptr;

--- a/firmware/src/gui/pages/cable_drawer.hh
+++ b/firmware/src/gui/pages/cable_drawer.hh
@@ -22,7 +22,8 @@ class CableDrawer {
 	lv_draw_rect_dsc_t injack_dsc;
 	lv_draw_rect_dsc_t outjack_dsc;
 
-	static constexpr uint32_t Height = MaxCanvasHeight;
+	//LVGL canvas is internally an img, which has 11 bits for height, so max is 2047
+	static constexpr uint32_t Height = std::min<uint32_t>(MaxCanvasHeight, 2047);
 	static inline std::array<uint8_t, LV_CANVAS_BUF_SIZE_TRUE_COLOR_ALPHA(320, Height)> cable_buf;
 
 	struct Vec2 {

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -607,7 +607,7 @@ private:
 private:
 	lv_obj_t *base;
 	lv_obj_t *modules_cont;
-	CableDrawer<4 * 240 + 8> cable_drawer; //TODO: relate this number to the module container size
+	CableDrawer<MaxBufferHeight> cable_drawer;
 
 	ModuleDisplaySettings &page_settings;
 	PatchViewSettingsMenu settings_menu;


### PR DESCRIPTION
LVGL internally uses img types for canvases, and the height variable has 11 bits -- so we are limited to 2047 pixels

Fixes #408 