### PR TITLE
Fix Plateau stopping audio when size is low

### DIFF
--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -351,7 +351,6 @@ private:
 			}
 
 			// Get number of lights per module and resize the vectors
-			Debug::Pin0::high();
 			light_vals.clear();
 			for (auto const &slug : patch->module_slugs) {
 				auto info = ModuleFactory::getModuleInfo(slug);
@@ -366,7 +365,6 @@ private:
 				}
 				vec.resize(max + 1, 0.f);
 			}
-			Debug::Pin0::low();
 		}
 	}
 
@@ -378,7 +376,6 @@ private:
 			if (wl.is_active()) {
 				if (wl.module_id < light_vals.size()) {
 					auto &vec = light_vals[wl.module_id];
-					Debug::Pin1::high();
 					if (wl.light_id < 256) {
 						if (wl.light_id < vec.size())
 							vec[wl.light_id] = wl.value;
@@ -387,7 +384,6 @@ private:
 					} else {
 						pr_err("Can only watch 256 lights, request made for %u\n", wl.light_id);
 					}
-					Debug::Pin1::low();
 				} else
 					pr_err("Invalid module id in watch lights: %u\n", wl.module_id);
 			}
@@ -425,10 +421,8 @@ private:
 				}
 			}
 
-			Debug::Pin3::high();
 			if (gui_el.module_idx < light_vals.size())
 				update_light(drawn_el, light_vals[gui_el.module_idx]);
-			Debug::Pin3::low();
 
 			redraw_display(drawn_el, gui_el.module_idx, params.displays.watch_displays);
 		}

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -744,8 +744,12 @@ private:
 
 	// Cache functions:
 	void clear_cache() {
-		for (auto &d : dup_module_index)
-			d = 0;
+		for (auto i = 0u; i < dup_module_index.size(); i++)
+			dup_module_index[i] = 0;
+		// gcc 12.3 complains of writing past end of array
+		// when using range-based for loop:
+		// for (auto &d : dup_module_index)
+		// 	d = 0;
 
 		for (auto &out_conn : out_conns)
 			out_conn = disconnected_jack;


### PR DESCRIPTION
InterpDelay was setting a value for the phase outside of 0-1 if a delay time < 0 was set. This can happen when Size is very small and the LFO depth is high enough.

https://forum.4ms.info/t/plateau-built-in-mm-stops-audio-when-turning-size-smaller-than-9-oclock/431/5