### PR TITLE
Various fixes: Pot ranges, midi gate, wifi status display

### DIFF
--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -308,7 +308,7 @@ void AudioStream::handle_midi(bool is_connected, Midi::Event const &event, unsig
 		player.set_midi_note_gate(event.poly_chan, 10.f);
 		player.set_midi_note_velocity(event.poly_chan, event.val);
 		player.set_midi_note_retrig(event.poly_chan, 10.f);
-		player.set_midi_gate(event.note, event.val); //TODO: if not velocity mode, then event.val => 10
+		player.set_midi_gate(event.note, 10.f);
 		sync_params.midi_events.put(event);
 
 	} else if (event.type == Midi::Event::Type::NoteOff) {

--- a/firmware/src/core_m4/controls.hh
+++ b/firmware/src/core_m4/controls.hh
@@ -63,7 +63,7 @@ private:
 	mdrivlib::AdcDmaPeriph<PotAdcConf> pot_adc{pot_vals, PotConfs};
 
 	InterpParamVariable<float> _knobs[PanelDef::NumPot]{};
-	static constexpr uint32_t AdcReadFrequency = 580; //measured
+	static constexpr uint32_t AdcReadFrequency = 580; //571
 	bool _new_adc_data_ready = false;
 
 	SensePinReader sense_pin_reader;

--- a/firmware/src/core_m4/midi_controls.hh
+++ b/firmware/src/core_m4/midi_controls.hh
@@ -26,17 +26,17 @@ struct MessageParser {
 		// Monophonic MIDI CV/Gate
 		if (msg.is_noteoff()) {
 
+			// Find the note in held midi_notes, and get the poly chan if found.
 			for (unsigned i = 0; auto &midi_note : midi_notes) {
 				if (midi_note.note == msg.note() && midi_note.gate) {
 					midi_note.gate = false;
-
-					event.type = Midi::Event::Type::NoteOff;
-					event.note = msg.note();
 					event.poly_chan = i;
 					break;
 				}
 				i++;
 			}
+			event.type = Midi::Event::Type::NoteOff;
+			event.note = msg.note();
 
 		} else if (msg.is_command<MidiCommand::NoteOn>()) {
 

--- a/firmware/src/gui/pages/add_map_popup.hh
+++ b/firmware/src/gui/pages/add_map_popup.hh
@@ -49,9 +49,9 @@ struct AddMapPopUp {
 		visible = true;
 
 		lv_group_activate(popup_group);
-		lv_group_focus_obj(ui_CancelAdd);
+		lv_group_focus_obj(ui_OkAdd);
 		lv_group_set_editing(popup_group, false);
-		lv_group_set_wrap(popup_group, true);
+		lv_group_set_wrap(popup_group, false);
 	}
 
 	void hide() {

--- a/firmware/src/gui/pages/system_info_tab.hh
+++ b/firmware/src/gui/pages/system_info_tab.hh
@@ -68,6 +68,7 @@ struct InfoTab : SystemMenuTab {
 		}
 
 		detect_wifi.start();
+		detect_wifi.new_wifi_status_available(lv_tick_get());
 	}
 
 	void update() override {

--- a/firmware/src/medium/conf/control_conf.hh
+++ b/firmware/src/medium/conf/control_conf.hh
@@ -61,6 +61,7 @@ constexpr auto PotConfs = std::to_array({
 	AdcChannelConf{{GPIO::A, PinNum::_4}, mdrivlib::AdcChanNum::_18, PotZ, AdcSampTime},
 });
 
-constexpr int32_t MinPotValue = 72; // more like 69
+constexpr int32_t MinPotValue = 72; // more like 69, actually 0x3D = 61
+constexpr float MaxPotValue = 4095.f - (float)MinPotValue - 4.f;
 
 } // namespace MetaModule

--- a/firmware/src/wifi/detection.hh
+++ b/firmware/src/wifi/detection.hh
@@ -20,10 +20,10 @@ struct DetectExpander {
 
 			case WifiIPState::Idle: {
 				if (now - last_check_wifi_ip_tm > 1000) { //poll once per second
-					last_check_wifi_ip_tm = now;
 
 					if (storage.request_wifi_ip()) {
 						wifi_ip_state = WifiIPState::Requested;
+						last_check_wifi_ip_tm = now;
 					}
 				}
 			} break;


### PR DESCRIPTION
- Pot ranges are hard-limited to the range 0..1 (previously it was possible to have the interpolator overshoot and get a small negative value).

- WiFi status displays more consistently on the Info settings page

- Add Map pop-up pane defaults the cursor to the "OK" button, and does not wrap.

- Fixed issue with multiple MIDI notes firing causing some gates to be lost