### PR TITLE
Load Presets from subdirs

### DIFF
--- a/firmware/src/fs/asset_drive/untar.cc
+++ b/firmware/src/fs/asset_drive/untar.cc
@@ -63,9 +63,8 @@ Archive::Archive(std::span<const char> filedata)
 
 	bool update = true;
 
-	int count = 0;
 	unsigned offset = 0;
-	for (count = 0;; count++) {
+	while (true) {
 		TarRaw buffer;
 
 		if (update) {


### PR DESCRIPTION
This came up with Venom, where presets are located in `presets/SUBDIR/*.vcvm`. 
Modified the preset loading to search for subdirs and cleaned up a few things.