### PR TITLE
Add "Catchup" knob modes

### DIFF
--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(
   ${FWDIR}/src/fw_update/updater_proxy.cc
   ${FWDIR}/src/gui/elements/element_name.cc
   ${FWDIR}/src/gui/slsexport/ui_local.cc
+  ${FWDIR}/src/gui/slsexport/prefs_menu.cc
   ${FWDIR}/src/gui/fonts/fonts.cc
   ${FWDIR}/src/midi/midi_router.cc
   ${FWDIR}/src/params/expanders.cc
@@ -191,6 +192,7 @@ set_source_files_properties(
   ${FWDIR}/src/core_a7/aux_core_main.cc
   ${FWDIR}/src/gui/elements/element_name.cc
   ${FWDIR}/src/gui/slsexport/ui_local.cc
+  ${FWDIR}/src/gui/slsexport/prefs_menu.cc
   ${FWDIR}/src/gui/fonts/fonts.cc
   PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-enum-enum-conversion;-Wno-deprecated-anon-enum-enum-conversion;"
 )

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -125,6 +125,8 @@ add_executable(
   ${FWDIR}/src/gui/fonts/fonts.cc
   ${FWDIR}/src/midi/midi_router.cc
   ${FWDIR}/src/params/expanders.cc
+  ${FWDIR}/src/patch_play/patch_player_catchup.cc
+
   #
   ${FWDIR}/src/dynload/dynloader.cc
   ${FWDIR}/metamodule-plugin-sdk/version.cc

--- a/firmware/src/gui/pages/knobset_view.hh
+++ b/firmware/src/gui/pages/knobset_view.hh
@@ -25,7 +25,6 @@ struct KnobSetViewPage : PageBase {
 		, patch{patches.get_view_patch()} {
 		init_bg(base);
 		lv_group_set_editing(group, false);
-		// lv_obj_add_event_cb(ui_PreviousKnobSet, prev_knobset_cb, LV_EVENT_CLICKED, this);
 		// Use Prev button for Jack Map
 		lv_show(ui_PreviousKnobSet);
 		lv_obj_add_event_cb(ui_PreviousKnobSet, goto_jackmap_cb, LV_EVENT_CLICKED, this);
@@ -35,6 +34,8 @@ struct KnobSetViewPage : PageBase {
 
 		lv_obj_add_event_cb(ui_NextKnobSet, next_knobset_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_ActivateKnobSet, activate_knobset_cb, LV_EVENT_CLICKED, this);
+
+		lv_hide(ui_KnobSetDescript);
 
 		kb_popup.init(base, group);
 	}
@@ -58,12 +59,10 @@ struct KnobSetViewPage : PageBase {
 			lv_arc_set_mode(knob, LV_ARC_MODE_NORMAL);
 			lv_arc_set_bg_angles(knob, min_arc, max_arc);
 			lv_arc_set_value(knob, 0);
-			lv_obj_set_style_opa(knob, LV_OPA_0, LV_PART_KNOB);
+			// lv_obj_set_style_opa(knob, LV_OPA_0, LV_PART_KNOB);
 
 			auto label = get_label(cont);
 			lv_label_set_text(label, "");
-
-			disable(cont, i);
 
 			i++;
 		}
@@ -71,22 +70,18 @@ struct KnobSetViewPage : PageBase {
 
 		knobset = nullptr;
 		arcs.clear();
-		static_params.clear();
+		indicators.clear();
 
-		// Setup
+		for (auto &m : num_maps)
+			m = 0;
+
 		update_active_status();
-		display_active_status();
 
 		patch = patches.get_view_patch();
 
-		if (patch->knob_sets.size() > 2) {
-			// lv_show(ui_PreviousKnobSet);
-			lv_show(ui_NextKnobSet);
-		} else if (patch->knob_sets.size() > 1) {
-			// lv_hide(ui_PreviousKnobSet);
+		if (patch->knob_sets.size() > 1) {
 			lv_show(ui_NextKnobSet);
 		} else {
-			// lv_hide(ui_PreviousKnobSet);
 			lv_hide(ui_NextKnobSet);
 		}
 		lv_group_add_obj(group, ui_PreviousKnobSet);
@@ -105,10 +100,13 @@ struct KnobSetViewPage : PageBase {
 		update_knobset_text_area();
 
 		// Set mappings in knobset
-		unsigned num_maps[PanelDef::NumKnobs]{};
+		for (auto &m : num_maps)
+			m = 0;
 		arcs.resize(knobset->set.size());
-		static_params.resize(knobset->set.size());
+		indicators.resize(knobset->set.size());
+
 		lv_obj_t *focus{};
+		params.param_watcher.stop_watching_all();
 
 		for (auto [idx, map] : enumerate(knobset->set)) {
 			if (!map.is_panel_knob())
@@ -133,21 +131,16 @@ struct KnobSetViewPage : PageBase {
 				}
 			}
 
-			static_params[idx] = patch->find_static_knob(map.module_id, map.param_id);
-			float val = static_params[idx] ? map.unmap_val(static_params[idx]->value) : 0;
-			set_knob_arc<min_arc, max_arc>(map, get_knob(cont), val);
+			params.param_watcher.start_watching_param(map.module_id, map.param_id);
+			set_knob_arc<min_arc, max_arc>(map, get_knob(cont), 0);
 
 			set_for_knob(cont, map.panel_knob_id);
-
-			if (is_actively_playing)
-				enable(cont, map.panel_knob_id);
-			else
-				disable(cont, map.panel_knob_id);
 
 			lv_obj_remove_event_cb(cont, mapping_cb);
 			lv_obj_add_event_cb(cont, mapping_cb, LV_EVENT_CLICKED, this);
 
 			arcs[idx] = get_knob(cont);
+			indicators[idx] = get_indicator(cont);
 
 			lv_obj_set_user_data(cont, reinterpret_cast<void *>(idx));
 
@@ -174,6 +167,8 @@ struct KnobSetViewPage : PageBase {
 		lv_group_focus_obj(focus);
 
 		lv_group_set_editing(group, false);
+
+		display_active_status();
 	}
 
 	void jump_to_active_knobset() {
@@ -211,28 +206,13 @@ struct KnobSetViewPage : PageBase {
 	}
 
 	void display_active_status() {
-		if (is_actively_playing) {
-			lv_show(ui_KnobSetDescript);
-			lv_hide(ui_ActivateKnobSet);
-			// lv_label_set_text(ui_KnobSetDescript, "(Active)");
-			lv_hide(ui_KnobSetDescript);
+		lv_show(ui_ActivateKnobSet, !is_actively_playing && is_patch_playing);
 
-			for (auto [knob_i, pane] : enumerate(panes)) {
-				auto num_children = lv_obj_get_child_cnt(pane);
-				for (auto i = 0u; i < num_children; i++) {
-					auto child = lv_obj_get_child(pane, i);
-					enable(child, knob_i);
-				}
-			}
-		} else {
-			lv_hide(ui_KnobSetDescript);
-			lv_show(ui_ActivateKnobSet, is_patch_playing);
-			for (auto [knob_i, pane] : enumerate(panes)) {
-				auto num_children = lv_obj_get_child_cnt(pane);
-				for (auto i = 0u; i < num_children; i++) {
-					auto child = lv_obj_get_child(pane, i);
-					disable(child, knob_i);
-				}
+		for (auto [knob_i, pane] : enumerate(panes)) {
+			auto num_children = lv_obj_get_child_cnt(pane);
+			for (auto i = 0u; i < num_children; i++) {
+				auto child = lv_obj_get_child(pane, i);
+				update_enabled_status(child, knob_i, is_actively_playing);
 			}
 		}
 	}
@@ -259,9 +239,47 @@ struct KnobSetViewPage : PageBase {
 		handle_changed_active_status();
 
 		if (knobset) {
-			for (auto [arc, s_param, map] : zip(arcs, static_params, knobset->set)) {
-				float s_val = s_param ? map.unmap_val(s_param->value) : 0;
-				lv_arc_set_value(arc, s_val * 120.f);
+			auto watched_params = params.param_watcher.active_watched_params();
+
+			for (auto const &p : watched_params) {
+				if (p.is_active()) {
+					auto map_it = std::find_if(knobset->set.begin(), knobset->set.end(), [&p](MappedKnob const &m) {
+						return m.module_id == p.module_id && m.param_id == p.param_id;
+					});
+					if (map_it != knobset->set.end()) {
+						auto idx = std::distance(knobset->set.begin(), map_it);
+						auto val = map_it->unmap_val(p.value);
+						lv_arc_set_value(arcs[idx], val * 120.f);
+
+						if (map_it->is_panel_knob()) {
+							auto phys_val = params.knobs[map_it->panel_knob_id].val;
+							auto mapped_phys_val = map_it->get_mapped_val(phys_val);
+
+							lv_obj_set_style_transform_angle(
+								indicators[idx], mapped_phys_val * 2500.f - 1250.f, LV_PART_MAIN);
+
+							// show catchup mode with knob color
+							update_knob_color(arcs[idx], p.module_id, p.param_id); //mapped_phys_val, p.value);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	void update_knob_color(lv_obj_t *arc,
+						   unsigned module_id,
+						   unsigned param_id) { //float mapped_phys_val, float cur_value) {
+		auto color = lv_obj_get_style_bg_color(arc, LV_PART_KNOB);
+
+		if (patch_playloader.is_param_tracking(module_id, param_id)) {
+			// if (MathTools::abs_diff(mapped_phys_val, cur_value) < 10.f / 4096.f) {
+			if (color.full != lv_color_hex(0xFFFFFF).full) {
+				lv_obj_set_style_bg_color(arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB);
+			}
+		} else {
+			if (color.full != lv_color_hex(0xAAAAAA).full) {
+				lv_obj_set_style_bg_color(arc, lv_color_hex(0xAAAAAA), LV_PART_KNOB);
 			}
 		}
 	}
@@ -426,6 +444,10 @@ private:
 
 		auto circle_letter = get_circle_letter(cont);
 		lv_label_set_text(circle_letter, PanelDef::get_map_param_name(knob_i).data());
+
+		auto indicator = get_indicator(cont);
+		lv_obj_set_style_bg_color(indicator, Gui::knob_palette[(knob_i + 1) % 6], LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(indicator, LV_OPA_100, LV_STATE_DEFAULT);
 	}
 
 	lv_obj_t *base = nullptr;
@@ -438,7 +460,8 @@ private:
 	unsigned last_known_active_knobset = 0;
 
 	std::vector<lv_obj_t *> arcs;
-	std::vector<const StaticParam *> static_params;
+	std::vector<lv_obj_t *> indicators;
+	std::array<unsigned, PanelDef::NumKnobs> num_maps{};
 
 	bool kb_visible = false;
 
@@ -497,6 +520,17 @@ private:
 		return ui_comp_get_child(container, UI_COMP_KNOBCONTAINERBIG_CIRCLE_KNOBLETTER);
 	}
 
+	lv_obj_t *get_indicator(lv_obj_t *container) {
+		return ui_comp_get_child(container, UI_COMP_KNOBCONTAINER_INDICATOR);
+	}
+
+	void update_enabled_status(lv_obj_t *container, unsigned knob_i, bool actively_playing) {
+		if (actively_playing && num_maps[knob_i] > 0)
+			enable(container, knob_i);
+		else
+			disable(container, knob_i);
+	}
+
 	void disable(lv_obj_t *container, unsigned knob_i) {
 		auto knob = get_knob(container);
 		auto circle = get_circle(container);
@@ -507,6 +541,9 @@ private:
 
 		lv_obj_set_style_arc_color(knob, Gui::knob_disabled_palette[knob_i % 6], LV_PART_INDICATOR);
 		lv_obj_set_style_opa(knob, LV_OPA_0, LV_PART_KNOB);
+
+		auto indicator = get_indicator(container);
+		lv_obj_add_flag(indicator, LV_OBJ_FLAG_HIDDEN);
 	}
 
 	void enable(lv_obj_t *container, unsigned knob_i) {
@@ -519,6 +556,9 @@ private:
 
 		lv_obj_set_style_arc_color(knob, Gui::knob_palette[knob_i % 6], LV_PART_INDICATOR);
 		lv_obj_set_style_opa(knob, LV_OPA_100, LV_PART_KNOB);
+
+		auto indicator = get_indicator(container);
+		lv_obj_clear_flag(indicator, LV_OBJ_FLAG_HIDDEN);
 	}
 };
 

--- a/firmware/src/gui/pages/knobset_view.hh
+++ b/firmware/src/gui/pages/knobset_view.hh
@@ -59,7 +59,6 @@ struct KnobSetViewPage : PageBase {
 			lv_arc_set_mode(knob, LV_ARC_MODE_NORMAL);
 			lv_arc_set_bg_angles(knob, min_arc, max_arc);
 			lv_arc_set_value(knob, 0);
-			// lv_obj_set_style_opa(knob, LV_OPA_0, LV_PART_KNOB);
 
 			auto label = get_label(cont);
 			lv_label_set_text(label, "");
@@ -248,8 +247,8 @@ struct KnobSetViewPage : PageBase {
 					});
 					if (map_it != knobset->set.end()) {
 						auto idx = std::distance(knobset->set.begin(), map_it);
-						auto val = map_it->unmap_val(p.value);
-						lv_arc_set_value(arcs[idx], val * 120.f);
+						auto arc_val = map_it->unmap_val(p.value) * 120.f;
+						lv_arc_set_value(arcs[idx], arc_val);
 
 						if (map_it->is_panel_knob()) {
 							auto phys_val = params.knobs[map_it->panel_knob_id].val;
@@ -259,7 +258,7 @@ struct KnobSetViewPage : PageBase {
 								indicators[idx], mapped_phys_val * 2500.f - 1250.f, LV_PART_MAIN);
 
 							// show catchup mode with knob color
-							update_knob_color(arcs[idx], p.module_id, p.param_id); //mapped_phys_val, p.value);
+							update_knob_color(arcs[idx], p.module_id, p.param_id, arc_val);
 						}
 					}
 				}
@@ -267,19 +266,26 @@ struct KnobSetViewPage : PageBase {
 		}
 	}
 
-	void update_knob_color(lv_obj_t *arc,
-						   unsigned module_id,
-						   unsigned param_id) { //float mapped_phys_val, float cur_value) {
+	void update_knob_color(lv_obj_t *arc, unsigned module_id, unsigned param_id, float arc_val) {
+
 		auto color = lv_obj_get_style_bg_color(arc, LV_PART_KNOB);
 
-		if (patch_playloader.is_param_tracking(module_id, param_id)) {
-			// if (MathTools::abs_diff(mapped_phys_val, cur_value) < 10.f / 4096.f) {
-			if (color.full != lv_color_hex(0xFFFFFF).full) {
-				lv_obj_set_style_bg_color(arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB);
+		if (arc_val > lv_arc_get_max_value(arc) || arc_val < lv_arc_get_min_value(arc)) {
+			lv_obj_set_style_radius(arc, 0, LV_PART_KNOB);
+			if (color.full != lv_color_hex(0x000000).full) {
+				lv_obj_set_style_bg_color(arc, lv_color_hex(0x000000), LV_PART_KNOB);
 			}
 		} else {
-			if (color.full != lv_color_hex(0xAAAAAA).full) {
-				lv_obj_set_style_bg_color(arc, lv_color_hex(0xAAAAAA), LV_PART_KNOB);
+			lv_obj_set_style_radius(arc, 20, LV_PART_KNOB);
+
+			if (patch_playloader.is_param_tracking(module_id, param_id)) {
+				if (color.full != lv_color_hex(0xFFFFFF).full) {
+					lv_obj_set_style_bg_color(arc, lv_color_hex(0xFFFFFF), LV_PART_KNOB);
+				}
+			} else {
+				if (color.full != lv_color_hex(0xAAAAAA).full) {
+					lv_obj_set_style_bg_color(arc, lv_color_hex(0xAAAAAA), LV_PART_KNOB);
+				}
 			}
 		}
 	}

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -103,6 +103,9 @@ struct PrefsTab : SystemMenuTab {
 		lv_group_focus_obj(ui_SystemPrefsAudioSampleRateDropdown);
 		lv_group_set_editing(group, true);
 
+		//todo: implement this
+		lv_hide(ui_SystemPrefsCatchupExcludeButtonsCont);
+
 		update_dropdowns_from_settings();
 	}
 
@@ -213,6 +216,7 @@ struct PrefsTab : SystemMenuTab {
 		if (catchup.mode != catchupmode || catchup.button_exclude != catchup_exclude_buttons) {
 			catchup.mode = catchupmode;
 			catchup.button_exclude = catchup_exclude_buttons;
+			patch_playloader.set_all_param_catchup_mode(catchup.mode, catchup.button_exclude);
 			gui_state.do_write_settings = true;
 		}
 

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -4,6 +4,7 @@
 #include "gui/pages/base.hh"
 #include "gui/pages/system_menu_tab_base.hh"
 #include "gui/slsexport/meta5/ui.h"
+#include "gui/slsexport/prefs_menu.hh"
 #include "patch_play/patch_playloader.hh"
 #include "src/core/lv_obj_scroll.h"
 #include <functional>
@@ -13,13 +14,17 @@ namespace MetaModule
 
 struct PrefsTab : SystemMenuTab {
 	PrefsTab(PatchPlayLoader &patch_playloader,
-			 AudioSettings &settings,
+			 AudioSettings &audio_settings,
 			 ScreensaverSettings &screensaver,
+			 CatchupSettings &catchup,
 			 GuiState &gui_state)
 		: patch_playloader{patch_playloader}
-		, settings{settings}
+		, audio_settings{audio_settings}
 		, screensaver{screensaver}
+		, catchup{catchup}
 		, gui_state{gui_state} {
+		init_SystemPrefsCatchupPane(ui_SystemMenuPrefsTab);
+
 		lv_obj_add_event_cb(ui_SystemPrefsSaveButton, save_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_SystemPrefsRevertButton, revert_cb, LV_EVENT_CLICKED, this);
 
@@ -27,11 +32,17 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(ui_SystemPrefsAudioSampleRateDropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(ui_SystemPrefsScreensaverTimeDropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(ui_SystemPrefsScreensaverKnobsCheck, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(ui_SystemPrefsCatchupModeDropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(ui_SystemPrefsCatchupExcludeButtonsCheck, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 
 		lv_obj_add_event_cb(ui_SystemPrefsAudioBlocksizeDropdown, focus_cb, LV_EVENT_FOCUSED, nullptr);
 		lv_obj_add_event_cb(ui_SystemPrefsAudioSampleRateDropdown, focus_cb, LV_EVENT_FOCUSED, nullptr);
 		lv_obj_add_event_cb(ui_SystemPrefsScreensaverTimeDropdown, focus_cb, LV_EVENT_FOCUSED, nullptr);
 		lv_obj_add_event_cb(ui_SystemPrefsScreensaverKnobsCheck, focus_cb, LV_EVENT_FOCUSED, nullptr);
+		lv_obj_add_event_cb(ui_SystemPrefsCatchupModeDropdown, focus_cb, LV_EVENT_FOCUSED, nullptr);
+		lv_obj_add_event_cb(ui_SystemPrefsCatchupExcludeButtonsCheck, focus_cb, LV_EVENT_FOCUSED, nullptr);
+
+		lv_obj_move_foreground(ui_SystemPrefsButtonCont);
 
 		std::string opts;
 		for (auto item : AudioSettings::ValidBlockSizes) {
@@ -49,13 +60,18 @@ struct PrefsTab : SystemMenuTab {
 			opts.pop_back();
 		lv_dropdown_set_options(ui_SystemPrefsAudioSampleRateDropdown, opts.c_str());
 
-		opts = "";
-		for (auto item : ScreensaverSettings::ValidOptions) {
-			opts += std::string(item.label) + "\n";
-		}
-		if (opts.length())
-			opts.pop_back();
-		lv_dropdown_set_options(ui_SystemPrefsScreensaverTimeDropdown, opts.c_str());
+		auto set_options = [](auto const &ValidOptions, lv_obj_t *dropdown) {
+			std::string opts = "";
+			for (auto item : ValidOptions) {
+				opts += std::string(item.label) + "\n";
+			}
+			if (opts.length())
+				opts.pop_back();
+			lv_dropdown_set_options(dropdown, opts.c_str());
+		};
+
+		set_options(ScreensaverSettings::ValidOptions, ui_SystemPrefsCatchupModeDropdown);
+		set_options(CatchupSettings::ValidOptions, ui_SystemPrefsCatchupModeDropdown);
 	}
 
 	void prepare_focus(lv_group_t *group) override {
@@ -65,6 +81,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_group_remove_obj(ui_SystemPrefsAudioBlocksizeDropdown);
 		lv_group_remove_obj(ui_SystemPrefsScreensaverTimeDropdown);
 		lv_group_remove_obj(ui_SystemPrefsScreensaverKnobsCheck);
+		lv_group_remove_obj(ui_SystemPrefsCatchupModeDropdown);
+		lv_group_remove_obj(ui_SystemPrefsCatchupExcludeButtonsCheck);
 		lv_group_remove_obj(ui_SystemPrefsRevertButton);
 		lv_group_remove_obj(ui_SystemPrefsSaveButton);
 
@@ -72,12 +90,15 @@ struct PrefsTab : SystemMenuTab {
 		lv_group_add_obj(group, ui_SystemPrefsAudioBlocksizeDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsScreensaverTimeDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsScreensaverKnobsCheck);
+		lv_group_add_obj(group, ui_SystemPrefsCatchupModeDropdown);
+		lv_group_add_obj(group, ui_SystemPrefsCatchupExcludeButtonsCheck);
 		lv_group_add_obj(group, ui_SystemPrefsRevertButton);
 		lv_group_add_obj(group, ui_SystemPrefsSaveButton);
 
 		lv_dropdown_close(ui_SystemPrefsAudioSampleRateDropdown);
 		lv_dropdown_close(ui_SystemPrefsAudioBlocksizeDropdown);
 		lv_dropdown_close(ui_SystemPrefsScreensaverTimeDropdown);
+		lv_dropdown_close(ui_SystemPrefsCatchupModeDropdown);
 
 		lv_group_focus_obj(ui_SystemPrefsAudioSampleRateDropdown);
 		lv_group_set_editing(group, true);
@@ -93,10 +114,12 @@ struct PrefsTab : SystemMenuTab {
 			}
 			return idx;
 		};
-		auto sr_item = get_index(AudioSettings::ValidSampleRates, [this](auto t) { return t == settings.sample_rate; });
+		auto sr_item =
+			get_index(AudioSettings::ValidSampleRates, [this](auto t) { return t == audio_settings.sample_rate; });
 		lv_dropdown_set_selected(ui_SystemPrefsAudioSampleRateDropdown, sr_item >= 0 ? sr_item : 1);
 
-		auto bs_item = get_index(AudioSettings::ValidBlockSizes, [this](auto t) { return t == settings.block_size; });
+		auto bs_item =
+			get_index(AudioSettings::ValidBlockSizes, [this](auto t) { return t == audio_settings.block_size; });
 		lv_dropdown_set_selected(ui_SystemPrefsAudioBlocksizeDropdown, bs_item >= 0 ? bs_item : 1);
 
 		auto screensaver_item = get_index(ScreensaverSettings::ValidOptions,
@@ -104,6 +127,12 @@ struct PrefsTab : SystemMenuTab {
 		lv_dropdown_set_selected(ui_SystemPrefsScreensaverTimeDropdown, screensaver_item >= 0 ? screensaver_item : 1);
 
 		lv_check(ui_SystemPrefsScreensaverKnobsCheck, screensaver.knobs_can_wake);
+
+		auto catchupmode_item =
+			get_index(CatchupSettings::ValidOptions, [this](auto t) { return t.mode == catchup.mode; });
+		lv_dropdown_set_selected(ui_SystemPrefsCatchupModeDropdown, catchupmode_item >= 0 ? catchupmode_item : 1);
+
+		lv_check(ui_SystemPrefsCatchupExcludeButtonsCheck, catchup.button_exclude);
 
 		gui_state.do_write_settings = false;
 
@@ -142,14 +171,28 @@ struct PrefsTab : SystemMenuTab {
 		return lv_obj_has_state(ui_SystemPrefsScreensaverKnobsCheck, LV_STATE_CHECKED);
 	}
 
+	CatchupParam::Mode read_catchup_mode_dropdown() {
+		auto item = lv_dropdown_get_selected(ui_SystemPrefsCatchupModeDropdown);
+
+		if (item >= 0 && item < CatchupSettings::ValidOptions.size()) {
+			return CatchupSettings::ValidOptions[item].mode;
+		} else {
+			return CatchupSettings::DefaultMode;
+		}
+	}
+
+	bool read_catchup_exclude_check() {
+		return lv_obj_has_state(ui_SystemPrefsCatchupExcludeButtonsCheck, LV_STATE_CHECKED);
+	}
+
 	void update_settings_from_dropdown() {
 		auto block_size = read_blocksize_dropdown();
 		auto sample_rate = read_samplerate_dropdown();
 
-		if (settings.block_size != block_size || settings.sample_rate != sample_rate) {
+		if (audio_settings.block_size != block_size || audio_settings.sample_rate != sample_rate) {
 
-			settings.block_size = block_size;
-			settings.sample_rate = sample_rate;
+			audio_settings.block_size = block_size;
+			audio_settings.sample_rate = sample_rate;
 
 			patch_playloader.request_new_audio_settings(sample_rate, block_size);
 			gui_state.do_write_settings = true;
@@ -161,6 +204,15 @@ struct PrefsTab : SystemMenuTab {
 		if (screensaver.timeout_ms != timeout || screensaver.knobs_can_wake != knobwake) {
 			screensaver.timeout_ms = timeout;
 			screensaver.knobs_can_wake = knobwake;
+			gui_state.do_write_settings = true;
+		}
+
+		auto catchupmode = read_catchup_mode_dropdown();
+		auto catchup_exclude_buttons = read_catchup_exclude_check();
+
+		if (catchup.mode != catchupmode || catchup.button_exclude != catchup_exclude_buttons) {
+			catchup.mode = catchupmode;
+			catchup.button_exclude = catchup_exclude_buttons;
 			gui_state.do_write_settings = true;
 		}
 
@@ -188,8 +240,16 @@ struct PrefsTab : SystemMenuTab {
 			lv_group_set_editing(group, false);
 			return true;
 
-		} else
+		} else if (lv_dropdown_is_open(ui_SystemPrefsCatchupModeDropdown)) {
+			lv_dropdown_close(ui_SystemPrefsCatchupModeDropdown);
+			lv_group_focus_obj(ui_SystemPrefsCatchupModeDropdown);
+			lv_group_set_editing(group, false);
+			return true;
+
+		} else {
+			update_settings_from_dropdown();
 			return false;
+		}
 	}
 
 private:
@@ -220,9 +280,12 @@ private:
 		auto sample_rate = page->read_samplerate_dropdown();
 		auto timeout = page->read_timeout_dropdown();
 		auto knobwake = page->read_knobwake_check();
+		auto catchupmode = page->read_catchup_mode_dropdown();
+		auto catchup_exclude_buttons = page->read_catchup_exclude_check();
 
-		if (block_size == page->settings.block_size && sample_rate == page->settings.sample_rate &&
-			timeout == page->screensaver.timeout_ms && knobwake == page->screensaver.knobs_can_wake)
+		if (block_size == page->audio_settings.block_size && sample_rate == page->audio_settings.sample_rate &&
+			timeout == page->screensaver.timeout_ms && knobwake == page->screensaver.knobs_can_wake &&
+			catchupmode == page->catchup.mode && catchup_exclude_buttons == page->catchup.button_exclude)
 		{
 			lv_disable(ui_SystemPrefsSaveButton);
 			lv_disable(ui_SystemPrefsRevertButton);
@@ -238,7 +301,7 @@ private:
 
 		auto tar = event->target;
 
-		if (tar == ui_SystemPrefsScreensaverTimeDropdown || tar == ui_SystemPrefsScreensaverKnobsCheck) {
+		if (tar == ui_SystemPrefsCatchupModeDropdown || tar == ui_SystemPrefsCatchupExcludeButtonsCheck) {
 			lv_obj_scroll_to_view_recursive(ui_SystemPrefsSaveButton, LV_ANIM_ON);
 
 		} else if (tar == ui_SystemPrefsAudioBlocksizeDropdown || tar == ui_SystemPrefsAudioSampleRateDropdown) {
@@ -247,8 +310,9 @@ private:
 	}
 
 	PatchPlayLoader &patch_playloader;
-	AudioSettings &settings;
+	AudioSettings &audio_settings;
 	ScreensaverSettings &screensaver;
+	CatchupSettings &catchup;
 	GuiState &gui_state;
 
 	lv_group_t *group = nullptr;

--- a/firmware/src/gui/pages/system_menu.hh
+++ b/firmware/src/gui/pages/system_menu.hh
@@ -21,7 +21,11 @@ struct SystemMenuPage : PageBase {
 		: PageBase{info, PageId::SystemMenu}
 		, info_tab{patch_storage}
 		, plugin_tab{info.plugin_manager, info.settings.plugin_autoload, info.notify_queue, gui_state, patch_playloader}
-		, prefs_tab{info.patch_playloader, info.settings.audio, info.settings.screensaver, gui_state}
+		, prefs_tab{info.patch_playloader,
+					info.settings.audio,
+					info.settings.screensaver,
+					info.settings.catchup,
+					gui_state}
 		, system_tab{patch_storage, params, metaparams, patch_playloader, patch_mod_queue}
 		, fwupdate_tab{patch_storage, patch_playloader}
 		, tab_bar(lv_tabview_get_tab_btns(ui_SystemMenuTabView)) {

--- a/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainer.c
+++ b/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainer.c
@@ -129,12 +129,25 @@ lv_obj_set_style_text_font(cui_Label, &ui_font_MuseoSansRounded50012, LV_PART_MA
 lv_obj_set_style_text_color(cui_Label, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DISABLED );
 lv_obj_set_style_text_opa(cui_Label, 128, LV_PART_MAIN| LV_STATE_DISABLED);
 
+lv_obj_t *cui_Indicator;
+cui_Indicator = lv_btn_create(cui_KnobContainer);
+lv_obj_set_width( cui_Indicator, 3);
+lv_obj_set_height( cui_Indicator, 5);
+lv_obj_set_x( cui_Indicator, 0 );
+lv_obj_set_y( cui_Indicator, 11 );
+lv_obj_set_align( cui_Indicator, LV_ALIGN_TOP_MID );
+lv_obj_set_style_bg_color(cui_Indicator, lv_color_hex(0x0), LV_PART_MAIN);
+lv_obj_set_style_radius(cui_Indicator, 0, LV_PART_MAIN);
+lv_obj_set_style_transform_pivot_x(cui_Indicator, 0, LV_PART_MAIN);
+lv_obj_set_style_transform_pivot_y(cui_Indicator, 10, LV_PART_MAIN);
+
 lv_obj_t ** children = lv_mem_alloc(sizeof(lv_obj_t *) * _UI_COMP_KNOBCONTAINER_NUM);
 children[UI_COMP_KNOBCONTAINER_KNOBCONTAINER] = cui_KnobContainer;
 children[UI_COMP_KNOBCONTAINER_KNOB] = cui_Knob;
 children[UI_COMP_KNOBCONTAINER_CIRCLE] = cui_Circle;
 children[UI_COMP_KNOBCONTAINER_CIRCLE_KNOBLETTER] = cui_KnobLetter;
 children[UI_COMP_KNOBCONTAINER_LABEL] = cui_Label;
+children[UI_COMP_KNOBCONTAINER_INDICATOR] = cui_Indicator;
 lv_obj_add_event_cb(cui_KnobContainer, get_component_child_event_cb, LV_EVENT_GET_COMP_CHILD, children);
 lv_obj_add_event_cb(cui_KnobContainer, del_component_child_event_cb, LV_EVENT_DELETE, children);
 ui_comp_KnobContainer_create_hook(cui_KnobContainer);

--- a/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainer.h
+++ b/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainer.h
@@ -18,7 +18,8 @@ extern "C" {
 #define UI_COMP_KNOBCONTAINER_CIRCLE 2
 #define UI_COMP_KNOBCONTAINER_CIRCLE_KNOBLETTER 3
 #define UI_COMP_KNOBCONTAINER_LABEL 4
-#define _UI_COMP_KNOBCONTAINER_NUM 5
+#define UI_COMP_KNOBCONTAINER_INDICATOR 5
+#define _UI_COMP_KNOBCONTAINER_NUM 6
 lv_obj_t *ui_KnobContainer_create(lv_obj_t *comp_parent);
 
 #ifdef __cplusplus

--- a/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainerbig.c
+++ b/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainerbig.c
@@ -129,12 +129,26 @@ lv_obj_set_style_pad_bottom(cui_Label, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_color(cui_Label, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DISABLED );
 lv_obj_set_style_text_opa(cui_Label, 128, LV_PART_MAIN| LV_STATE_DISABLED);
 
+lv_obj_t *cui_Indicator;
+cui_Indicator = lv_btn_create(cui_KnobContainerBig);
+lv_obj_set_width(cui_Indicator, 3);
+lv_obj_set_height(cui_Indicator, 5);
+lv_obj_set_x(cui_Indicator, 0);
+lv_obj_set_y(cui_Indicator, 15);
+lv_obj_set_align(cui_Indicator, LV_ALIGN_TOP_MID);
+lv_obj_set_style_bg_color(cui_Indicator, lv_color_hex(0xffffff), LV_PART_MAIN);
+lv_obj_set_style_bg_opa(cui_Indicator, LV_OPA_50, LV_PART_MAIN);
+lv_obj_set_style_radius(cui_Indicator, 0, LV_PART_MAIN);
+lv_obj_set_style_transform_pivot_x(cui_Indicator, 0, LV_PART_MAIN);
+lv_obj_set_style_transform_pivot_y(cui_Indicator, 11, LV_PART_MAIN);
+
 lv_obj_t ** children = lv_mem_alloc(sizeof(lv_obj_t *) * _UI_COMP_KNOBCONTAINERBIG_NUM);
 children[UI_COMP_KNOBCONTAINERBIG_KNOBCONTAINERBIG] = cui_KnobContainerBig;
 children[UI_COMP_KNOBCONTAINERBIG_KNOB] = cui_Knob;
 children[UI_COMP_KNOBCONTAINERBIG_CIRCLE] = cui_Circle;
 children[UI_COMP_KNOBCONTAINERBIG_CIRCLE_KNOBLETTER] = cui_KnobLetter;
 children[UI_COMP_KNOBCONTAINERBIG_LABEL] = cui_Label;
+children[UI_COMP_KNOBCONTAINERBIG_INDICATOR] = cui_Indicator;
 lv_obj_add_event_cb(cui_KnobContainerBig, get_component_child_event_cb, LV_EVENT_GET_COMP_CHILD, children);
 lv_obj_add_event_cb(cui_KnobContainerBig, del_component_child_event_cb, LV_EVENT_DELETE, children);
 ui_comp_KnobContainerBig_create_hook(cui_KnobContainerBig);

--- a/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainerbig.h
+++ b/firmware/src/gui/slsexport/meta5/components/ui_comp_knobcontainerbig.h
@@ -18,7 +18,8 @@ extern "C" {
 #define UI_COMP_KNOBCONTAINERBIG_CIRCLE 2
 #define UI_COMP_KNOBCONTAINERBIG_CIRCLE_KNOBLETTER 3
 #define UI_COMP_KNOBCONTAINERBIG_LABEL 4
-#define _UI_COMP_KNOBCONTAINERBIG_NUM 5
+#define UI_COMP_KNOBCONTAINERBIG_INDICATOR 5
+#define _UI_COMP_KNOBCONTAINERBIG_NUM 6
 lv_obj_t *ui_KnobContainerBig_create(lv_obj_t *comp_parent);
 
 #ifdef __cplusplus

--- a/firmware/src/gui/slsexport/prefs_menu.cc
+++ b/firmware/src/gui/slsexport/prefs_menu.cc
@@ -1,0 +1,192 @@
+#include "lvgl.h"
+// #include "meta5/ui.h"
+
+namespace MetaModule
+{
+
+lv_obj_t *ui_SystemPrefsCatchupTitle;
+lv_obj_t *ui_SystemPrefsCatchupModeCont;
+lv_obj_t *ui_SystemPrefsCatchupModeLabel;
+lv_obj_t *ui_SystemPrefsCatchupModeDropdown;
+lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCont;
+lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsLabel;
+lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCheck;
+
+void init_SystemPrefsCatchupPane(lv_obj_t *parentTab) {
+
+	ui_SystemPrefsCatchupTitle = lv_label_create(parentTab);
+	lv_obj_set_width(ui_SystemPrefsCatchupTitle, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsCatchupTitle, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsCatchupTitle, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsCatchupTitle, "KNOB CATCHUP MODE");
+	lv_obj_set_style_text_color(ui_SystemPrefsCatchupTitle, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_opa(ui_SystemPrefsCatchupTitle, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_font(
+		ui_SystemPrefsCatchupTitle, &ui_font_MuseoSansRounded70016, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_border_color(ui_SystemPrefsCatchupTitle, lv_color_hex(0x888888), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_border_opa(ui_SystemPrefsCatchupTitle, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_border_width(ui_SystemPrefsCatchupTitle, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_border_side(ui_SystemPrefsCatchupTitle, LV_BORDER_SIDE_BOTTOM, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupTitle, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupTitle, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupTitle, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupTitle, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_SystemPrefsCatchupModeCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsCatchupModeCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupModeCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsCatchupModeCont, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsCatchupModeCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsCatchupModeCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(
+		ui_SystemPrefsCatchupModeCont, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsCatchupModeCont, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupModeCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupModeCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupModeCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupModeCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_SystemPrefsCatchupModeLabel = lv_label_create(ui_SystemPrefsCatchupModeCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupModeLabel, LV_SIZE_CONTENT);
+	lv_obj_set_height(ui_SystemPrefsCatchupModeLabel, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsCatchupModeLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsCatchupModeLabel, "Default Catchup Mode:");
+	lv_obj_set_style_text_font(
+		ui_SystemPrefsCatchupModeLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	lv_obj_t *spacer1 = lv_obj_create(ui_SystemPrefsCatchupModeCont);
+	lv_obj_set_height(spacer1, 1);
+	lv_obj_set_width(spacer1, 1);
+	lv_obj_set_style_bg_opa(spacer1, LV_OPA_0, LV_PART_MAIN);
+	lv_obj_set_style_border_opa(spacer1, LV_OPA_0, LV_PART_MAIN);
+
+	lv_obj_t *spacer2 = lv_obj_create(ui_SystemPrefsCatchupModeCont);
+	lv_obj_set_height(spacer2, 55);
+	lv_obj_set_width(spacer2, 1);
+	lv_obj_add_flag(spacer2, LV_OBJ_FLAG_FLEX_IN_NEW_TRACK);
+	lv_obj_set_style_bg_opa(spacer2, LV_OPA_0, LV_PART_MAIN);
+	lv_obj_set_style_border_opa(spacer2, LV_OPA_0, LV_PART_MAIN);
+
+	ui_SystemPrefsCatchupModeDropdown = lv_dropdown_create(ui_SystemPrefsCatchupModeCont);
+	lv_dropdown_set_options(ui_SystemPrefsCatchupModeDropdown, "Knob movement\nEqual value\nLinear fade");
+	lv_dropdown_set_dir(ui_SystemPrefsCatchupModeDropdown, LV_DIR_BOTTOM);
+	lv_obj_set_width(ui_SystemPrefsCatchupModeDropdown, 185);
+	lv_obj_set_height(ui_SystemPrefsCatchupModeDropdown, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsCatchupModeDropdown, LV_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsCatchupModeDropdown,
+					  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE |
+						  LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM |
+						  LV_OBJ_FLAG_SCROLL_CHAIN); /// Flags
+	lv_obj_set_style_text_font(
+		ui_SystemPrefsCatchupModeDropdown, &ui_font_MuseoSansRounded70014, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(
+		ui_SystemPrefsCatchupModeDropdown, lv_color_hex(0x666666), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupModeDropdown, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_outline_color(
+		ui_SystemPrefsCatchupModeDropdown, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_EDITED);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupModeDropdown, 0, LV_PART_MAIN | LV_STATE_EDITED);
+	lv_obj_set_style_outline_color(
+		ui_SystemPrefsCatchupModeDropdown, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupModeDropdown, 255, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupModeDropdown, 2, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupModeDropdown, 1, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_color(
+		ui_SystemPrefsCatchupModeDropdown, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupModeDropdown, 255, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+
+	lv_obj_set_style_text_font(
+		ui_SystemPrefsCatchupModeDropdown, &lv_font_montserrat_14, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+
+	lv_obj_set_style_text_letter_space(
+		lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown), 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_line_space(
+		lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown), 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown),
+							  lv_color_hex(0x666666),
+							  LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(
+		lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown), 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	lv_obj_set_style_bg_color(lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown),
+							  lv_color_hex(0xFD8B18),
+							  LV_PART_SELECTED | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(
+		lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown), 255, LV_PART_SELECTED | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown),
+							  lv_color_hex(0xFD8B18),
+							  LV_PART_SELECTED | LV_STATE_CHECKED);
+	lv_obj_set_style_bg_opa(
+		lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown), 255, LV_PART_SELECTED | LV_STATE_CHECKED);
+
+	ui_SystemPrefsCatchupExcludeButtonsCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsCatchupExcludeButtonsCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupExcludeButtonsCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsCatchupExcludeButtonsCont, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsCatchupExcludeButtonsCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsCatchupExcludeButtonsCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(ui_SystemPrefsCatchupExcludeButtonsCont,
+						  LV_FLEX_ALIGN_SPACE_BETWEEN,
+						  LV_FLEX_ALIGN_CENTER,
+						  LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsCatchupExcludeButtonsCont,
+					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
+	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupExcludeButtonsCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupExcludeButtonsCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupExcludeButtonsCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupExcludeButtonsCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_SystemPrefsCatchupExcludeButtonsLabel = lv_label_create(ui_SystemPrefsCatchupExcludeButtonsCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupExcludeButtonsLabel, LV_SIZE_CONTENT);
+	lv_obj_set_height(ui_SystemPrefsCatchupExcludeButtonsLabel, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsCatchupExcludeButtonsLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsCatchupExcludeButtonsLabel, "Switches always track:");
+	lv_obj_set_style_text_font(
+		ui_SystemPrefsCatchupExcludeButtonsLabel, &ui_font_MuseoSansRounded70014, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_SystemPrefsCatchupExcludeButtonsCheck = lv_switch_create(ui_SystemPrefsCatchupExcludeButtonsCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupExcludeButtonsCheck, 35);
+	lv_obj_set_height(ui_SystemPrefsCatchupExcludeButtonsCheck, 20);
+	lv_obj_set_align(ui_SystemPrefsCatchupExcludeButtonsCheck, LV_ALIGN_TOP_RIGHT);
+	lv_obj_add_flag(ui_SystemPrefsCatchupExcludeButtonsCheck, LV_OBJ_FLAG_SCROLL_ON_FOCUS); /// Flags
+	lv_obj_clear_flag(ui_SystemPrefsCatchupExcludeButtonsCheck,
+					  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE); /// Flags
+	lv_obj_set_style_radius(ui_SystemPrefsCatchupExcludeButtonsCheck, 20, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0x202328), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_outline_color(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupExcludeButtonsCheck, 2, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupExcludeButtonsCheck, 1, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_color(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupExcludeButtonsCheck, 2, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupExcludeButtonsCheck, 1, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_color(ui_SystemPrefsCatchupExcludeButtonsCheck,
+								   lv_color_hex(0xFD8B18),
+								   LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_opa(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, 200, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_width(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, 2, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_pad(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, 1, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+
+	lv_obj_set_style_radius(ui_SystemPrefsCatchupExcludeButtonsCheck, 20, LV_PART_INDICATOR | LV_STATE_CHECKED);
+	lv_obj_set_style_bg_color(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0x4067D3), LV_PART_INDICATOR | LV_STATE_CHECKED);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_INDICATOR | LV_STATE_CHECKED);
+
+	lv_obj_set_style_radius(ui_SystemPrefsCatchupExcludeButtonsCheck, 20, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(
+		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupExcludeButtonsCheck, -4, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupExcludeButtonsCheck, -6, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupExcludeButtonsCheck, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupExcludeButtonsCheck, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
+}
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_menu.hh
+++ b/firmware/src/gui/slsexport/prefs_menu.hh
@@ -1,0 +1,16 @@
+#include "lvgl.h"
+
+namespace MetaModule
+{
+
+extern lv_obj_t *ui_SystemPrefsCatchupTitle;
+extern lv_obj_t *ui_SystemPrefsCatchupModeCont;
+extern lv_obj_t *ui_SystemPrefsCatchupModeLabel;
+extern lv_obj_t *ui_SystemPrefsCatchupModeDropdown;
+extern lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCont;
+extern lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsLabel;
+extern lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCheck;
+
+void init_SystemPrefsCatchupPane(lv_obj_t *parentTab);
+
+} // namespace MetaModule

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -69,6 +69,7 @@ public:
 		}
 
 		patch_playloader.request_new_audio_settings(settings.audio.sample_rate, settings.audio.block_size);
+		patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.button_exclude);
 	}
 
 	void update_screen() {

--- a/firmware/src/load_test/compare.py
+++ b/firmware/src/load_test/compare.py
@@ -4,6 +4,12 @@ import argparse
 import logging
 import csv
 
+def try_float(x):
+    try:
+        return float(x)
+    except:
+        return 0
+
 def process_file(filename):
     r = {}
     testnames = []
@@ -20,7 +26,8 @@ def process_file(filename):
             if skipFirstRow:
                 skipFirstRow = False
             else:
-                r[row[0]] = [float(x) for x in row[1:-1]]
+                r[row[0]] = [try_float(x) for x in row[1:-1]]
+
 
     return r, testnames
 
@@ -36,6 +43,7 @@ if __name__ == "__main__":
     parser.add_argument("--tol", dest="tol", default=0.02, type=float, help="Tolerance: ignore differences equal or below to this")
     parser.add_argument("--brand", dest="onlybrand", help="Compare only specific brand")
     parser.add_argument("--module", dest="onlymodule", help="Compare only specific module (Brand:Module format)")
+    parser.add_argument("--show-mem", dest="showmem", action="store_true", default=False, help="Show changes in memory usage (not reliable)")
     parser.add_argument("-v", dest="verbose", help="Verbose logging", action="store_true")
     args = parser.parse_args()
 
@@ -51,6 +59,8 @@ if __name__ == "__main__":
     not_found = []
     changes = {}
     for module, refload in ref.items():
+        if not args.showmem:
+            refload = refload[:-2] #Skip PeakStartupMem and PeakRunningMem
         if args.onlymodule:
             if module != args.onlymodule:
                 continue

--- a/firmware/src/medium/conf/catchup_settings.hh
+++ b/firmware/src/medium/conf/catchup_settings.hh
@@ -1,5 +1,5 @@
 #pragma once
-#include "catchup_param.hh"
+#include "params/catchup_param.hh"
 #include <array>
 #include <cstdint>
 #include <string_view>
@@ -34,7 +34,7 @@ struct CatchupSettings {
 			mode = DefaultMode;
 
 		// Check if deserialized data contains a value other than 0 or 1
-		if (*reinterpret_cast<int *>(&button_exclude) != 0)
+		if (*reinterpret_cast<uint8_t *>(&button_exclude) != 0)
 			button_exclude = true;
 		else
 			button_exclude = false;

--- a/firmware/src/medium/conf/catchup_settings.hh
+++ b/firmware/src/medium/conf/catchup_settings.hh
@@ -1,0 +1,44 @@
+#pragma once
+#include "catchup_param.hh"
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace MetaModule
+{
+
+struct CatchupSettings {
+	struct Option {
+		CatchupParam::Mode mode;
+		std::string_view label;
+	};
+	static constexpr std::array ValidOptions = {
+		Option{CatchupParam::Mode::ResumeOnMotion, "Track if knob moves"},
+		Option{CatchupParam::Mode::ResumeOnEqual, "Track when equal"},
+		Option{CatchupParam::Mode::LinearFade, "Linear fade"},
+	};
+	static constexpr CatchupParam::Mode DefaultMode = CatchupParam::Mode::ResumeOnMotion;
+	static constexpr bool DefaultButtonExclude = true;
+
+	CatchupParam::Mode mode = DefaultMode;
+	bool button_exclude = DefaultButtonExclude;
+
+	void make_valid() {
+
+		bool valid = false;
+		for (auto opt : ValidOptions) {
+			if (mode == opt.mode)
+				valid = true;
+		}
+		if (!valid)
+			mode = DefaultMode;
+
+		// Check if deserialized data contains a value other than 0 or 1
+		if (*reinterpret_cast<int *>(&button_exclude) != 0)
+			button_exclude = true;
+		else
+			button_exclude = false;
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/params/catchup_manager.hh
+++ b/firmware/src/params/catchup_manager.hh
@@ -1,0 +1,48 @@
+#pragma once
+#include "catchup_param.hh"
+#include "conf/panel_conf.hh"
+#include "patch-serial/patch/patch.hh"
+#include <vector>
+
+namespace MetaModule
+{
+
+struct MappedParam {
+	MappedKnob map;
+	CatchupParam catchup;
+};
+using ParamSet = std::array<std::vector<MappedParam>, PanelDef::NumKnobs>;
+
+class CatchupManager {
+
+	std::array<float, PanelDef::NumKnobs> panel_knobs{};
+
+public:
+	void set_panel_param(auto &modules, ParamSet &active_knob_maps, unsigned panel_knob_id, float val) {
+		panel_knobs[panel_knob_id] = val;
+
+		for (auto &knob_map : active_knob_maps[panel_knob_id]) {
+			auto &map = knob_map.map;
+
+			auto module_val = modules[map.module_id]->get_param(map.param_id);
+			auto scaled_phys_val = map.get_mapped_val(val);
+			if (auto v = knob_map.catchup.update(scaled_phys_val, module_val)) {
+				modules[map.module_id]->set_param(map.param_id, *v);
+			}
+		}
+	}
+
+	void reset(auto &modules, ParamSet &active_knob_maps) {
+		// Reset all catchups in the new active knobset.
+		// This allows them to change to catchup mode if necessary
+		for (unsigned i = 0u; auto &knob : active_knob_maps) {
+			for (auto &map : knob) {
+				auto module_val = modules[map.map.module_id]->get_param(map.map.param_id);
+				map.catchup.reset_phys_val(panel_knobs[i], module_val);
+			}
+			i++;
+		}
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/params/catchup_manager.hh
+++ b/firmware/src/params/catchup_manager.hh
@@ -28,6 +28,8 @@ public:
 			auto scaled_phys_val = map.get_mapped_val(val);
 			if (auto v = knob_map.catchup.update(scaled_phys_val, module_val)) {
 				modules[map.module_id]->set_param(map.param_id, *v);
+				auto new_module_val = modules[map.module_id]->get_param(map.param_id);
+				knob_map.catchup.report_actual_module_val(new_module_val);
 			}
 		}
 	}

--- a/firmware/src/params/catchup_manager.hh
+++ b/firmware/src/params/catchup_manager.hh
@@ -38,7 +38,7 @@ public:
 		for (unsigned i = 0u; auto &knob : active_knob_maps) {
 			for (auto &map : knob) {
 				auto module_val = modules[map.map.module_id]->get_param(map.map.param_id);
-				map.catchup.reset_phys_val(panel_knobs[i], module_val);
+				map.catchup.reset_phys_val(map.map.get_mapped_val(panel_knobs[i]), module_val);
 			}
 			i++;
 		}

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -1,0 +1,143 @@
+#pragma once
+#include "console/pr_dbg.hh"
+#include "debug.hh"
+#include "util/math.hh"
+#include <optional>
+
+namespace MetaModule
+{
+
+class CatchupParam {
+	using T = float;
+	static constexpr T Max = T{1};
+	static constexpr T Tolerance = T{5.f} / T{4095};
+
+	T last_module_val{0};
+	T last_phys_val{0};
+	float fade_phys_val{0};
+	float fade_mod_val{0};
+
+	enum class State { Tracking, Catchup } state = State::Catchup;
+
+public:
+	enum class Mode { ResumeOnMotion, ResumeOnEqual, LinearFade } mode = Mode::LinearFade;
+
+	// Called when a physical knob changes value.
+	std::optional<T> update(T cur_phys_val, T cur_module_val) {
+		last_phys_val = cur_phys_val;
+
+		if (state == State::Tracking) {
+			// Change to Catchup mode if module changes value
+			if (MathTools::abs_diff(last_module_val, cur_module_val) >= Tolerance) {
+				pr_dbg("update(): m:%f=>%f  ->c\n", last_module_val, cur_module_val);
+				last_module_val = cur_module_val;
+				enter_catchup();
+				return {};
+
+			} else {
+				pr_dbg("update(): m:%f=>%f (t)\n", last_module_val, cur_module_val);
+				last_module_val = cur_phys_val;
+				return cur_phys_val;
+			}
+		}
+
+		if (mode == Mode::ResumeOnMotion) {
+			return update_resume_motion(cur_phys_val, cur_module_val);
+		}
+
+		if (mode == Mode::ResumeOnEqual) {
+			return update_resume_equal(cur_phys_val, cur_module_val);
+		}
+
+		if (mode == Mode::LinearFade) {
+			return update_linear_fade(cur_phys_val, cur_module_val);
+		}
+
+		return {};
+	}
+
+	void reset_phys_val(T phys_val, T module_val) {
+		if (mode == Mode::LinearFade) {
+			if (MathTools::abs_diff(module_val, phys_val) < Tolerance) {
+				enter_tracking(phys_val);
+				pr_dbg("reset(): m:%f p:%f  ->t\n", module_val, phys_val);
+			} else {
+				fade_phys_val = std::clamp(phys_val, Tolerance, Max - Tolerance); //cannot be 0 or Max
+				fade_mod_val = module_val;
+				pr_dbg("reset(): m:%f p:%f  ->c\n", module_val, phys_val);
+				enter_catchup();
+			}
+		} else {
+
+			// If phys knob value jumps (e.g. loaded a knobset or patch and knobs are in a different position)
+			// then enter catchup mode
+			if (MathTools::abs_diff(last_phys_val, phys_val) >= Tolerance) {
+				enter_catchup();
+			}
+		}
+
+		last_phys_val = phys_val;
+		last_module_val = module_val;
+	}
+
+	void set_mode(Mode newmode) {
+		mode = newmode;
+		// TODO: does it matter if we're in the Tracking or Catchup state when the mode changes?
+	}
+
+	bool is_tracking() const {
+		return state == State::Tracking;
+	}
+
+private:
+	T update_resume_motion(T phys_val, T) {
+		// Since update() is only is called if the physical value changed
+		// then always start tracking
+		return enter_tracking(phys_val);
+	}
+
+	std::optional<T> update_resume_equal(T phys_val, T module_val) {
+		// Exit catchup mode if module and physical values are close
+		if (MathTools::abs_diff(module_val, phys_val) < Tolerance) {
+			return enter_tracking(phys_val);
+		}
+		return {};
+	}
+
+	T update_linear_fade(T phys_val, T) {
+		// Exit by moving physical knob to min or max (0 or 1)
+		if (phys_val <= Tolerance || phys_val >= (Max - Tolerance)) {
+			enter_tracking(phys_val);
+		}
+
+		// TODO: cache these coefficients
+		if (phys_val > fade_phys_val)
+			return (phys_val - fade_phys_val) * (Max - fade_mod_val) / (Max - fade_phys_val) + fade_mod_val;
+		else
+			return phys_val * fade_mod_val / fade_phys_val;
+	}
+
+	T enter_tracking(T phys_val) {
+		Debug::Pin1::high();
+
+		state = State::Tracking;
+
+		Debug::Pin1::low();
+
+		return phys_val;
+	}
+
+	void enter_catchup() {
+		if (state != State::Catchup && mode == Mode::LinearFade) {
+			pr_dbg("Should not get here!\n");
+		}
+
+		Debug::Pin0::high();
+
+		state = State::Catchup;
+
+		Debug::Pin0::low();
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -1,8 +1,5 @@
 #pragma once
-#include "console/pr_dbg.hh"
-#include "debug.hh"
 #include "util/math.hh"
-#include <math.h>
 
 #include <optional>
 
@@ -41,12 +38,10 @@ public:
 		if (state == State::Tracking) {
 			// Change to Catchup mode if module changes value
 			if (MathTools::abs_diff(last_module_val, cur_module_val) >= Tolerance) {
-				// last_module_val = cur_module_val; //not needed??
 				enter_catchup();
 				return {};
 			} else {
 				//Otherwise return the physical knob value
-				// last_module_val = cur_phys_val; //not needed if we also call report_actual_module_val()
 				return cur_phys_val;
 			}
 		}
@@ -146,7 +141,7 @@ private:
 
 	void enter_catchup() {
 		if (state != State::Catchup && mode == Mode::LinearFade) {
-			pr_dbg("Should not get here!\n");
+			// pr_dbg("Should not get here!\n");
 		}
 		state = State::Catchup;
 	}

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -20,7 +20,7 @@ class CatchupParam {
 	enum class State { Tracking, Catchup } state = State::Catchup;
 
 public:
-	enum class Mode { ResumeOnMotion, ResumeOnEqual, LinearFade } mode = Mode::LinearFade;
+	enum class Mode { ResumeOnMotion, ResumeOnEqual, LinearFade } mode = Mode::ResumeOnMotion;
 
 	// Called when a physical knob changes value.
 	std::optional<T> update(T cur_phys_val, T cur_module_val) {
@@ -29,13 +29,13 @@ public:
 		if (state == State::Tracking) {
 			// Change to Catchup mode if module changes value
 			if (MathTools::abs_diff(last_module_val, cur_module_val) >= Tolerance) {
-				pr_dbg("update(): m:%f=>%f  ->c\n", last_module_val, cur_module_val);
+				// printf("update(): m:%f=>%f  ->c\n", last_module_val, cur_module_val);
 				last_module_val = cur_module_val;
 				enter_catchup();
 				return {};
 
 			} else {
-				pr_dbg("update(): m:%f=>%f (t)\n", last_module_val, cur_module_val);
+				// pr_dbg("update(): m:%f=>%f (t)\n", last_module_val, cur_module_val);
 				last_module_val = cur_phys_val;
 				return cur_phys_val;
 			}
@@ -60,11 +60,11 @@ public:
 		if (mode == Mode::LinearFade) {
 			if (MathTools::abs_diff(module_val, phys_val) < Tolerance) {
 				enter_tracking(phys_val);
-				pr_dbg("reset(): m:%f p:%f  ->t\n", module_val, phys_val);
+				// pr_dbg("reset(): m:%f p:%f  ->t\n", module_val, phys_val);
 			} else {
 				fade_phys_val = std::clamp(phys_val, Tolerance, Max - Tolerance); //cannot be 0 or Max
 				fade_mod_val = module_val;
-				pr_dbg("reset(): m:%f p:%f  ->c\n", module_val, phys_val);
+				// pr_dbg("reset(): m:%f p:%f  ->c\n", module_val, phys_val);
 				enter_catchup();
 			}
 		} else {
@@ -122,12 +122,7 @@ private:
 	}
 
 	T enter_tracking(T phys_val) {
-		Debug::Pin1::high();
-
 		state = State::Tracking;
-
-		Debug::Pin1::low();
-
 		return phys_val;
 	}
 
@@ -135,12 +130,7 @@ private:
 		if (state != State::Catchup && mode == Mode::LinearFade) {
 			pr_dbg("Should not get here!\n");
 		}
-
-		Debug::Pin0::high();
-
 		state = State::Catchup;
-
-		Debug::Pin0::low();
 	}
 };
 

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -102,6 +102,7 @@ private:
 	std::optional<T> update_resume_equal(T phys_val, T module_val) {
 		// Exit catchup mode if module and physical values are close
 		if (MathTools::abs_diff(module_val, phys_val) < Tolerance) {
+			last_module_val = phys_val;
 			return enter_tracking(phys_val);
 		}
 		return {};

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -73,6 +73,9 @@ public:
 			// then enter catchup mode
 			if (MathTools::abs_diff(last_phys_val, phys_val) >= Tolerance) {
 				enter_catchup();
+
+			} else if (MathTools::abs_diff(last_module_val, module_val) >= Tolerance) {
+				enter_catchup();
 			}
 		}
 

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -791,6 +791,9 @@ public:
 	// Set mode for one mapping only
 	void set_catchup_mode(int knob_set_idx, unsigned module_id, unsigned param_id, CatchupParam::Mode mode);
 
+	// Set mode for one module/param, in any knobset
+	void set_catchup_mode(unsigned module_id, unsigned param_id, CatchupParam::Mode mode);
+
 	bool is_param_tracking(unsigned module_id, unsigned param_id);
 
 private:

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -284,10 +284,17 @@ public:
 
 	// K-rate setters/getters:
 
-	void set_panel_param(unsigned param_id, float val) {
-		if (param_id < PanelDef::NumKnobs) {
-			for (auto const &k : knob_conns[active_knob_set][param_id]) {
-				modules[k.module_id]->set_param(k.param_id, k.get_mapped_val(val));
+	void set_panel_param(unsigned panel_knob_id, float val) {
+		panel_knobs[panel_knob_id] = val;
+
+		for (auto &knob_map : knob_maps[active_knob_set][panel_knob_id]) {
+			auto &k = knob_map.map;
+			auto &catchup = knob_map.catchup;
+
+			auto module_val = modules[k.module_id]->get_param(k.param_id);
+			auto scaled_phys_val = k.get_mapped_val(val);
+			if (auto v = catchup.update(scaled_phys_val, module_val)) {
+				modules[k.module_id]->set_param(k.param_id, *v);
 			}
 		}
 	}
@@ -477,7 +484,21 @@ public:
 	}
 
 	void set_active_knob_set(unsigned num) {
-		active_knob_set = std::min(num, MaxKnobSets - 1);
+		auto new_active_knob_set = std::min(num, MaxKnobSets - 1);
+
+		if (active_knob_set != new_active_knob_set) {
+			active_knob_set = new_active_knob_set;
+
+			// Reset all catchups in the new active knobset.
+			// This allows them to change to catchup mode if necessary
+			for (unsigned i = 0u; auto &knob : knob_maps[active_knob_set]) {
+				for (auto &map : knob) {
+					auto module_val = modules[map.map.module_id]->get_param(map.map.param_id);
+					map.catchup.reset_phys_val(panel_knobs[i], module_val);
+				}
+				i++;
+			}
+		}
 	}
 
 	void add_internal_cable(Jack in, Jack out) {

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -758,6 +758,18 @@ public:
 		midi_connected = false;
 	}
 
+	// Set mode for all maps
+	void set_catchup_mode(CatchupParam::Mode mode);
+
+	// Set mode for one knobset only.
+	// If knob_set_idx is out of range, then active knob set will be changed.
+	void set_catchup_mode(CatchupParam::Mode mode, int knob_set_idx);
+
+	// Set mode for one mapping only
+	void set_catchup_mode(int knob_set_idx, unsigned module_id, unsigned param_id, CatchupParam::Mode mode);
+
+	bool is_param_tracking(unsigned module_id, unsigned param_id);
+
 private:
 	static inline Jack disconnected_jack = {0xFFFF, 0xFFFF};
 

--- a/firmware/src/patch_play/patch_player_catchup.cc
+++ b/firmware/src/patch_play/patch_player_catchup.cc
@@ -1,0 +1,56 @@
+#include "patch_player.hh"
+
+namespace MetaModule
+{
+
+// Set mode for all maps
+void PatchPlayer::set_catchup_mode(CatchupParam::Mode mode) {
+	for (auto &knobset : knob_maps) {
+		for (auto &knob : knobset) {
+			for (auto &map : knob) {
+				map.catchup.set_mode(mode);
+			}
+		}
+	}
+}
+
+// Set mode for one knobset only.
+// If knob_set_idx is out of range, then active knob set will be changed.
+void PatchPlayer::set_catchup_mode(CatchupParam::Mode mode, int knob_set_idx) {
+	if (knob_set_idx < 0 || knob_set_idx >= (int)knob_maps.size())
+		knob_set_idx = active_knob_set;
+
+	for (auto &knob : knob_maps[knob_set_idx]) {
+		for (auto &map : knob) {
+			map.catchup.set_mode(mode);
+		}
+	}
+}
+
+// Set mode for one mapping only
+void PatchPlayer::set_catchup_mode(int knob_set_idx, unsigned module_id, unsigned param_id, CatchupParam::Mode mode) {
+	if (knob_set_idx < 0 || knob_set_idx >= (int)knob_maps.size())
+		knob_set_idx = active_knob_set;
+
+	for (auto &knob : knob_maps[knob_set_idx]) {
+		for (auto &map : knob) {
+			if (map.map.module_id == module_id && map.map.param_id == param_id) {
+				map.catchup.set_mode(mode);
+				return;
+			}
+		}
+	}
+}
+
+bool PatchPlayer::is_param_tracking(unsigned module_id, unsigned param_id) {
+	for (auto const &knob : knob_maps[active_knob_set]) {
+		for (auto const &map : knob) {
+			if (map.map.module_id == module_id && map.map.param_id == param_id) {
+				return map.catchup.is_tracking();
+			}
+		}
+	}
+	return false;
+}
+
+} // namespace MetaModule

--- a/firmware/src/patch_play/patch_player_catchup.cc
+++ b/firmware/src/patch_play/patch_player_catchup.cc
@@ -28,6 +28,7 @@ void PatchPlayer::set_catchup_mode(CatchupParam::Mode mode, int knob_set_idx) {
 }
 
 // Set mode for one mapping only
+// If knob_set_idx is out of range, then active knob set will be changed.
 void PatchPlayer::set_catchup_mode(int knob_set_idx, unsigned module_id, unsigned param_id, CatchupParam::Mode mode) {
 	if (knob_set_idx < 0 || knob_set_idx >= (int)knob_maps.size())
 		knob_set_idx = active_knob_set;
@@ -37,6 +38,20 @@ void PatchPlayer::set_catchup_mode(int knob_set_idx, unsigned module_id, unsigne
 			if (map.map.module_id == module_id && map.map.param_id == param_id) {
 				map.catchup.set_mode(mode);
 				return;
+			}
+		}
+	}
+}
+
+// Set mode for a particular param on a particular module, in any/all knobsets
+void PatchPlayer::set_catchup_mode(unsigned module_id, unsigned param_id, CatchupParam::Mode mode) {
+	for (auto &knobset : knob_maps) {
+		for (auto &knob : knobset) {
+			for (auto &map : knob) {
+				if (map.map.module_id == module_id && map.map.param_id == param_id) {
+					map.catchup.set_mode(mode);
+					return;
+				}
 			}
 		}
 	}

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -265,6 +265,10 @@ struct PatchPlayLoader {
 			return nullptr;
 	}
 
+	bool is_param_tracking(unsigned module_id, unsigned param_id) {
+		return player_.is_param_tracking(module_id, param_id);
+	}
+
 private:
 	PatchPlayer &player_;
 	FileStorageProxy &storage_;

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -9,6 +9,7 @@
 #include "patch_play/patch_player.hh"
 #include "pr_dbg.hh"
 #include "result_t.hh"
+#include "util/overloaded.hh"
 #include <atomic>
 
 size_t get_heap_size();
@@ -267,6 +268,38 @@ struct PatchPlayLoader {
 
 	bool is_param_tracking(unsigned module_id, unsigned param_id) {
 		return player_.is_param_tracking(module_id, param_id);
+	}
+
+	void set_all_param_catchup_mode(CatchupParam::Mode mode, bool exclude_buttons) {
+		// if (exclude_buttons) {
+
+		// 	for (auto module_id = 0u; auto slug : patches_.get_view_patch()->module_slugs) {
+		// 		auto info = ModuleFactory::getModuleInfo(slug);
+
+		// 		for (unsigned i = 0; auto const &element : info.elements) {
+		// 			auto param_id = info.indices[i].param_idx;
+		// 			enum { Ignore, Enable, Disable };
+		// 			auto action = std::visit(overloaded{
+		// 										 [](Pot const &el) { return el.integral ? Disable : Enable; },
+		// 										 [](Switch const &el) { return Disable; },
+		// 										 [](Button const &el) { return Disable; },
+		// 										 [](ParamElement const &el) { return Enable; },
+		// 										 [](BaseElement const &el) { return Ignore; },
+		// 									 },
+		// 									 element);
+		// 			if (action == Enable)
+		// 				player_.set_catchup_mode(module_id, param_id, mode);
+		// 			else if (action == Disable)
+		// 				player_.set_catchup_mode(module_id, param_id, CatchupParam::Mode::ResumeOnMotion);
+
+		// 			i++;
+		// 		}
+		// 		module_id++;
+		// 	}
+
+		// } else {
+		player_.set_catchup_mode(mode);
+		// }
 	}
 
 private:

--- a/firmware/src/user_settings/settings.hh
+++ b/firmware/src/user_settings/settings.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "conf/audio_settings.hh"
+#include "conf/catchup_settings.hh"
 #include "fs/volumes.hh"
 #include "gui/elements/screensaver_settings.hh"
 #include "gui/pages/view_settings.hh"
@@ -16,6 +17,7 @@ struct UserSettings {
 	std::string last_patch_opened{};
 	Volume last_patch_vol{Volume::NorFlash};
 	ScreensaverSettings screensaver{};
+	CatchupSettings catchup{};
 };
 
 } // namespace MetaModule

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -53,6 +53,18 @@ static void write(ryml::NodeRef *n, ScreensaverSettings const &s) {
 	n->append_child() << ryml::key("knobs_can_wake") << s.knobs_can_wake;
 }
 
+static void write(ryml::NodeRef *n, CatchupSettings const &s) {
+	*n |= ryml::MAP;
+
+	using enum CatchupParam::Mode;
+	ryml::csubstr mode_string = s.mode == ResumeOnEqual	 ? "ResumeOnEqual" :
+								s.mode == ResumeOnMotion ? "ResumeOnMotion" :
+								s.mode == LinearFade	 ? "LinearFade" :
+														   "ResumeOnMotion";
+	n->append_child() << ryml::key("mode") << mode_string;
+	n->append_child() << ryml::key("exclude_buttons") << s.button_exclude;
+}
+
 namespace Settings
 {
 
@@ -73,6 +85,7 @@ uint32_t serialize(UserSettings const &settings, std::span<char> buffer) {
 	data["last_patch_opened"] << settings.last_patch_opened;
 	data["last_patch_vol"] << static_cast<unsigned>(settings.last_patch_vol);
 	data["screensaver"] << settings.screensaver;
+	data["catchup"] << settings.catchup;
 
 	auto res = ryml::emit_yaml(tree, c4::substr(buffer.data(), buffer.size()));
 	return res.size();

--- a/firmware/tests/catchup_snap_tests.cc
+++ b/firmware/tests/catchup_snap_tests.cc
@@ -1,0 +1,552 @@
+#include "CoreModules/CoreProcessor.hh"
+#include "doctest.h"
+#include "params/catchup_manager.hh"
+#include "params/catchup_param.hh"
+#include <memory>
+
+// These tests use a module that has 'snapping' params:
+// only values N/4 are allowed: 0, 0.25, 0.5, 0.75, 1.0
+struct SnapModule : CoreProcessor {
+	std::array<float, 8> params{};
+
+	void set_param(int param_id, float val) override {
+		if (param_id > 0 && param_id < (int)params.size())
+			params[param_id] = std::round(val * 4.f) / 4.f;
+	}
+	float get_param(int param_id) const override {
+		if (param_id > 0 && param_id < (int)params.size())
+			return params[param_id];
+		else
+			return 0;
+	}
+	void update() override {
+	}
+	void set_samplerate(float sr) override {
+	}
+	void set_input(int input_id, float val) override {
+	}
+	float get_output(int output_id) const override {
+		return 0;
+	}
+};
+
+TEST_CASE("Basic usage of ResumeOnEqual") {
+	using namespace MetaModule;
+
+	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+	modules[0] = std::make_unique<SnapModule>();
+
+	CatchupManager catchup_manager;
+	std::array<ParamSet, MaxKnobSets> knob_maps;
+
+	unsigned active_knobset = 0;
+	unsigned panel_knob = 1;
+	unsigned param_id = 2;
+
+	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+	p.map.panel_knob_id = panel_knob;
+	p.map.module_id = 0;
+	p.map.param_id = param_id;
+	p.catchup.set_mode(CatchupParam::Mode::ResumeOnEqual);
+
+	SUBCASE("Normal mapping (0-1 => 0-1). Test for pickup on equal, module changing value, switching knobsets") {
+		p.map.min = 0;
+		p.map.max = 1;
+
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Moving knob has no effect
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Moving knob to 0, then to a new value makes it track
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.0f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == 0.5f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		//// Module changes own value -> stop tracking until knob value matches
+		//modules[0]->set_param(param_id, 0.75f);
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+		//CHECK(modules[0]->get_param(param_id) == 0.75f);
+		//CHECK(p.catchup.is_tracking() == false);
+
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		//CHECK(modules[0]->get_param(param_id) == 0.8f);
+		//CHECK(p.catchup.is_tracking() == false);
+
+		////.79999 vs 0.8, within tolerance -> start tracking
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.79999f);
+		//CHECK(modules[0]->get_param(param_id) == 0.79999f);
+		//CHECK(p.catchup.is_tracking() == true);
+
+		////User switches knobset, moves knob (which is mapped to something else)
+		//active_knobset = 1;
+		//catchup_manager.reset(modules, knob_maps[active_knobset]);
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+
+		//// User switches knobset back -> stop tracking
+		//active_knobset = 0;
+		//catchup_manager.reset(modules, knob_maps[active_knobset]);
+		//CHECK(modules[0]->get_param(param_id) == 0.79999f);
+		//CHECK(p.catchup.is_tracking() == false);
+
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		//CHECK(p.catchup.is_tracking() == false);
+
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		//CHECK(p.catchup.is_tracking() == false);
+
+		//// Move knob close to module value -> start tracking again
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		//CHECK(modules[0]->get_param(param_id) == 0.80001f);
+		//CHECK(p.catchup.is_tracking() == true);
+
+		//// User switches knobset and then back again, without moving knob -> still tracking
+		//active_knobset = 1;
+		//catchup_manager.reset(modules, knob_maps[active_knobset]);
+		//active_knobset = 0;
+		//catchup_manager.reset(modules, knob_maps[active_knobset]);
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		//CHECK(p.catchup.is_tracking() == true);
+
+		//// Module changes own value (so that tracking mode stops)
+		//modules[0]->set_param(param_id, 0.1f);
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		//CHECK(modules[0]->get_param(param_id) == 0.1f);
+		//CHECK(p.catchup.is_tracking() == false);
+
+		//// User switches knobset and then back again, without moving knob -> still not tracking
+		//active_knobset = 1;
+		//catchup_manager.reset(modules, knob_maps[active_knobset]);
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		//active_knobset = 0;
+		//catchup_manager.reset(modules, knob_maps[active_knobset]);
+		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		//CHECK(p.catchup.is_tracking() == false);
+		//CHECK(modules[0]->get_param(param_id) == 0.1f);
+	}
+
+	//SUBCASE("Inverted partial range mapping. Test for pickup on equal, module changing value, switching knobsets") {
+	//	p.map.min = 0.9f; // knob at 0 => module set to 0.9
+	//	p.map.max = 0.4f; // knob at 1 => module set to 0.4
+
+	//	// Starting (default) value
+	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	// Moving knob has no effect
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	// Even moving to min or max (1.0) has no effect, because module value is out of range
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.0f);
+	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
+	//	CHECK(p.catchup.is_tracking() == false);
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.0f);
+	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	// Now let's have the module set its value to be in our range (0.4 is knob at 1)
+	//	// It will now track
+	//	modules[0]->set_param(param_id, 0.5f);
+	//	CHECK(p.catchup.is_tracking() == false); //Note: is_tracking() does not update until set_panel_param is called!
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.8f);
+	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.5f));
+	//	CHECK(p.catchup.is_tracking() == true);
+
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.7f)); //knob 0.4 maps to module 0.7
+	//	CHECK(p.catchup.is_tracking() == true);
+
+	//	// Module changes own value -> stop tracking until knob value matches
+	//	modules[0]->set_param(param_id, 0.8f);
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+	//	CHECK(modules[0]->get_param(param_id) == 0.8f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+	//	CHECK(modules[0]->get_param(param_id) == 0.8f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	//.79995 vs 0.8 (which is what 0.2001 maps to) is within tolerance -> start tracking
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2001f);
+	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79995));
+	//	CHECK(p.catchup.is_tracking() == true);
+
+	//	//User switches knobset, moves knob (which is mapped to something else)
+	//	active_knobset = 1;
+	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+
+	//	// User switches knobset back -> stop tracking
+	//	active_knobset = 0;
+	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
+	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79995f));
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	// Move knob close to module value -> start tracking again
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.800005f));
+	//	CHECK(p.catchup.is_tracking() == true);
+
+	//	// User switches knobset and then back again, without moving knob -> still tracking
+	//	active_knobset = 1;
+	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
+	//	active_knobset = 0;
+	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+	//	CHECK(p.catchup.is_tracking() == true);
+
+	//	// Module changes own value (so that tracking mode stops)
+	//	modules[0]->set_param(param_id, 0.1f);
+	//	// Note: is_tracking() does not update until set_panel_param is called
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+	//	CHECK(modules[0]->get_param(param_id) == 0.1f);
+	//	CHECK(p.catchup.is_tracking() == false);
+
+	//	// User switches knobset and then back again, without moving knob -> still not tracking
+	//	active_knobset = 1;
+	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+	//	active_knobset = 0;
+	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
+	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+	//	CHECK(p.catchup.is_tracking() == false);
+	//	CHECK(modules[0]->get_param(param_id) == 0.1f);
+	//}
+}
+
+//TEST_CASE("Basic usage of ResumeOnMotion") {
+//	using namespace MetaModule;
+
+//	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+//	modules[0] = std::make_unique<SnapModule>();
+
+//	CatchupManager catchup_manager;
+//	std::array<ParamSet, MaxKnobSets> knob_maps;
+
+//	// Knob 1: set to .3
+//	unsigned active_knobset = 0;
+//	unsigned panel_knob = 1;
+//	unsigned param_id = 2;
+
+//	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+//	p.map.panel_knob_id = panel_knob;
+//	p.map.module_id = 0;
+//	p.map.param_id = param_id;
+//	p.catchup.set_mode(CatchupParam::Mode::ResumeOnMotion);
+
+//	SUBCASE("Normal mapping (0-1 => 0-1). Test for pickup, module changing value, switching knobsets") {
+//		p.map.min = 0;
+//		p.map.max = 1;
+
+//		// Starting (default) value
+//		CHECK(modules[0]->get_param(param_id) == 0.0f);
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// Moving knob has immediate effect
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		CHECK(modules[0]->get_param(param_id) == 0.2f);
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == 0.4f);
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		// Module changes own value -> immediately tracks knob
+//		// technically, this is not "resume on motion" since the knob did not move
+//		// but the engine only calls set_panel_param() if the knob changed values, so
+//		// effecively it works as "resume on motion"
+//		modules[0]->set_param(param_id, 0.8f);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == 0.4f);
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+//		CHECK(modules[0]->get_param(param_id) == 0.7f);
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		//User switches knobset, moves knob (which is mapped to something else)
+//		active_knobset = 1;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		// User switches knobset back -> stop tracking
+//		active_knobset = 0;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		CHECK(modules[0]->get_param(param_id) == 0.7f);
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// Starts tracking when knob moved
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+//		CHECK(modules[0]->get_param(param_id) == 0.3f);
+//		CHECK(p.catchup.is_tracking() == true);
+//	}
+
+//	SUBCASE("Inverted partial mapping. Test for pickup, module changing value, switching knobsets") {
+//		//0 to 1 => .9 to .4
+//		p.map.min = 0.9f;
+//		p.map.max = 0.4f;
+//		auto map = [&](float knob) {
+//			return 0.9f - knob / 2.f;
+//		};
+
+//		// Starting (default) value
+//		CHECK(modules[0]->get_param(param_id) == 0.0f);
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// Moving knob has immediate effect
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		CHECK(modules[0]->get_param(param_id) == map(0.2f));
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == map(0.4f));
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		// Module changes own value -> immediately tracks knob
+//		// technically, this is not "resume on motion" since the knob did not move
+//		// but the engine only calls set_panel_param() if the knob changed values, so
+//		// effecively it works as "resume on motion"
+//		modules[0]->set_param(param_id, 0.8f);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.4f)));
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.7f)));
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		//User switches knobset, moves knob (which is mapped to something else)
+//		active_knobset = 1;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		// User switches knobset back -> stop tracking
+//		active_knobset = 0;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.7f)));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// Starts tracking when knob moved
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.3f)));
+//		CHECK(p.catchup.is_tracking() == true);
+//	}
+//}
+
+//TEST_CASE("Basic usage of LinearFade") {
+//	using namespace MetaModule;
+
+//	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+//	modules[0] = std::make_unique<SnapModule>();
+
+//	CatchupManager catchup_manager;
+//	std::array<ParamSet, MaxKnobSets> knob_maps;
+
+//	// Knob 1: set to .3
+//	unsigned active_knobset = 0;
+//	unsigned panel_knob = 1;
+//	unsigned param_id = 2;
+
+//	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+//	p.map.panel_knob_id = panel_knob;
+//	p.map.module_id = 0;
+//	p.map.param_id = param_id;
+//	p.catchup.set_mode(CatchupParam::Mode::LinearFade);
+
+//	SUBCASE("Normal mapping (0-1 => 0-1). Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
+//			"value recalcs segments, switching knobsets") {
+//		p.map.min = 0;
+//		p.map.max = 1;
+
+//		// Starting (default) value
+//		CHECK(modules[0]->get_param(param_id) == 0.0f);
+
+//		// Starts in tracking mode by default
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		// Moving knob tracks 1:1
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		CHECK(modules[0]->get_param(param_id) == 0.2f);
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+//		CHECK(modules[0]->get_param(param_id) == 0.6f);
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		// Switching knob sets, moving the module or phys knob, then switching back
+//		// will enter catchup mode
+//		active_knobset = 1;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		active_knobset = 0;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		CHECK(modules[0]->get_param(param_id) == 0.6f);
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// Tracks with 2 segment function:
+//		// knob 0-0.2 => module 0-0.6
+//		// knob 0.2-1 => module 0.6-1
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.1f);
+//		CHECK(modules[0]->get_param(param_id) == 0.3f);
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		CHECK(modules[0]->get_param(param_id) == 0.6f);
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.65));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.7));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		SUBCASE("Moving to 1 will end tracking") {
+//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.f);
+//			CHECK(modules[0]->get_param(param_id) == 1.f);
+//			CHECK(p.catchup.is_tracking() == true);
+//		}
+
+//		SUBCASE("Moving to 0 will end tracking") {
+//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.f);
+//			CHECK(modules[0]->get_param(param_id) == 0.f);
+//			CHECK(p.catchup.is_tracking() == true);
+//		}
+
+//		SUBCASE("Module moves its own knob => linear fade is re-calculated") {
+//			CHECK(p.catchup.is_tracking() == false);
+//			modules[0]->set_param(param_id, 0.2f);
+//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//			// inflection point is now at: knob 0.4, module 0.2
+//			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
+//			CHECK(p.catchup.is_tracking() == false);
+
+//			// Switching knobsets and then back, with the knob set to the module value
+//			// is in tracking mode
+//			active_knobset = 1;
+//			catchup_manager.reset(modules, knob_maps[active_knobset]);
+//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//			active_knobset = 0;
+//			catchup_manager.reset(modules, knob_maps[active_knobset]);
+//			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
+//			CHECK(p.catchup.is_tracking() == true);
+
+//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+//			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.3f));
+//		}
+//	}
+
+//	SUBCASE("Inverted mapping. Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
+//			"value recalcs segments, switching knobsets") {
+//		p.map.min = 0.9f;
+//		p.map.max = 0.4f;
+//		auto map = [&](float knob) {
+//			return 0.9f - knob / 2.f;
+//		};
+
+//		// Starting (default) value
+//		CHECK(modules[0]->get_param(param_id) == 0.0f);
+
+//		// Starts in tracking mode by default
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		// Moving knob tracks
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+//		CHECK(modules[0]->get_param(param_id) == map(0.2f));
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == map(0.4f));
+//		CHECK(p.catchup.is_tracking() == true);
+
+//		// Switching knob sets, moving the phys knob, then switching back
+//		// will enter catchup mode
+//		active_knobset = 1;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.8f);
+//		active_knobset = 0;
+//		catchup_manager.reset(modules, knob_maps[active_knobset]);
+//		CHECK(modules[0]->get_param(param_id) == 0.7f); //map(0.4) == 0.7
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// Tracks with 2 segment function:
+//		// inflection point is at knob@0.8 (mapped val = 0.7), module@ 0.7
+
+//		// above 0.8: knob moves +0.05 => module moves -0.035
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.85f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.665f));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.9f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.630f));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.95f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.595f));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// below 0.8: knob moves -0.05 => module moves +0.030
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.73f));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.76));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		//Module moves its own knob => linear fade is re-calculated
+//		CHECK(p.catchup.is_tracking() == false);
+//		modules[0]->set_param(param_id, 0.2f);
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+
+//		// inflection point is now at: knob 0.4, module 0.2
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// knob moves +0.1, module moves -0.015385
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 - 0.015385));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 - 0.015385 - 0.015385));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		// knob moves -0.1, module moves 0.114286
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 + 0.114286));
+//		CHECK(p.catchup.is_tracking() == false);
+
+//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 + 0.114286 + 0.114286));
+//		CHECK(p.catchup.is_tracking() == false);
+//	}
+//}

--- a/firmware/tests/catchup_snap_tests.cc
+++ b/firmware/tests/catchup_snap_tests.cc
@@ -66,7 +66,7 @@ TEST_CASE("Basic usage of ResumeOnEqual") {
 		CHECK(modules[0]->get_param(param_id) == 0.0f);
 		CHECK(p.catchup.is_tracking() == false);
 
-		// Moving knob to 0, then to a new value makes it track
+		// Moving knob to 0, then to a new value makes it track (snapping to nearest N/4)
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.0f);
 		CHECK(modules[0]->get_param(param_id) == 0.0f);
 		CHECK(p.catchup.is_tracking() == true);
@@ -79,474 +79,238 @@ TEST_CASE("Basic usage of ResumeOnEqual") {
 		CHECK(modules[0]->get_param(param_id) == 0.5f);
 		CHECK(p.catchup.is_tracking() == true);
 
-		//// Module changes own value -> stop tracking until knob value matches
-		//modules[0]->set_param(param_id, 0.75f);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
-		//CHECK(modules[0]->get_param(param_id) == 0.75f);
-		//CHECK(p.catchup.is_tracking() == false);
+		// Module changes own value -> stop tracking until knob value matches
+		modules[0]->set_param(param_id, 0.75f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+		CHECK(modules[0]->get_param(param_id) == 0.75f);
+		CHECK(p.catchup.is_tracking() == false);
 
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-		//CHECK(modules[0]->get_param(param_id) == 0.8f);
-		//CHECK(p.catchup.is_tracking() == false);
+		// It's not enough for the knob to be a value that would normally caused the current module's value...
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == 0.75f);
+		CHECK(p.catchup.is_tracking() == false);
 
-		////.79999 vs 0.8, within tolerance -> start tracking
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.79999f);
-		//CHECK(modules[0]->get_param(param_id) == 0.79999f);
-		//CHECK(p.catchup.is_tracking() == true);
+		// ...knob value must match snapped module value to start tracking
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.75f);
+		CHECK(modules[0]->get_param(param_id) == 0.75);
+		CHECK(p.catchup.is_tracking() == true);
 
-		////User switches knobset, moves knob (which is mapped to something else)
-		//active_knobset = 1;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		//User switches knobset, moves knob (which is mapped to something else)
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		// User switches knobset back -> stop tracking
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.75);
+		CHECK(p.catchup.is_tracking() == false);
 
-		//// User switches knobset back -> stop tracking
-		//active_knobset = 0;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//CHECK(modules[0]->get_param(param_id) == 0.79999f);
-		//CHECK(p.catchup.is_tracking() == false);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(p.catchup.is_tracking() == false);
 
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-		//CHECK(p.catchup.is_tracking() == false);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(p.catchup.is_tracking() == false);
 
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-		//CHECK(p.catchup.is_tracking() == false);
-
-		//// Move knob close to module value -> start tracking again
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(modules[0]->get_param(param_id) == 0.80001f);
-		//CHECK(p.catchup.is_tracking() == true);
+		// Move knob close to module value -> start tracking again
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.75001f);
+		CHECK(modules[0]->get_param(param_id) == 0.75f);
+		CHECK(p.catchup.is_tracking() == true);
 
 		//// User switches knobset and then back again, without moving knob -> still tracking
-		//active_knobset = 1;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//active_knobset = 0;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(p.catchup.is_tracking() == true);
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.75001f);
+		CHECK(p.catchup.is_tracking() == true);
 
 		//// Module changes own value (so that tracking mode stops)
-		//modules[0]->set_param(param_id, 0.1f);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(modules[0]->get_param(param_id) == 0.1f);
-		//CHECK(p.catchup.is_tracking() == false);
+		modules[0]->set_param(param_id, 0.25f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.75001f);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
+		CHECK(p.catchup.is_tracking() == false);
 
-		//// User switches knobset and then back again, without moving knob -> still not tracking
-		//active_knobset = 1;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//active_knobset = 0;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(p.catchup.is_tracking() == false);
-		//CHECK(modules[0]->get_param(param_id) == 0.1f);
+		// User switches knobset and then back again, without moving knob -> still not tracking
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.75001f);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.75001f);
+		CHECK(p.catchup.is_tracking() == false);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
 	}
-
-	//SUBCASE("Inverted partial range mapping. Test for pickup on equal, module changing value, switching knobsets") {
-	//	p.map.min = 0.9f; // knob at 0 => module set to 0.9
-	//	p.map.max = 0.4f; // knob at 1 => module set to 0.4
-
-	//	// Starting (default) value
-	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	// Moving knob has no effect
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	// Even moving to min or max (1.0) has no effect, because module value is out of range
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.0f);
-	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
-	//	CHECK(p.catchup.is_tracking() == false);
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.0f);
-	//	CHECK(modules[0]->get_param(param_id) == 0.0f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	// Now let's have the module set its value to be in our range (0.4 is knob at 1)
-	//	// It will now track
-	//	modules[0]->set_param(param_id, 0.5f);
-	//	CHECK(p.catchup.is_tracking() == false); //Note: is_tracking() does not update until set_panel_param is called!
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.8f);
-	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.5f));
-	//	CHECK(p.catchup.is_tracking() == true);
-
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.7f)); //knob 0.4 maps to module 0.7
-	//	CHECK(p.catchup.is_tracking() == true);
-
-	//	// Module changes own value -> stop tracking until knob value matches
-	//	modules[0]->set_param(param_id, 0.8f);
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
-	//	CHECK(modules[0]->get_param(param_id) == 0.8f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-	//	CHECK(modules[0]->get_param(param_id) == 0.8f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	//.79995 vs 0.8 (which is what 0.2001 maps to) is within tolerance -> start tracking
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2001f);
-	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79995));
-	//	CHECK(p.catchup.is_tracking() == true);
-
-	//	//User switches knobset, moves knob (which is mapped to something else)
-	//	active_knobset = 1;
-	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-
-	//	// User switches knobset back -> stop tracking
-	//	active_knobset = 0;
-	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
-	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79995f));
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	// Move knob close to module value -> start tracking again
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
-	//	CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.800005f));
-	//	CHECK(p.catchup.is_tracking() == true);
-
-	//	// User switches knobset and then back again, without moving knob -> still tracking
-	//	active_knobset = 1;
-	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
-	//	active_knobset = 0;
-	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
-	//	CHECK(p.catchup.is_tracking() == true);
-
-	//	// Module changes own value (so that tracking mode stops)
-	//	modules[0]->set_param(param_id, 0.1f);
-	//	// Note: is_tracking() does not update until set_panel_param is called
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
-	//	CHECK(modules[0]->get_param(param_id) == 0.1f);
-	//	CHECK(p.catchup.is_tracking() == false);
-
-	//	// User switches knobset and then back again, without moving knob -> still not tracking
-	//	active_knobset = 1;
-	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
-	//	active_knobset = 0;
-	//	catchup_manager.reset(modules, knob_maps[active_knobset]);
-	//	catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
-	//	CHECK(p.catchup.is_tracking() == false);
-	//	CHECK(modules[0]->get_param(param_id) == 0.1f);
-	//}
 }
 
-//TEST_CASE("Basic usage of ResumeOnMotion") {
-//	using namespace MetaModule;
+TEST_CASE("Basic usage of ResumeOnMotion") {
+	using namespace MetaModule;
 
-//	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
-//	modules[0] = std::make_unique<SnapModule>();
+	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+	modules[0] = std::make_unique<SnapModule>();
 
-//	CatchupManager catchup_manager;
-//	std::array<ParamSet, MaxKnobSets> knob_maps;
+	CatchupManager catchup_manager;
+	std::array<ParamSet, MaxKnobSets> knob_maps;
 
-//	// Knob 1: set to .3
-//	unsigned active_knobset = 0;
-//	unsigned panel_knob = 1;
-//	unsigned param_id = 2;
+	// Knob 1: set to .3
+	unsigned active_knobset = 0;
+	unsigned panel_knob = 1;
+	unsigned param_id = 2;
 
-//	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
-//	p.map.panel_knob_id = panel_knob;
-//	p.map.module_id = 0;
-//	p.map.param_id = param_id;
-//	p.catchup.set_mode(CatchupParam::Mode::ResumeOnMotion);
+	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+	p.map.panel_knob_id = panel_knob;
+	p.map.module_id = 0;
+	p.map.param_id = param_id;
+	p.catchup.set_mode(CatchupParam::Mode::ResumeOnMotion);
 
-//	SUBCASE("Normal mapping (0-1 => 0-1). Test for pickup, module changing value, switching knobsets") {
-//		p.map.min = 0;
-//		p.map.max = 1;
+	SUBCASE("Normal mapping (0-1 => 0-1). Test for pickup, module changing value, switching knobsets") {
+		p.map.min = 0;
+		p.map.max = 1;
 
-//		// Starting (default) value
-//		CHECK(modules[0]->get_param(param_id) == 0.0f);
-//		CHECK(p.catchup.is_tracking() == false);
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
 
-//		// Moving knob has immediate effect
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		CHECK(modules[0]->get_param(param_id) == 0.2f);
-//		CHECK(p.catchup.is_tracking() == true);
+		// Moving knob has immediate effect
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
+		CHECK(p.catchup.is_tracking() == true);
 
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == 0.4f);
-//		CHECK(p.catchup.is_tracking() == true);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == 0.5f);
+		CHECK(p.catchup.is_tracking() == true);
 
-//		// Module changes own value -> immediately tracks knob
-//		// technically, this is not "resume on motion" since the knob did not move
-//		// but the engine only calls set_panel_param() if the knob changed values, so
-//		// effecively it works as "resume on motion"
-//		modules[0]->set_param(param_id, 0.8f);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == 0.4f);
-//		CHECK(p.catchup.is_tracking() == true);
+		// Module changes own value -> immediately tracks knob
+		// technically, this is not "resume on motion" since the knob did not move
+		// but the engine only calls set_panel_param() if the knob changed values, so
+		// effecively it works as "resume on motion"
+		modules[0]->set_param(param_id, 0.75f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == 0.5f);
+		CHECK(p.catchup.is_tracking() == true);
 
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-//		CHECK(modules[0]->get_param(param_id) == 0.7f);
-//		CHECK(p.catchup.is_tracking() == true);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == 0.75f);
+		CHECK(p.catchup.is_tracking() == true);
 
-//		//User switches knobset, moves knob (which is mapped to something else)
-//		active_knobset = 1;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		// User switches knobset back -> stop tracking
-//		active_knobset = 0;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		CHECK(modules[0]->get_param(param_id) == 0.7f);
-//		CHECK(p.catchup.is_tracking() == false);
+		//User switches knobset, moves knob (which is mapped to something else)
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		// User switches knobset back -> stop tracking
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.75f);
+		CHECK(p.catchup.is_tracking() == false);
 
-//		// Starts tracking when knob moved
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-//		CHECK(modules[0]->get_param(param_id) == 0.3f);
-//		CHECK(p.catchup.is_tracking() == true);
-//	}
+		// Starts tracking when knob moved
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
+		CHECK(p.catchup.is_tracking() == true);
+	}
+}
 
-//	SUBCASE("Inverted partial mapping. Test for pickup, module changing value, switching knobsets") {
-//		//0 to 1 => .9 to .4
-//		p.map.min = 0.9f;
-//		p.map.max = 0.4f;
-//		auto map = [&](float knob) {
-//			return 0.9f - knob / 2.f;
-//		};
+TEST_CASE("Basic usage of LinearFade") {
+	using namespace MetaModule;
 
-//		// Starting (default) value
-//		CHECK(modules[0]->get_param(param_id) == 0.0f);
-//		CHECK(p.catchup.is_tracking() == false);
+	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+	modules[0] = std::make_unique<SnapModule>();
 
-//		// Moving knob has immediate effect
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		CHECK(modules[0]->get_param(param_id) == map(0.2f));
-//		CHECK(p.catchup.is_tracking() == true);
+	CatchupManager catchup_manager;
+	std::array<ParamSet, MaxKnobSets> knob_maps;
 
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == map(0.4f));
-//		CHECK(p.catchup.is_tracking() == true);
+	// Knob 1: set to .3
+	unsigned active_knobset = 0;
+	unsigned panel_knob = 1;
+	unsigned param_id = 2;
 
-//		// Module changes own value -> immediately tracks knob
-//		// technically, this is not "resume on motion" since the knob did not move
-//		// but the engine only calls set_panel_param() if the knob changed values, so
-//		// effecively it works as "resume on motion"
-//		modules[0]->set_param(param_id, 0.8f);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.4f)));
-//		CHECK(p.catchup.is_tracking() == true);
+	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+	p.map.panel_knob_id = panel_knob;
+	p.map.module_id = 0;
+	p.map.param_id = param_id;
+	p.catchup.set_mode(CatchupParam::Mode::LinearFade);
 
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.7f)));
-//		CHECK(p.catchup.is_tracking() == true);
+	SUBCASE("Normal mapping (0-1 => 0-1). Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
+			"value recalcs segments, switching knobsets") {
+		p.map.min = 0;
+		p.map.max = 1;
 
-//		//User switches knobset, moves knob (which is mapped to something else)
-//		active_knobset = 1;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		// User switches knobset back -> stop tracking
-//		active_knobset = 0;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.7f)));
-//		CHECK(p.catchup.is_tracking() == false);
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
 
-//		// Starts tracking when knob moved
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.3f)));
-//		CHECK(p.catchup.is_tracking() == true);
-//	}
-//}
+		// Starts in tracking mode by default
+		CHECK(p.catchup.is_tracking() == true);
 
