### PR TITLE
Load balancing of modules and internal cables

### DIFF
--- a/firmware/src/core_a7/aux_core_main.cc
+++ b/firmware/src/core_a7/aux_core_main.cc
@@ -1,17 +1,14 @@
+#include "aux_core_player.hh"
 #include "conf/hsem_conf.hh"
 #include "core_a7/a7_shared_memory.hh"
 #include "core_a7/async_thread_control.hh"
-#include "core_a7/smp_api.hh"
 #include "debug.hh"
 #include "drivers/hsem.hh"
-#include "drivers/smp.hh"
-#include "drivers/timekeeper.hh"
 #include "dynload/plugin_manager.hh"
 #include "fs/filesystem.hh"
 #include "fs/norflash_layout.hh"
 #include "gui/ui.hh"
 #include "internal_plugin_manager.hh"
-#include "patch_play/patch_player.hh"
 
 using FrameBufferT =
 	std::array<lv_color_t, MetaModule::ScreenBufferConf::width * MetaModule::ScreenBufferConf::height / 4>;
@@ -31,29 +28,22 @@ extern "C" void aux_core_main() {
 
 	pr_info("A7 Core 2 starting\n");
 
-	auto patch_player = A7SharedMemoryS::ptrs.patch_player;
-	auto patch_playloader = A7SharedMemoryS::ptrs.patch_playloader;
-	auto file_storage_proxy = A7SharedMemoryS::ptrs.patch_storage;
-	auto open_patch_manager = A7SharedMemoryS::ptrs.open_patch_manager;
-	auto sync_params = A7SharedMemoryS::ptrs.sync_params;
-	auto patch_mod_queue = A7SharedMemoryS::ptrs.patch_mod_queue;
-	auto ramdisk_storage = A7SharedMemoryS::ptrs.ramdrive;
 #ifdef CONSOLE_USE_USB
 	UartLog::use_usb(A7SharedMemoryS::ptrs.console_buffer);
 #endif
 
 	LVGLDriver gui{MMDisplay::flush_to_screen, MMDisplay::read_input, MMDisplay::wait_cb, framebuf1, framebuf2};
 
-	RamDiskOps ramdisk_ops{*ramdisk_storage};
+	RamDiskOps ramdisk_ops{*A7SharedMemoryS::ptrs.ramdrive};
 	FatFileIO ramdisk{&ramdisk_ops, Volume::RamDisk};
 	AssetFS asset_fs{AssetVolFlashOffset};
 	Filesystem::Init(ramdisk);
-	PluginManager plugin_manager{*file_storage_proxy, ramdisk};
-	Ui ui{*patch_playloader,
-		  *file_storage_proxy,
-		  *open_patch_manager,
-		  *sync_params,
-		  *patch_mod_queue,
+	PluginManager plugin_manager{*A7SharedMemoryS::ptrs.patch_storage, ramdisk};
+	Ui ui{*A7SharedMemoryS::ptrs.patch_playloader,
+		  *A7SharedMemoryS::ptrs.patch_storage,
+		  *A7SharedMemoryS::ptrs.open_patch_manager,
+		  *A7SharedMemoryS::ptrs.sync_params,
+		  *A7SharedMemoryS::ptrs.patch_mod_queue,
 		  plugin_manager,
 		  ramdisk};
 	ui.update_screen();
@@ -61,62 +51,7 @@ extern "C" void aux_core_main() {
 
 	InternalPluginManager internal_plugin_manager{ramdisk, asset_fs};
 
-	struct AuxCoreModulesToRun {
-		uint32_t starting_idx = 1;
-		uint32_t num_modules = 0;
-		uint32_t idx_increment = 2;
-	} modules_to_run;
-
-	constexpr auto PlayModuleListIRQn = SMPControl::IRQn(SMPCommand::PlayModuleList);
-	InterruptManager::register_and_start_isr(PlayModuleListIRQn, 1, 0, [&modules_to_run, &patch_player]() {
-		// Debug::Pin1::high();
-		for (unsigned i = modules_to_run.starting_idx; i < modules_to_run.num_modules;
-			 i += modules_to_run.idx_increment)
-		{
-			patch_player->modules[i]->update();
-		}
-		// Debug::Pin1::low();
-		SMPThread::signal_done();
-	});
-
-	constexpr auto NewModuleListIRQn = SMPControl::IRQn(SMPCommand::NewModuleList);
-	InterruptManager::register_and_start_isr(NewModuleListIRQn, 0, 0, [&modules_to_run]() {
-		modules_to_run.starting_idx = SMPControl::read<SMPRegister::ModuleID>();
-		modules_to_run.num_modules = SMPControl::read<SMPRegister::NumModulesInPatch>();
-		modules_to_run.idx_increment = SMPControl::read<SMPRegister::UpdateModuleOffset>();
-		SMPThread::signal_done();
-	});
-
-	constexpr auto ReadPatchLightsIRQn = SMPControl::IRQn(SMPCommand::ReadPatchLights);
-	InterruptManager::register_and_start_isr(ReadPatchLightsIRQn, 2, 0, [patch_player, &ui]() {
-		if (ui.new_patch_data == false) {
-
-			for (auto &w : ui.lights().watch_lights) {
-				if (w.is_active()) {
-					auto val = patch_player->get_module_light(w.module_id, w.light_id);
-					w.value = val;
-				}
-			}
-
-			for (auto &d : ui.displays().watch_displays) {
-				if (d.is_active()) {
-					auto text = std::span<char>(d.text._data, d.text.capacity);
-					auto sz = patch_player->get_display_text(d.module_id, d.light_id, text);
-					d.text._data[sz] = '\0';
-				}
-			}
-
-			for (auto &p : ui.watched_params().active_watched_params()) {
-				if (p.is_active()) {
-					p.value = patch_player->get_param(p.module_id, p.param_id);
-				}
-			}
-
-			ui.new_patch_data = true;
-		}
-
-		SMPThread::signal_done();
-	});
+	AuxPlayer aux_player{*A7SharedMemoryS::ptrs.patch_player, ui};
 
 	// Wait for M4 to be ready (so USB and SD are available)
 	while (mdrivlib::HWSemaphore<M4CoreReady>::is_locked())

--- a/firmware/src/core_a7/aux_core_player.hh
+++ b/firmware/src/core_a7/aux_core_player.hh
@@ -33,6 +33,10 @@ struct AuxPlayer {
 	void play_modules() {
 
 		for (auto module_i : module_ids) {
+			patch_player.process_module_outputs(module_i);
+		}
+
+		for (auto module_i : module_ids) {
 			patch_player.step_module(module_i);
 		}
 
@@ -45,13 +49,11 @@ struct AuxPlayer {
 		module_ids.clear();
 
 		auto num_modules = SMPControl::read<SMPRegister::NumModulesInPatch>();
-		// pr_dbg("Core 2 will play %u modules:\n", num_modules);
 
 		if (num_modules < module_ids.max_size()) {
 			for (auto i = 0u; i < num_modules; i++) {
 				auto id = SMPControl::read(i + 2);
 				module_ids.push_back(id);
-				// pr_dbg("%u\n", id);
 			}
 
 		} else

--- a/firmware/src/core_a7/aux_core_player.hh
+++ b/firmware/src/core_a7/aux_core_player.hh
@@ -1,0 +1,95 @@
+#pragma once
+#include "core_a7/smp_api.hh"
+#include "drivers/interrupt.hh"
+#include "drivers/smp.hh"
+#include "gui/ui.hh"
+#include "patch_play/patch_player.hh"
+#include "util/fixed_vector.hh"
+
+namespace MetaModule
+{
+
+struct AuxPlayer {
+	PatchPlayer &patch_player;
+	Ui &ui;
+
+	FixedVector<unsigned, 64> module_ids;
+
+	AuxPlayer(PatchPlayer &patch_player, Ui &ui)
+		: patch_player{patch_player}
+		, ui{ui} {
+		using namespace mdrivlib;
+
+		constexpr auto NewModuleListIRQn = SMPControl::IRQn(SMPCommand::NewModuleList);
+		InterruptManager::register_and_start_isr(NewModuleListIRQn, 0, 0, [this]() { assign_module_list(); });
+
+		constexpr auto PlayModuleListIRQn = SMPControl::IRQn(SMPCommand::PlayModuleList);
+		InterruptManager::register_and_start_isr(PlayModuleListIRQn, 1, 0, [this]() { play_modules(); });
+
+		constexpr auto ReadPatchLightsIRQn = SMPControl::IRQn(SMPCommand::ReadPatchLights);
+		InterruptManager::register_and_start_isr(ReadPatchLightsIRQn, 2, 0, [this]() { read_patch_gui_elements(); });
+	}
+
+	void play_modules() {
+		for (auto i : module_ids) {
+			// Debug::Pin1::high();
+			patch_player.modules[i]->update();
+			// Debug::Pin1::low();
+		}
+
+		mdrivlib::SMPThread::signal_done();
+	}
+
+	void assign_module_list() {
+		using namespace mdrivlib;
+
+		module_ids.clear();
+
+		auto num_modules = SMPControl::read<SMPRegister::NumModulesInPatch>();
+		// pr_dbg("Core 2 will play %u modules:\n", num_modules);
+
+		if (num_modules < module_ids.max_size()) {
+			for (auto i = 0u; i < num_modules; i++) {
+				auto id = SMPControl::read(i + 2);
+				module_ids.push_back(id);
+				// pr_dbg("%u\n", id);
+			}
+
+		} else
+			pr_err("Error: %u modules requested to run on core 2, max is %z\n", num_modules, module_ids.size());
+
+		SMPThread::signal_done();
+	}
+
+	void read_patch_gui_elements() {
+		if (ui.new_patch_data == false) {
+
+			for (auto &w : ui.lights().watch_lights) {
+				if (w.is_active()) {
+					auto val = patch_player.get_module_light(w.module_id, w.light_id);
+					w.value = val;
+				}
+			}
+
+			for (auto &d : ui.displays().watch_displays) {
+				if (d.is_active()) {
+					auto text = std::span<char>(d.text._data, d.text.capacity);
+					auto sz = patch_player.get_display_text(d.module_id, d.light_id, text);
+					d.text._data[sz] = '\0';
+				}
+			}
+
+			for (auto &p : ui.watched_params().active_watched_params()) {
+				if (p.is_active()) {
+					p.value = patch_player.get_param(p.module_id, p.param_id);
+				}
+			}
+
+			ui.new_patch_data = true;
+		}
+
+		SMPThread::signal_done();
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/core_a7/aux_core_player.hh
+++ b/firmware/src/core_a7/aux_core_player.hh
@@ -31,10 +31,9 @@ struct AuxPlayer {
 	}
 
 	void play_modules() {
-		for (auto i : module_ids) {
-			// Debug::Pin1::high();
-			patch_player.modules[i]->update();
-			// Debug::Pin1::low();
+
+		for (auto module_i : module_ids) {
+			patch_player.step_module(module_i);
 		}
 
 		mdrivlib::SMPThread::signal_done();

--- a/firmware/src/core_a7/smp_api.hh
+++ b/firmware/src/core_a7/smp_api.hh
@@ -13,12 +13,6 @@ namespace SMPRegister
 {
 enum : uint32_t {
 	DoneZero,
-	ModuleID,
-	ParamID,
-	ParamVal,
-	FunctionAddress,
 	NumModulesInPatch,
-	UpdateModuleOffset,
-	Unused,
 };
 } // namespace SMPRegister

--- a/firmware/src/patch_play/balance_modules.hh
+++ b/firmware/src/patch_play/balance_modules.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include "CoreModules/CoreProcessor.hh"
 #include "drivers/cycle_counter.hh"
+#include "patch/module_type_slug.hh"
 #include "util/partition.hh"
 #include <memory>
 #include <vector>
@@ -14,32 +15,36 @@ template<size_t NumCores, size_t MaxModules>
 struct Balancer {
 	Partition<NumCores, MaxModules> cores;
 
-	void split_modules(std::span<std::unique_ptr<CoreProcessor>> modules, unsigned num_modules, auto &&prepare) {
+	std::vector<unsigned>
+	measure_modules(std::span<std::unique_ptr<CoreProcessor>> modules, unsigned num_modules, auto run) {
+
 		mdrivlib::CycleCounter counter;
-		counter.init();
+
+		constexpr size_t NumIterations = 512;
+		constexpr size_t DropFirst = 32;
+
 		std::vector<unsigned> times(num_modules - 1, 0);
 
-		for (auto iter_i = 0; iter_i < 512 + 32; iter_i++) {
+		for (auto iter_i = 0u; iter_i < NumIterations + DropFirst; iter_i++) {
 
 			for (size_t module_i = 1; module_i < num_modules; module_i++) {
 
 				counter.start_measurement();
-				modules[module_i]->update();
+				run(module_i);
 				counter.end_measurement();
 
-				// Discard first 32 runs
-				if (iter_i >= 32)
+				if (iter_i >= DropFirst)
 					times[module_i - 1] += counter.get_last_measurement_raw();
 			}
-
-			prepare();
 		}
 
-		for (size_t module_i = 1; module_i < num_modules; module_i++) {
-			pr_dbg("Module %u: %u\n", module_i, times[module_i - 1]);
-		}
+		return times;
+	}
 
+	void balance_loads(std::span<unsigned> times) {
 		if (NumCores == 2) {
+			// Core 2 needs extra time to respond to its interrupt
+			// units is 1/24MHz
 			auto bias = std::array<unsigned, 2>{0, 1000};
 			cores.calc_partitions(times, bias);
 		} else
@@ -50,12 +55,14 @@ struct Balancer {
 			for (auto &idx : part)
 				idx++;
 		}
+	}
 
+	void print_times(std::span<unsigned> times, std::span<BrandModuleSlug> slugs) {
 		// Debug output:
 		for (auto core = 0u; core < NumCores; core++) {
 			unsigned sum = 0;
 			for (auto idx : cores.parts[core]) {
-				pr_dbg("Core %d: Module %u: %u\n", core, idx, times[idx - 1]);
+				pr_dbg("Core %d: Module %u (%s): %u\n", core, idx, slugs[idx].c_str(), times[idx - 1]);
 				sum += times[idx - 1];
 			}
 			pr_dbg("Core %d Total: %u\n", core, sum);

--- a/firmware/src/patch_play/balance_modules.hh
+++ b/firmware/src/patch_play/balance_modules.hh
@@ -1,0 +1,62 @@
+#pragma once
+#include "CoreModules/CoreProcessor.hh"
+#include "drivers/cycle_counter.hh"
+#include "util/partition.hh"
+#include <memory>
+#include <vector>
+
+#include "console/pr_dbg.hh"
+
+namespace MetaModule
+{
+
+template<size_t NumCores, size_t MaxModules>
+struct Balancer {
+	Partition<NumCores, MaxModules> cores;
+
+	void split_modules(std::span<std::unique_ptr<CoreProcessor>> modules, unsigned num_modules, auto &&prepare) {
+		mdrivlib::CycleCounter counter;
+		counter.init();
+		std::vector<unsigned> times(num_modules - 1);
+
+		for (size_t i = 1; i < num_modules; i++) {
+			// Run 512 samples, and discard
+			for (auto j = 0; j < 512; j++) {
+				modules[i]->update();
+			}
+
+			// Run another 512 samples and measure
+			times[i - 1] = 0;
+			for (auto j = 0; j < 512; j++) {
+				counter.start_measurement();
+				modules[i]->update();
+				counter.end_measurement();
+				times[i - 1] += counter.get_last_measurement_raw();
+				prepare();
+			}
+
+			// times[i - 1] = counter.get_last_measurement_raw();
+			pr_dbg("Module %u: %u\n", i, times[i - 1]);
+		}
+
+		cores.calc_partitions(times);
+
+		// Adjust indices since we skip module 0
+		for (auto &part : cores.parts) {
+			for (auto &idx : part)
+				idx++;
+		}
+
+		// Debug output:
+		for (auto core = 0u; core < NumCores; core++) {
+			unsigned sum = 0;
+			for (auto idx : cores.parts[core]) {
+				pr_dbg("Core %d: Module %u: %u\n", core, idx, times[idx - 1]);
+				sum += times[idx - 1];
+			}
+			pr_dbg("Core %d Total: %u\n", core, sum);
+		}
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/patch_play/cable_cache.hh
+++ b/firmware/src/patch_play/cable_cache.hh
@@ -1,0 +1,64 @@
+#pragma once
+#include "conf/patch_conf.hh"
+#include "patch/patch_data.hh"
+#include <span>
+
+namespace MetaModule
+{
+
+struct CableCache {
+	CableCache() = default;
+
+	struct CableOut {
+		float val;
+		uint16_t jack_id;
+	};
+
+	struct CableIn {
+		uint16_t jack_id;
+		uint16_t out_module_id;
+		uint16_t out_cache_idx;
+		//todo: profile using this instead:
+		// CableOut *out;
+	};
+
+	void clear() {
+		for (auto &out : outs)
+			out.clear();
+		for (auto &in : ins)
+			in.clear();
+	}
+
+	void build(std::span<const InternalCable> cables) {
+		clear();
+
+		for (auto &cable : cables) {
+			if (cable.out.module_id >= outs.size())
+				continue;
+
+			auto &out = outs[cable.out.module_id];
+			auto out_idx = out.size();
+			out.emplace_back(0.f, cable.out.jack_id);
+
+			for (auto &in : cable.ins) {
+				if (in.module_id < ins.size()) {
+					ins[in.module_id].emplace_back(in.jack_id, cable.out.module_id, out_idx);
+				}
+			}
+		}
+	}
+
+	void add(Jack injack, Jack outjack) {
+		if (injack.module_id < ins.size() && outjack.module_id < outs.size()) {
+			auto &out = outs[outjack.module_id];
+			auto out_idx = out.size();
+			out.emplace_back(0.f, outjack.jack_id);
+			ins[injack.module_id].emplace_back(injack.jack_id, outjack.module_id, out_idx);
+		}
+	}
+
+	// outs[N] and ins[N] are the cables connected to module id N
+	std::array<std::vector<CableOut>, MAX_MODULES_IN_PATCH> outs;
+	std::array<std::vector<CableIn>, MAX_MODULES_IN_PATCH> ins;
+};
+} // namespace MetaModule

--- a/firmware/src/patch_play/multicore_play.hh
+++ b/firmware/src/patch_play/multicore_play.hh
@@ -1,52 +1,41 @@
 #pragma once
 #include "core_a7/smp_api.hh"
 #include "drivers/smp.hh"
+#include <span>
 
 namespace MetaModule
 {
 
 class MulticorePlayer {
 public:
-	static constexpr unsigned ModuleStride = mdrivlib::SMPControl::NumCores;
+	static constexpr unsigned NumCores = mdrivlib::SMPControl::NumCores;
 
-	void load_patch(unsigned num_modules) {
-
-		//Module 0 is the hub
-		//Module 1 is processed by first core
-		//Module 2 is processed by second core
-		//Module 3 is processed by first core
-		//Module 4 is processed by second core
-		//... etc
-		if constexpr (mdrivlib::SMPControl::NumCores > 1) {
+	void assign_modules(std::span<unsigned> module_ids) {
+		if constexpr (NumCores > 1) {
 			mdrivlib::SMPThread::init();
+			mdrivlib::SMPControl::write(SMPRegister::NumModulesInPatch, module_ids.size());
 
-			if (num_modules == 0)
-				num_modules = 1;
-
-			mdrivlib::SMPControl::write<SMPRegister::NumModulesInPatch>((num_modules - 1) / 2);
-
-			for (auto i = 2u, module_id = 2u; module_id < num_modules; module_id += 2) {
+			for (auto i = 2u; auto module_id : module_ids) { // regs 2 and up are the module ids
 				mdrivlib::SMPControl::write(i++, module_id);
 			}
-
 			mdrivlib::SMPControl::notify<SMPCommand::NewModuleList>();
 		}
 	}
 
 	void update_modules() {
-		if constexpr (mdrivlib::SMPControl::NumCores > 1) {
+		if constexpr (NumCores > 1) {
 			mdrivlib::SMPThread::split_with_command<SMPCommand::PlayModuleList>();
 		}
 	}
 
 	void read_patch_state() {
-		if constexpr (mdrivlib::SMPControl::NumCores > 1) {
+		if constexpr (NumCores > 1) {
 			mdrivlib::SMPThread::split_with_command<SMPCommand::ReadPatchLights>();
 		}
 	}
 
 	void join() {
-		if constexpr (mdrivlib::SMPControl::NumCores > 1) {
+		if constexpr (NumCores > 1) {
 			mdrivlib::SMPThread::join();
 		}
 	}

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -214,6 +214,9 @@ public:
 		else if (num_modules > 2) {
 			smp.update_modules();
 			for (auto module_i : core_balancer.cores.parts[0]) {
+				process_module_outputs(module_i);
+			}
+			for (auto module_i : core_balancer.cores.parts[0]) {
 				step_module(module_i);
 			}
 			smp.join();
@@ -223,14 +226,16 @@ public:
 		update_midi_pulses();
 	}
 
+	void process_module_outputs(unsigned module_i) {
+		for (auto &out : cables.outs[module_i])
+			out.val = modules[module_i]->get_output(out.jack_id);
+	}
+
 	void step_module(unsigned module_i) {
 		for (auto const &in : cables.ins[module_i])
 			modules[module_i]->set_input(in.jack_id, cables.outs[in.out_module_id][in.out_cache_idx].val);
 
 		modules[module_i]->update();
-
-		for (auto &out : cables.outs[module_i])
-			out.val = modules[module_i]->get_output(out.jack_id);
 	}
 
 	void update_patch_singlecore() {

--- a/simulator/stubs/drivers/cycle_counter.hh
+++ b/simulator/stubs/drivers/cycle_counter.hh
@@ -1,0 +1,57 @@
+#pragma once
+#include <chrono>
+#include <cstdint>
+
+namespace mdrivlib
+{
+class CycleCounter {
+public:
+	CycleCounter() {
+		init();
+	}
+
+	void init() {
+	}
+
+	void start_measurement() {
+		_start_tm = read_cycle_count();
+		_period = _start_tm - _last_start_tm;
+		_last_start_tm = _start_tm;
+	}
+
+	void end_measurement() {
+		_measured_tm = read_cycle_count() - _start_tm;
+	}
+
+	uint32_t get_last_measurement_raw() {
+		return _measured_tm;
+	}
+
+	uint32_t get_last_period_raw() {
+		return _period;
+	}
+
+	float get_last_measurement_load_float() {
+		if (_period == 0)
+			return 0;
+		return (float)_measured_tm / (float)_period;
+	}
+
+	uint32_t get_last_measurement_load_percent() {
+		if (_period == 0)
+			return 0;
+		return (_measured_tm * 100) / _period;
+	}
+
+private:
+	uint32_t _last_start_tm = 0;
+	uint32_t _start_tm = 0;
+	uint32_t _measured_tm = 0;
+	uint32_t _period = 0;
+
+	uint32_t read_cycle_count() {
+		auto now = std::chrono::system_clock::now().time_since_epoch();
+		return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+	}
+};
+} // namespace mdrivlib


### PR DESCRIPTION
This allows the PatchPlayer to balance the cpu load of modules between both cores when playing a patch. It brings down the overall CPU load of large patches.

There are two aspects of it:
- Internal cables are processed by both cores instead of just by one. First, the output jacks of **all** of the core's modules are read and the values are written to a cable cache. Then for each module, the input jacks are populated from this common cache and the module is run. This has two advantages: 1) cable update takes 50% of the time (at best) since both cores operate in parallel, and 2) cable update happens closer to module update and on the same core, so we benefit from more cache hits. Both of these benefits depend on the details of the patch topology, but in practice I measured some substantial gains in a handful of real-world patches due to this change.

- Module load balancing: When a patch is loaded, it's played for 512 samples and the time to update each module and its cables is measured. Then these time values are partitioned into two groups having nearly-equal sums (I used the ordered ["Greedy number" technique](https://en.wikipedia.org/wiki/Partition_problem)). This has no effect on small patches (two or one modules), but the effect can be large on patches that have several cpu-intensive modules and lots of smaller lightweight modules.

Doing both of these things, I measured gains up to 33% on patches from the [Patch Gallery](https://forum.4ms.info/c/patch-gallery/11). The benefit is roughly proportional to the number of modules and number of cables in the patch.
