### PR TITLE
Fix DLD clock issues

### DIFF
--- a/firmware/.clangd
+++ b/firmware/.clangd
@@ -23,8 +23,8 @@ CompileFlags:
         "-DSIMULATOR",
 	]
 	Add: [
-		"--target=arm-none-eabi", 
-        "-std=gnu++2b",
+		# "--target=arm-none-eabi", 
+        "-std=c++20",
         "-I../src/console", #Needed because clangd16 infers compilation of some headers with a file from a different cmake target
         "-I../src/medium",
         "-I../lib/lvgl/lvgl",


### PR DESCRIPTION
DLD would sometimes start up with one channel (usually A) not clocking. This was due to the saved state having a default ping time of 0.

Also fixes an issue with the Ping LED not tracking an external ping very well.