-//TEST_CASE("Basic usage of LinearFade") {
-//	using namespace MetaModule;
+		// Moving knob tracks 1:1
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
+		CHECK(p.catchup.is_tracking() == true);
 
-//	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
-//	modules[0] = std::make_unique<SnapModule>();
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+		CHECK(modules[0]->get_param(param_id) == 0.5f);
+		CHECK(p.catchup.is_tracking() == true);
 
-//	CatchupManager catchup_manager;
-//	std::array<ParamSet, MaxKnobSets> knob_maps;
+		// Switching knob sets, moving the module or phys knob, then switching back
+		// will enter catchup mode
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.5f);
+		CHECK(p.catchup.is_tracking() == false);
 
-//	// Knob 1: set to .3
-//	unsigned active_knobset = 0;
-//	unsigned panel_knob = 1;
-//	unsigned param_id = 2;
+		// Tracks with 2 segment function:
+		// knob 0-0.2 => module 0-0.5
+		// knob 0.2-1 => module 0.5-1
 
-//	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
-//	p.map.panel_knob_id = panel_knob;
-//	p.map.module_id = 0;
-//	p.map.param_id = param_id;
-//	p.catchup.set_mode(CatchupParam::Mode::LinearFade);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.1f);
+		CHECK(modules[0]->get_param(param_id) == 0.25f);
+		CHECK(p.catchup.is_tracking() == false);
 
