### PR TITLE
Lists cleanup

### DIFF
--- a/firmware/src/dynload/plugin_file_list.hh
+++ b/firmware/src/dynload/plugin_file_list.hh
@@ -20,7 +20,7 @@ struct PluginFile {
 	unsigned sdk_minor_version = 0;
 };
 
-static constexpr size_t MaxPlugins = 32;
+static constexpr size_t MaxPlugins = 64;
 using PluginFileList = FixedVector<PluginFile, MaxPlugins>;
 
 } // namespace MetaModule

--- a/firmware/src/dynload/plugin_file_scan.hh
+++ b/firmware/src/dynload/plugin_file_scan.hh
@@ -19,8 +19,10 @@ inline bool scan_volume(FileIoC auto &fileio, PluginFileList &plugin_files, std:
 			if (kind == DirEntryKind::File) {
 				if (entryname.ends_with(".mmplugin") && !entryname.starts_with(".")) {
 					entryname.remove_suffix(9);
-					plugin_files.push_back({fileio.vol_id(), full_path.c_str(), entryname, filesize, "", 1, 0});
-					pr_trace("Found plugin file %s\n", full_path.c_str());
+					if (plugin_files.push_back({fileio.vol_id(), full_path.c_str(), entryname, filesize, "", 1, 0}))
+						pr_trace("Found plugin file %s\n", full_path.c_str());
+					else
+						pr_err("More than %zu plugins found\n", plugin_files.max_size());
 				}
 			}
 		});

--- a/firmware/src/dynload/plugin_loader.hh
+++ b/firmware/src/dynload/plugin_loader.hh
@@ -9,7 +9,9 @@
 #include "patch_file/file_storage_proxy.hh"
 #include "plugin/Plugin.hpp"
 #include "util/monotonic_allocator.hh"
+#include "util/string_compare.hh"
 #include "util/version_tools.hh"
+#include <algorithm>
 #include <cstdint>
 #include <deque>
 #include <string>
@@ -95,9 +97,8 @@ public:
 
 				if (message.message_type == IntercoreStorageMessage::PluginFileListOK) {
 					plugin_files = *plugin_file_list; //make local copy
-					std::sort(plugin_files.begin(), plugin_files.end(), [](auto const &a, auto const &b) {
-						return std::string_view{a.plugin_name} < std::string_view{b.plugin_name};
-					});
+
+					std::ranges::sort(plugin_files, less_ci, &PluginFile::plugin_name);
 					pr_trace("Found %d plugins\n", plugin_files.size());
 
 					parse_versions();

--- a/firmware/src/dynload/plugin_loader.hh
+++ b/firmware/src/dynload/plugin_loader.hh
@@ -292,6 +292,8 @@ public:
 
 				auto version = VersionUtil::Version(vers);
 				plugin.version = std::string_view(vers);
+				plugin.sdk_major_version = version.major;
+				plugin.sdk_minor_version = version.minor;
 				pr_trace("Plugin: %s => %s => %u.%u.%u\n",
 						 name.c_str(),
 						 vers.c_str(),

--- a/firmware/src/gui/pages/main_menu.hh
+++ b/firmware/src/gui/pages/main_menu.hh
@@ -14,14 +14,16 @@ struct MainMenuPage : PageBase {
 		: PageBase{info, PageId::MainMenu} {
 		init_bg(ui_MainMenu);
 		lv_group_remove_all_objs(group);
-		lv_group_add_obj(group, ui_MenuPanelPatches);
-		lv_group_add_obj(group, ui_MenuPanelSave); //new patch
-		lv_group_add_obj(group, ui_MenuPanelSettings);
 
 		lv_group_add_obj(group, ui_MainMenuNowPlayingPanel);
 		lv_group_add_obj(group, ui_MainMenuLastViewedPanel);
 
+		lv_group_add_obj(group, ui_MenuPanelPatches);
+		lv_group_add_obj(group, ui_MenuPanelSave); //new patch
+		lv_group_add_obj(group, ui_MenuPanelSettings);
+
 		lv_group_focus_obj(ui_MenuPanelPatches);
+		lv_group_set_wrap(group, false);
 
 		lv_obj_add_event_cb(ui_MenuPanelPatches, patchsel_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_MenuPanelSettings, settings_cb, LV_EVENT_CLICKED, this);

--- a/firmware/src/patch_file/patch_fileio.hh
+++ b/firmware/src/patch_file/patch_fileio.hh
@@ -5,6 +5,7 @@
 #include "patch_file/patch_dir_list.hh"
 #include "patches_default.hh"
 #include "pr_dbg.hh"
+#include "util/string_compare.hh"
 
 namespace MetaModule
 {
@@ -91,10 +92,8 @@ public:
 			}
 		}
 
-		std::sort(patch_dir.files.begin(), patch_dir.files.end(), [](auto a, auto b) {
-			return std::string_view{a.patchname} < std::string_view{b.patchname};
-		});
-		std::sort(patch_dir.dirs.begin(), patch_dir.dirs.end(), [](auto a, auto b) { return a.name < b.name; });
+		std::ranges::sort(patch_dir.files, less_ci, &PatchFile::patchname);
+		std::ranges::sort(patch_dir.dirs, less_ci, &DirTree<PatchFile>::name);
 
 		return ok;
 	}


### PR DESCRIPTION
- Sort plugin names, and patch list alphabetically case-insensitive
- Hide plugins that can't be loaded by the current firmware
- Fix issue with max 32 mmplugin files being scanned
- Remove "wrapping" on main menu group (when the rotary selects the last time, continuing to turn the rotary does not wrap around to the first time anymore)