-//	SUBCASE("Normal mapping (0-1 => 0-1). Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
-//			"value recalcs segments, switching knobsets") {
-//		p.map.min = 0;
-//		p.map.max = 1;
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.5f);
+		CHECK(p.catchup.is_tracking() == false);
 
-//		// Starting (default) value
-//		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == 0.5); //would be 0.5625, snaps to 0.5
+		CHECK(p.catchup.is_tracking() == false);
 
-//		// Starts in tracking mode by default
-//		CHECK(p.catchup.is_tracking() == true);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.45f);
+		CHECK(modules[0]->get_param(param_id) == 0.75); //would be 0.65625, snaps to 0.75
+		CHECK(p.catchup.is_tracking() == false);
 
-//		// Moving knob tracks 1:1
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		CHECK(modules[0]->get_param(param_id) == 0.2f);
-//		CHECK(p.catchup.is_tracking() == true);
+		SUBCASE("Moving to 1 will end tracking") {
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.f);
+			CHECK(modules[0]->get_param(param_id) == 1.f);
+			CHECK(p.catchup.is_tracking() == true);
+		}
 
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
-//		CHECK(modules[0]->get_param(param_id) == 0.6f);
-//		CHECK(p.catchup.is_tracking() == true);
+		SUBCASE("Moving to 0 will end tracking") {
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.f);
+			CHECK(modules[0]->get_param(param_id) == 0.f);
+			CHECK(p.catchup.is_tracking() == true);
+		}
 
-//		// Switching knob sets, moving the module or phys knob, then switching back
-//		// will enter catchup mode
-//		active_knobset = 1;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		active_knobset = 0;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		CHECK(modules[0]->get_param(param_id) == 0.6f);
-//		CHECK(p.catchup.is_tracking() == false);
+		SUBCASE("Module moves its own knob => linear fade is re-calculated") {
+			CHECK(p.catchup.is_tracking() == false);
+			modules[0]->set_param(param_id, 0.25f);
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+			// inflection point is now at: knob 0.4, module 0.25
+			CHECK(modules[0]->get_param(param_id) == 0.25f);
+			CHECK(p.catchup.is_tracking() == false);
 
-//		// Tracks with 2 segment function:
-//		// knob 0-0.2 => module 0-0.6
-//		// knob 0.2-1 => module 0.6-1
+			// Switching knobsets, moving knob to the module's snapped value,
+			// then switching knobsets back, it goes into 1:1 tracking mode
+			active_knobset = 1;
+			catchup_manager.reset(modules, knob_maps[active_knobset]);
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.25f);
+			active_knobset = 0;
+			catchup_manager.reset(modules, knob_maps[active_knobset]);
+			CHECK(modules[0]->get_param(param_id) == 0.25f);
+			CHECK(p.catchup.is_tracking() == true);
 
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.1f);
-//		CHECK(modules[0]->get_param(param_id) == 0.3f);
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		CHECK(modules[0]->get_param(param_id) == 0.6f);
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.65));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.7));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		SUBCASE("Moving to 1 will end tracking") {
-//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.f);
-//			CHECK(modules[0]->get_param(param_id) == 1.f);
-//			CHECK(p.catchup.is_tracking() == true);
-//		}
-
-//		SUBCASE("Moving to 0 will end tracking") {
-//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.f);
-//			CHECK(modules[0]->get_param(param_id) == 0.f);
-//			CHECK(p.catchup.is_tracking() == true);
-//		}
-
-//		SUBCASE("Module moves its own knob => linear fade is re-calculated") {
-//			CHECK(p.catchup.is_tracking() == false);
-//			modules[0]->set_param(param_id, 0.2f);
-//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//			// inflection point is now at: knob 0.4, module 0.2
-//			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
-//			CHECK(p.catchup.is_tracking() == false);
-
-//			// Switching knobsets and then back, with the knob set to the module value
-//			// is in tracking mode
-//			active_knobset = 1;
-//			catchup_manager.reset(modules, knob_maps[active_knobset]);
-//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//			active_knobset = 0;
-//			catchup_manager.reset(modules, knob_maps[active_knobset]);
-//			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
-//			CHECK(p.catchup.is_tracking() == true);
-
-//			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-//			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.3f));
-//		}
-//	}
-
-//	SUBCASE("Inverted mapping. Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
-//			"value recalcs segments, switching knobsets") {
-//		p.map.min = 0.9f;
-//		p.map.max = 0.4f;
-//		auto map = [&](float knob) {
-//			return 0.9f - knob / 2.f;
-//		};
-
-//		// Starting (default) value
-//		CHECK(modules[0]->get_param(param_id) == 0.0f);
-
-//		// Starts in tracking mode by default
-//		CHECK(p.catchup.is_tracking() == true);
-
-//		// Moving knob tracks
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-//		CHECK(modules[0]->get_param(param_id) == map(0.2f));
-//		CHECK(p.catchup.is_tracking() == true);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == map(0.4f));
-//		CHECK(p.catchup.is_tracking() == true);
-
-//		// Switching knob sets, moving the phys knob, then switching back
-//		// will enter catchup mode
-//		active_knobset = 1;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.8f);
-//		active_knobset = 0;
-//		catchup_manager.reset(modules, knob_maps[active_knobset]);
-//		CHECK(modules[0]->get_param(param_id) == 0.7f); //map(0.4) == 0.7
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		// Tracks with 2 segment function:
-//		// inflection point is at knob@0.8 (mapped val = 0.7), module@ 0.7
-
-//		// above 0.8: knob moves +0.05 => module moves -0.035
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.85f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.665f));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.9f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.630f));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.95f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.595f));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		// below 0.8: knob moves -0.05 => module moves +0.030
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.73f));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.76));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		//Module moves its own knob => linear fade is re-calculated
-//		CHECK(p.catchup.is_tracking() == false);
-//		modules[0]->set_param(param_id, 0.2f);
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
-
-//		// inflection point is now at: knob 0.4, module 0.2
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		// knob moves +0.1, module moves -0.015385
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 - 0.015385));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 - 0.015385 - 0.015385));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		// knob moves -0.1, module moves 0.114286
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 + 0.114286));
-//		CHECK(p.catchup.is_tracking() == false);
-
-//		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-//		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 + 0.114286 + 0.114286));
-//		CHECK(p.catchup.is_tracking() == false);
-//	}
-//}
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.55f);
+			CHECK(modules[0]->get_param(param_id) == 0.5f);
+		}
+	}
+}

--- a/firmware/tests/catchup_tests.cc
+++ b/firmware/tests/catchup_tests.cc
@@ -46,12 +46,11 @@ TEST_CASE("Basic usage of ResumeOnEqual") {
 	p.map.panel_knob_id = panel_knob;
 	p.map.module_id = 0;
 	p.map.param_id = param_id;
+	p.catchup.set_mode(CatchupParam::Mode::ResumeOnEqual);
 
-	SUBCASE("ResumeOnEqual: Normal mapping (0-1 => 0-1). Test for pickup on equal, module changing value, switching "
-			"knobsets") {
+	SUBCASE("Normal mapping (0-1 => 0-1). Test for pickup on equal, module changing value, switching knobsets") {
 		p.map.min = 0;
 		p.map.max = 1;
-		p.catchup.set_mode(CatchupParam::Mode::ResumeOnEqual);
 
 		// Starting (default) value
 		CHECK(modules[0]->get_param(param_id) == 0.0f);
@@ -141,11 +140,9 @@ TEST_CASE("Basic usage of ResumeOnEqual") {
 		CHECK(modules[0]->get_param(param_id) == 0.1f);
 	}
 
-	SUBCASE("ResumeOnEqual: Inverted partial range mapping. Test for pickup on equal, module changing value, switching "
-			"knobsets") {
+	SUBCASE("Inverted partial range mapping. Test for pickup on equal, module changing value, switching knobsets") {
 		p.map.min = 0.9f; // knob at 0 => module set to 0.9
 		p.map.max = 0.4f; // knob at 1 => module set to 0.4
-		p.catchup.set_mode(CatchupParam::Mode::ResumeOnEqual);
 
 		// Starting (default) value
 		CHECK(modules[0]->get_param(param_id) == 0.0f);
@@ -258,12 +255,11 @@ TEST_CASE("Basic usage of ResumeOnMotion") {
 	p.map.panel_knob_id = panel_knob;
 	p.map.module_id = 0;
 	p.map.param_id = param_id;
+	p.catchup.set_mode(CatchupParam::Mode::ResumeOnMotion);
 
-	SUBCASE("ResumeOnMotion: Normal mapping (0-1 => 0-1). Test for pickup on equal, module changing value, switching "
-			"knobsets") {
+	SUBCASE("Normal mapping (0-1 => 0-1). Test for pickup, module changing value, switching knobsets") {
 		p.map.min = 0;
 		p.map.max = 1;
-		p.catchup.set_mode(CatchupParam::Mode::ResumeOnMotion);
 
 		// Starting (default) value
 		CHECK(modules[0]->get_param(param_id) == 0.0f);
@@ -274,64 +270,38 @@ TEST_CASE("Basic usage of ResumeOnMotion") {
 		CHECK(modules[0]->get_param(param_id) == 0.2f);
 		CHECK(p.catchup.is_tracking() == true);
 
+		printf("set to 0.4 (1)\n");
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
 		CHECK(modules[0]->get_param(param_id) == 0.4f);
 		CHECK(p.catchup.is_tracking() == true);
 
-		// Module changes own value -> stop tracking until knob moves
+		// Module changes own value -> immediately tracks knob
+		// technically, this is not "resume on motion" since the knob did not move
+		// but the engine only calls set_panel_param() if the knob changed values, so
+		// effecively it works as "resume on motion"
 		modules[0]->set_param(param_id, 0.8f);
+		printf("set to 0.4 (2)\n");
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
-		CHECK(modules[0]->get_param(param_id) == 0.8f);
-		CHECK(p.catchup.is_tracking() == false);
+		CHECK(modules[0]->get_param(param_id) == 0.4f);
+		CHECK(p.catchup.is_tracking() == true);
 
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
 		CHECK(modules[0]->get_param(param_id) == 0.7f);
 		CHECK(p.catchup.is_tracking() == true);
 
-		////User switches knobset, moves knob (which is mapped to something else)
-		//active_knobset = 1;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		//User switches knobset, moves knob (which is mapped to something else)
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		// User switches knobset back -> stop tracking
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.7f);
+		CHECK(p.catchup.is_tracking() == false);
 
-		//// User switches knobset back -> stop tracking
-		//active_knobset = 0;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//CHECK(modules[0]->get_param(param_id) == 0.79999f);
-		//CHECK(p.catchup.is_tracking() == false);
-
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
-		//CHECK(p.catchup.is_tracking() == false);
-
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
-		//CHECK(p.catchup.is_tracking() == false);
-
-		//// Move knob close to module value -> start tracking again
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(modules[0]->get_param(param_id) == 0.80001f);
-		//CHECK(p.catchup.is_tracking() == true);
-
-		//// User switches knobset and then back again, without moving knob -> still tracking
-		//active_knobset = 1;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//active_knobset = 0;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(p.catchup.is_tracking() == true);
-
-		//// Module changes own value (so that tracking mode stops)
-		//modules[0]->set_param(param_id, 0.1f);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(modules[0]->get_param(param_id) == 0.1f);
-		//CHECK(p.catchup.is_tracking() == false);
-
-		//// User switches knobset and then back again, without moving knob -> still not tracking
-		//active_knobset = 1;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//active_knobset = 0;
-		//catchup_manager.reset(modules, knob_maps[active_knobset]);
-		//catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
-		//CHECK(p.catchup.is_tracking() == false);
-		//CHECK(modules[0]->get_param(param_id) == 0.1f);
+		// Starts tracking when knob moved
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == 0.3f);
+		CHECK(p.catchup.is_tracking() == true);
 	}
 }

--- a/firmware/tests/catchup_tests.cc
+++ b/firmware/tests/catchup_tests.cc
@@ -1,0 +1,241 @@
+#include "CoreModules/CoreProcessor.hh"
+#include "doctest.h"
+#include "params/catchup_manager.hh"
+#include "params/catchup_param.hh"
+#include <memory>
+
+struct TestModule : CoreProcessor {
+	std::array<float, 8> params{};
+
+	void set_param(int param_id, float val) override {
+		if (param_id > 0 && param_id < (int)params.size())
+			params[param_id] = val;
+	}
+	float get_param(int param_id) const override {
+		if (param_id > 0 && param_id < (int)params.size())
+			return params[param_id];
+		else
+			return 0;
+	}
+	void update() override {
+	}
+	void set_samplerate(float sr) override {
+	}
+	void set_input(int input_id, float val) override {
+	}
+	float get_output(int output_id) const override {
+		return 0;
+	}
+};
+
+TEST_CASE("Basic usage") {
+	using namespace MetaModule;
+
+	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+	modules[0] = std::make_unique<TestModule>();
+
+	CatchupManager catchup_manager;
+	std::array<ParamSet, MaxKnobSets> knob_maps;
+
+	// Knob 1: set to .3
+	unsigned active_knobset = 0;
+	unsigned panel_knob = 1;
+	unsigned param_id = 2;
+
+	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+	p.map.panel_knob_id = panel_knob;
+	p.map.module_id = 0;
+	p.map.param_id = param_id;
+
+	SUBCASE("ResumeOnEqual: Normal mapping (0-1 => 0-1). Test for pickup on equal, module changing value, switching "
+			"knobsets") {
+		p.map.min = 0;
+		p.map.max = 1;
+		p.catchup.set_mode(CatchupParam::Mode::ResumeOnEqual);
+
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Moving knob has no effect
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Moving knob to 0, then to a new value makes it track
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.0f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == 0.3f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == 0.4f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Module changes own value -> stop tracking until knob value matches
+		modules[0]->set_param(param_id, 0.8f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+		CHECK(modules[0]->get_param(param_id) == 0.8f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == 0.8f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		//.79999 vs 0.8, within tolerance -> start tracking
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.79999f);
+		CHECK(modules[0]->get_param(param_id) == 0.79999f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		//User switches knobset, moves knob (which is mapped to something else)
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+
+		// User switches knobset back -> stop tracking
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.79999f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Move knob close to module value -> start tracking again
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		CHECK(modules[0]->get_param(param_id) == 0.80001f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		// User switches knobset and then back again, without moving knob -> still tracking
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Module changes own value (so that tracking mode stops)
+		modules[0]->set_param(param_id, 0.1f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		CHECK(modules[0]->get_param(param_id) == 0.1f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// User switches knobset and then back again, without moving knob -> still not tracking
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.80001f);
+		CHECK(p.catchup.is_tracking() == false);
+		CHECK(modules[0]->get_param(param_id) == 0.1f);
+	}
+
+	SUBCASE("ResumeOnEqual: Inverted partial range mapping. Test for pickup on equal, module changing value, switching "
+			"knobsets") {
+		p.map.min = 0.9f; // knob at 0 => module set to 0.9
+		p.map.max = 0.4f; // knob at 1 => module set to 0.4
+		p.catchup.set_mode(CatchupParam::Mode::ResumeOnEqual);
+
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Moving knob has no effect
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Even moving to min or max (1.0) has no effect, because module value is out of range
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.0f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.0f);
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Now let's have the module set its value to be in our range (0.4 is knob at 1)
+		// It will now track
+		modules[0]->set_param(param_id, 0.5f);
+		CHECK(p.catchup.is_tracking() == false); //Note: is_tracking() does not update until set_panel_param is called!
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.8f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.5f));
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.7f)); //knob 0.4 maps to module 0.7
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Module changes own value -> stop tracking until knob value matches
+		modules[0]->set_param(param_id, 0.8f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+		CHECK(modules[0]->get_param(param_id) == 0.8f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == 0.8f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		//.79995 vs 0.8 (which is what 0.2001 maps to) is within tolerance -> start tracking
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2001f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79995));
+		CHECK(p.catchup.is_tracking() == true);
+
+		//User switches knobset, moves knob (which is mapped to something else)
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+
+		// User switches knobset back -> stop tracking
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79995f));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Move knob close to module value -> start tracking again
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.800005f));
+		CHECK(p.catchup.is_tracking() == true);
+
+		// User switches knobset and then back again, without moving knob -> still tracking
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Module changes own value (so that tracking mode stops)
+		modules[0]->set_param(param_id, 0.1f);
+		// Note: is_tracking() does not update until set_panel_param is called
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+		CHECK(modules[0]->get_param(param_id) == 0.1f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// User switches knobset and then back again, without moving knob -> still not tracking
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.19999f);
+		CHECK(p.catchup.is_tracking() == false);
+		CHECK(modules[0]->get_param(param_id) == 0.1f);
+	}
+}

--- a/firmware/tests/catchup_tests.cc
+++ b/firmware/tests/catchup_tests.cc
@@ -270,7 +270,6 @@ TEST_CASE("Basic usage of ResumeOnMotion") {
 		CHECK(modules[0]->get_param(param_id) == 0.2f);
 		CHECK(p.catchup.is_tracking() == true);
 
-		printf("set to 0.4 (1)\n");
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
 		CHECK(modules[0]->get_param(param_id) == 0.4f);
 		CHECK(p.catchup.is_tracking() == true);
@@ -280,7 +279,6 @@ TEST_CASE("Basic usage of ResumeOnMotion") {
 		// but the engine only calls set_panel_param() if the knob changed values, so
 		// effecively it works as "resume on motion"
 		modules[0]->set_param(param_id, 0.8f);
-		printf("set to 0.4 (2)\n");
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
 		CHECK(modules[0]->get_param(param_id) == 0.4f);
 		CHECK(p.catchup.is_tracking() == true);
@@ -303,5 +301,251 @@ TEST_CASE("Basic usage of ResumeOnMotion") {
 		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
 		CHECK(modules[0]->get_param(param_id) == 0.3f);
 		CHECK(p.catchup.is_tracking() == true);
+	}
+
+	SUBCASE("Inverted partial mapping. Test for pickup, module changing value, switching knobsets") {
+		//0 to 1 => .9 to .4
+		p.map.min = 0.9f;
+		p.map.max = 0.4f;
+		auto map = [&](float knob) {
+			return 0.9f - knob / 2.f;
+		};
+
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Moving knob has immediate effect
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == map(0.2f));
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == map(0.4f));
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Module changes own value -> immediately tracks knob
+		// technically, this is not "resume on motion" since the knob did not move
+		// but the engine only calls set_panel_param() if the knob changed values, so
+		// effecively it works as "resume on motion"
+		modules[0]->set_param(param_id, 0.8f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.4f)));
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.7f)));
+		CHECK(p.catchup.is_tracking() == true);
+
+		//User switches knobset, moves knob (which is mapped to something else)
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		// User switches knobset back -> stop tracking
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.7f)));
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Starts tracking when knob moved
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(map(0.3f)));
+		CHECK(p.catchup.is_tracking() == true);
+	}
+}
+
+TEST_CASE("Basic usage of LinearFade") {
+	using namespace MetaModule;
+
+	std::array<std::unique_ptr<CoreProcessor>, 1> modules;
+	modules[0] = std::make_unique<TestModule>();
+
+	CatchupManager catchup_manager;
+	std::array<ParamSet, MaxKnobSets> knob_maps;
+
+	// Knob 1: set to .3
+	unsigned active_knobset = 0;
+	unsigned panel_knob = 1;
+	unsigned param_id = 2;
+
+	auto &p = knob_maps[active_knobset][panel_knob].emplace_back();
+	p.map.panel_knob_id = panel_knob;
+	p.map.module_id = 0;
+	p.map.param_id = param_id;
+	p.catchup.set_mode(CatchupParam::Mode::LinearFade);
+
+	SUBCASE("Normal mapping (0-1 => 0-1). Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
+			"value recalcs segments, switching knobsets") {
+		p.map.min = 0;
+		p.map.max = 1;
+
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+
+		// Starts in tracking mode by default
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Moving knob tracks 1:1
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.2f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+		CHECK(modules[0]->get_param(param_id) == 0.6f);
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Switching knob sets, moving the module or phys knob, then switching back
+		// will enter catchup mode
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.6f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Tracks with 2 segment function:
+		// knob 0-0.2 => module 0-0.6
+		// knob 0.2-1 => module 0.6-1
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.1f);
+		CHECK(modules[0]->get_param(param_id) == 0.3f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == 0.6f);
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.65));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.7));
+		CHECK(p.catchup.is_tracking() == false);
+
+		SUBCASE("Moving to 1 will end tracking") {
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 1.f);
+			CHECK(modules[0]->get_param(param_id) == 1.f);
+			CHECK(p.catchup.is_tracking() == true);
+		}
+
+		SUBCASE("Moving to 0 will end tracking") {
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.f);
+			CHECK(modules[0]->get_param(param_id) == 0.f);
+			CHECK(p.catchup.is_tracking() == true);
+		}
+
+		SUBCASE("Module moves its own knob => linear fade is re-calculated") {
+			CHECK(p.catchup.is_tracking() == false);
+			modules[0]->set_param(param_id, 0.2f);
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+			// inflection point is now at: knob 0.4, module 0.2
+			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
+			CHECK(p.catchup.is_tracking() == false);
+
+			// Switching knobsets and then back, with the knob set to the module value
+			// is in tracking mode
+			active_knobset = 1;
+			catchup_manager.reset(modules, knob_maps[active_knobset]);
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+			active_knobset = 0;
+			catchup_manager.reset(modules, knob_maps[active_knobset]);
+			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
+			CHECK(p.catchup.is_tracking() == true);
+
+			catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+			CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.3f));
+		}
+	}
+
+	SUBCASE("Inverted mapping. Test for 2-segment linear fade, tracking if hitting 0 or 1, module changing "
+			"value recalcs segments, switching knobsets") {
+		p.map.min = 0.9f;
+		p.map.max = 0.4f;
+		auto map = [&](float knob) {
+			return 0.9f - knob / 2.f;
+		};
+
+		// Starting (default) value
+		CHECK(modules[0]->get_param(param_id) == 0.0f);
+
+		// Starts in tracking mode by default
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Moving knob tracks
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.2f);
+		CHECK(modules[0]->get_param(param_id) == map(0.2f));
+		CHECK(p.catchup.is_tracking() == true);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == map(0.4f));
+		CHECK(p.catchup.is_tracking() == true);
+
+		// Switching knob sets, moving the phys knob, then switching back
+		// will enter catchup mode
+		active_knobset = 1;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.8f);
+		active_knobset = 0;
+		catchup_manager.reset(modules, knob_maps[active_knobset]);
+		CHECK(modules[0]->get_param(param_id) == 0.7f); //map(0.4) == 0.7
+		CHECK(p.catchup.is_tracking() == false);
+
+		// Tracks with 2 segment function:
+		// inflection point is at knob@0.8 (mapped val = 0.7), module@ 0.7
+
+		// above 0.8: knob moves +0.05 => module moves -0.035
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.85f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.665f));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.9f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.630f));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.95f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.595f));
+		CHECK(p.catchup.is_tracking() == false);
+
+		// below 0.8: knob moves -0.05 => module moves +0.030
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.73f));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.76));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.79));
+		CHECK(p.catchup.is_tracking() == false);
+
+		//Module moves its own knob => linear fade is re-calculated
+		CHECK(p.catchup.is_tracking() == false);
+		modules[0]->set_param(param_id, 0.2f);
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.5f);
+
+		// inflection point is now at: knob 0.4, module 0.2
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2f));
+		CHECK(p.catchup.is_tracking() == false);
+
+		// knob moves +0.1, module moves -0.015385
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.6f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 - 0.015385));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.7f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 - 0.015385 - 0.015385));
+		CHECK(p.catchup.is_tracking() == false);
+
+		// knob moves -0.1, module moves 0.114286
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.4f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 + 0.114286));
+		CHECK(p.catchup.is_tracking() == false);
+
+		catchup_manager.set_panel_param(modules, knob_maps[active_knobset], panel_knob, 0.3f);
+		CHECK(modules[0]->get_param(param_id) == doctest::Approx(0.2 + 0.114286 + 0.114286));
+		CHECK(p.catchup.is_tracking() == false);
 	}
 }

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -51,6 +51,10 @@ TEST_CASE("Parse settings file") {
     index: 3
     knobs_can_wake: 1
 
+  catchup:
+    mode: ResumeOnEqual
+    exclude_buttons: 0
+
 )";
 	// clang format-on
 
@@ -91,6 +95,9 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.screensaver.timeout_ms == 3);
 	CHECK(settings.screensaver.knobs_can_wake == true);
+
+	CHECK(settings.catchup.mode == MetaModule::CatchupParam::Mode::ResumeOnEqual);
+	CHECK(settings.catchup.button_exclude == false);
 }
 
 TEST_CASE("Get default settings if file is missing fields") {
@@ -151,6 +158,18 @@ TEST_CASE("Get default settings if file is missing fields") {
   screensaver:
 )";
 	}
+	SUBCASE("Bad catchup settings:") {
+		yaml = R"(Settings:
+  catchup:
+    mode: INvaliDmodE
+)";
+	}
+	SUBCASE("Bad catchup settings:") {
+		yaml = R"(Settings:
+  catchup:
+    exclude_buttons: 2
+)";
+	}
 
 	MetaModule::UserSettings settings;
 	auto ok = MetaModule::Settings::parse(yaml, &settings);
@@ -190,6 +209,9 @@ TEST_CASE("Get default settings if file is missing fields") {
 
 	CHECK(settings.screensaver.timeout_ms == MetaModule::ScreensaverSettings::defaultTimeout);
 	CHECK(settings.screensaver.knobs_can_wake == true);
+
+	CHECK(settings.catchup.mode == MetaModule::CatchupParam::Mode::ResumeOnMotion);
+	CHECK(settings.catchup.button_exclude == true);
 }
 
 TEST_CASE("Serialize settings") {
@@ -230,6 +252,9 @@ TEST_CASE("Serialize settings") {
 	settings.screensaver.knobs_can_wake = false;
 	settings.screensaver.timeout_ms = 2;
 
+	settings.catchup.mode = MetaModule::CatchupParam::Mode::LinearFade;
+	settings.catchup.button_exclude = false;
+
 	// clang format-off
 	std::string expected = R"(Settings:
   patch_view:
@@ -269,6 +294,9 @@ TEST_CASE("Serialize settings") {
   screensaver:
     index: 2
     knobs_can_wake: 0
+  catchup:
+    mode: LinearFade
+    exclude_buttons: 0
 )";
 	// clang format-on
 

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(
 	stubs/memory/heap.cc
     ${FWDIR}/src/gui/elements/element_name.cc
     ${FWDIR}/src/gui/slsexport/ui_local.cc
+    ${FWDIR}/src/gui/slsexport/prefs_menu.cc
     ${FWDIR}/src/gui/fonts/fonts.cc
     ${FWDIR}/src/fw_update/updater_proxy.cc
     ${FWDIR}/src/patch_play/modules_helpers.cc

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(
     ${FWDIR}/src/patch_play/modules_helpers.cc
     ${FWDIR}/src/midi/midi_router.cc
     ${FWDIR}/src/params/expanders.cc
+    ${FWDIR}/src/patch_play/patch_player_catchup.cc
 
     #Fatfs:
     stubs/fattime.cc

--- a/simulator/lvgl_drv/lv_port_indev.h
+++ b/simulator/lvgl_drv/lv_port_indev.h
@@ -20,6 +20,7 @@ struct RotaryEncoderKeys {
 	SDL_Keycode quit;
 	SDL_Keycode param_inc;
 	SDL_Keycode param_dec;
+	SDL_Keycode param_fine_toggle;
 	SDL_Keycode prev_knobset;
 	SDL_Keycode next_knobset;
 };
@@ -37,6 +38,7 @@ struct LvglEncoderSimulatorDriver {
 
 	bool param_inc();
 	bool param_dec();
+	bool param_fine();
 	int knobset_changed();
 	unsigned selected_param();
 	unsigned selected_outchan();
@@ -59,6 +61,7 @@ private:
 
 	bool param_inc_pressed = false;
 	bool param_dec_pressed = false;
+	bool param_fine_mode = false;
 	int knobset_change = 0;
 	unsigned last_selected_param = 0;
 	unsigned last_selected_outchan = 0;

--- a/simulator/lvgl_drv/lv_port_indev_encoder.cc
+++ b/simulator/lvgl_drv/lv_port_indev_encoder.cc
@@ -98,6 +98,10 @@ void LvglEncoderSimulatorDriver::handle_key_up(SDL_Keycode key, lv_indev_data_t 
 		_instance->param_inc_pressed = true;
 	}
 
+	if (key == keys.param_fine_toggle) {
+		_instance->param_fine_mode = !_instance->param_fine_mode;
+	}
+
 	if (key == keys.param_dec) {
 		_instance->param_dec_pressed = true;
 	}
@@ -183,6 +187,10 @@ bool LvglEncoderSimulatorDriver::param_dec() {
 	bool pressed = param_dec_pressed;
 	param_dec_pressed = false;
 	return pressed;
+}
+
+bool LvglEncoderSimulatorDriver::param_fine() {
+	return param_fine_mode;
 }
 
 int LvglEncoderSimulatorDriver::knobset_changed() {

--- a/simulator/patches/ChaosPlaits.yml
+++ b/simulator/patches/ChaosPlaits.yml
@@ -84,7 +84,7 @@ PatchData:
       value: 0
     - module_id: 2
       param_id: 2
-      value: -1.4843364
+      value: 0
     - module_id: 2
       param_id: 3
       value: 0.40000007
@@ -96,10 +96,10 @@ PatchData:
       value: 0.56746995
     - module_id: 2
       param_id: 6
-      value: -0.016867995
+      value: 0.016867995
     - module_id: 2
       param_id: 7
-      value: -0.04337436
+      value: 0.04337436
     - module_id: 2
       param_id: 8
       value: 0

--- a/simulator/src/audio_stream.hh
+++ b/simulator/src/audio_stream.hh
@@ -37,6 +37,8 @@ public:
 		Expanders::ext_audio_found(true);
 	}
 
+	std::array<float, PanelDef::NumPot> last_knob_val{};
+
 	void process(StreamConfSim::Audio::AudioInBuffer in_buff, StreamConfSim::Audio::AudioOutBuffer out_buff) {
 
 		if (!is_playing_patch()) {
@@ -58,7 +60,10 @@ public:
 			// Knobs
 			for (auto i = 0u; auto &knob : params.knobs) {
 				// if (knob.did_change()) { // Why does the changed flag not sync with the SDL audio callback?
-				player.set_panel_param(i, knob.val);
+				if (last_knob_val[i] != knob.val) {
+					last_knob_val[i] = knob.val;
+					player.set_panel_param(i, knob.val);
+				}
 				// }
 				i++;
 			}

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -144,8 +144,10 @@ void Ui::transfer_aux_button_events() {
 void Ui::transfer_params() {
 	if (unsigned cur_param = input_driver.selected_param(); cur_param < params.knobs.size()) {
 
+		auto delta = input_driver.param_fine() ? 0.001f : 0.05f;
+
 		if (input_driver.param_inc()) {
-			float val = std::clamp(params.knobs[cur_param].val + 0.05f, 0.f, 1.f);
+			float val = std::clamp(params.knobs[cur_param].val + delta, 0.f, 1.f);
 			if (params.knobs[cur_param].store_changed(val))
 				std::cout << "Knob #" << cur_param << " = " << params.knobs[cur_param].val << "\n";
 			else
@@ -153,7 +155,7 @@ void Ui::transfer_params() {
 		}
 
 		if (input_driver.param_dec()) {
-			float val = std::clamp(params.knobs[cur_param].val - 0.05f, 0.f, 1.f);
+			float val = std::clamp(params.knobs[cur_param].val - delta, 0.f, 1.f);
 			if (params.knobs[cur_param].store_changed(val))
 				std::cout << "Knob #" << cur_param << " = " << params.knobs[cur_param].val << "\n";
 			else

--- a/simulator/src/ui.hh
+++ b/simulator/src/ui.hh
@@ -21,6 +21,7 @@ class Ui {
 		.quit = SDLK_ESCAPE,
 		.param_inc = ']',
 		.param_dec = '[',
+		.param_fine_toggle = '\\',
 		.prev_knobset = ',',
 		.next_knobset = '.',
 	};


### PR DESCRIPTION
Aka "Pickup" or "Tracking" modes.

Three modes added which determine what happens when the knob set is changed or a patch is loaded and the physical knobs don't match the virtual knob values:
- ResumeOnMotion: this is the current mode: virtual knobs jump to value when the physical knob is moved
- ResumeOnEqual: virtual knobs are in "catchup" mode (ignoring the physical knobs) until you turn the physical knob to where the virtual knob is set. Then the virtual knobs are in "tracking" mode.
- LinearFade: a two-segment piecewise linear function maps the physical knob to virtual knob values. One segment goes from the current physical and virtual values to 100% for both. The other segment goes from the current values to 0% for both. The knob exits this mode and starts tracking normally if you turn the knob to 0% or 100% (which are the only two points where the normal mapping intersects the two-segment function)

Several variations of solutions to this problem have been tried. This is especially complex of an issue because it must handle the following:
- Modules might change their own knob values at any time (e.g. a "Scale Preset" knob might toggle buttons or set some knobs). Thus tracking/catchup state could change without the user changing knobsets or patches.
- Similarly, multiple knob sets might change the module's knob value.
- A single physical knob might control multiple virtual knobs, each with its own mapping min and max. So within such a multi-map, one mapping might be in tracking mode but another mapping might be in catchup mode.
- Virtual knobs might only snap to certain values, without allowing for continuous values in between. E.g. buttons are 0.0 or 1.0, or some knobs have "snap" enabled and might be 0.0, 0.25, 0.5, 0.75, or 1.0 only. Compare this to the knob value which is essentially continuous.
- Mapping knobs to buttons is common, but things like linear fade mode are not useful for these mappings. Therefore it would be ideal to allow for multiple catchup modes present, even within a single multi-map.

TODO:
X Various edge cases are not working:
  X Linear mode can see NaN sometimes when going to 0 or 1
  X Sometimes the first crossing of values in ResumeOnEqual mode does not enter tracking mode
  X Needs more edge-case testing in all modes
- Add GUI for changing catchup mode
  X Globally (default)
      X On the Prefs page
      - Right-click menu in VCV hub panel
  - Globally by type (button/switch vs. knob)
  - Per mapping:
    - In the EditKnobMapping page
    - In the right-click menu for a hub knob in VCV