### PR TITLE
Dirent functions: opendir(), closedir(), readdir(), etc.

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -38,11 +38,11 @@ set(SYMBOLS_BINFILE_DIRS
   --objdir ${VcvPluginBinDir} 
   --objdir ${CoreProcPluginBinDir} 
   --objdir ${CMAKE_BINARY_DIR}/mp1corea7/medium/CMakeFiles/main.elf.dir/vcv_hardware/
+  --objdir ${CMAKE_BINARY_DIR}/mp1corea7/medium/CMakeFiles/main.elf.dir/fs/dirent/
 )
 
 add_custom_target(
   new-api-sym-list
-  COMMAND echo "vcv export dir is ${VcvPluginBinDir}"
   COMMAND scripts/dump_syms.py
           ${SYMBOLS_BINFILE_DIRS}
           --text-out ${API_SYMBOL_NAMES_FILE}

--- a/firmware/lib/fatfs/source/ff.h
+++ b/firmware/lib/fatfs/source/ff.h
@@ -225,7 +225,7 @@ typedef struct {
 
 /* Directory object structure (DIR) */
 
-typedef struct {
+typedef struct DIR {
 	FFOBJID	obj;			/* Object identifier */
 	DWORD	dptr;			/* Current read/write offset */
 	DWORD	clust;			/* Current cluster */

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -139,6 +139,7 @@ add_executable(
   ${FWDIR}/src/fs/syscall/fs_syscall_proxy.cc
   ${FWDIR}/src/fs/syscall/filedesc_manager.cc
   ${FWDIR}/src/fs/fatfs/fatfs_adaptor.cc
+  ${FWDIR}/src/fs/dirent/dirent.cc
 
   #
   ${FWDIR}/src/dynload/dynloader.cc

--- a/firmware/src/core_a7/fs_proxy.hh
+++ b/firmware/src/core_a7/fs_proxy.hh
@@ -1,10 +1,7 @@
 #pragma once
 #include "console/pr_dbg.hh"
 #include "core_intercom/intercore_modulefs_message.hh"
-#include "drivers/cache.hh"
 #include "drivers/inter_core_comm.hh"
-#include "util/overloaded.hh"
-#include "util/padded_aligned.hh"
 #include <cstring>
 #include <optional>
 

--- a/firmware/src/fs/dirent/dirent.cc
+++ b/firmware/src/fs/dirent/dirent.cc
@@ -1,0 +1,59 @@
+#include "filesystem/dirent.h"
+#include "ff.h"
+#include "fs/syscall/filesystem.hh"
+
+DIR *opendir(const char *path) {
+	return MetaModule::Filesystem::opendir(path);
+}
+
+int closedir(DIR *dir) {
+	return MetaModule::Filesystem::closedir(dir);
+}
+
+struct dirent *readdir(DIR *dir) {
+	return MetaModule::Filesystem::readdir(dir);
+}
+
+int alphasort(const struct dirent **, const struct dirent **) {
+	// TODO
+	return -1;
+}
+
+int dirfd(DIR *) {
+	// TODO
+	return -1;
+}
+
+DIR *fdopendir(int) {
+	// TODO
+	return nullptr;
+}
+
+int readdir_r(DIR *dir, struct dirent *dirent, struct dirent **) {
+	if (dirent) {
+		// TODO: is this correct?
+		dirent = MetaModule::Filesystem::readdir(dir);
+	}
+	return dirent ? 0 : -1;
+}
+
+void rewinddir(DIR *dir) {
+	MetaModule::Filesystem::rewinddir(dir);
+}
+
+int scandir(const char *,
+			struct dirent ***,
+			int (*)(const struct dirent *),
+			int (*)(const struct dirent **, const struct dirent **)) {
+	// TODO
+	return -1;
+}
+
+void seekdir(DIR *, long) {
+	// TODO
+}
+
+long telldir(DIR *) {
+	// TODO
+	return -1;
+}

--- a/firmware/src/fs/fatfs/fat_file_io.hh
+++ b/firmware/src/fs/fatfs/fat_file_io.hh
@@ -358,6 +358,24 @@ public:
 			   info.second);
 	}
 
+	bool opendir(std::string_view path, DIR *dir) {
+		if (!dir)
+			return false;
+
+		if (f_opendir(dir, _fatvol) != FR_OK) {
+			if (!mount_disk())
+				return false;
+			if (f_opendir(dir, _fatvol) != FR_OK)
+				return false;
+		}
+
+		return true;
+	}
+
+	bool closedir(DIR *dir) {
+		return f_closedir(dir) == FR_OK;
+	}
+
 	// Returns false if dir cannot be opened
 	bool foreach_file_with_ext(const std::string_view extension, auto action) {
 		DIR dj;

--- a/firmware/src/fs/fileio_t.hh
+++ b/firmware/src/fs/fileio_t.hh
@@ -5,6 +5,12 @@
 #include <span>
 #include <string_view>
 
+// TODO:
+// Rename this DiskDevice
+// Add more functions to make it a complete driver (opendir, closedir, readdir)
+// Use more standard names (maybe just use POSIX?): update_or_create_file => write(), etc..
+// Make it a virtual base class
+
 using FileAction = std::function<void(const std::string_view filename, uint32_t timestamp, uint32_t filesize)>;
 
 using DirEntryAction =

--- a/firmware/src/fs/syscall/filedesc_manager.cc
+++ b/firmware/src/fs/syscall/filedesc_manager.cc
@@ -1,13 +1,16 @@
 #include "filedesc_manager.hh"
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <optional>
 #include <unistd.h>
+#include <vector>
 
 namespace MetaModule::FileDescManager
 {
 
 static constexpr auto MaxOpenFiles = 64;
+static constexpr auto MaxOpenDirs = 8;
 
 // Newlib uses particular file descriptors for stdout, stdin, and stderr:
 static constexpr auto FirstFileFD = 3;
@@ -16,6 +19,7 @@ static_assert(FirstFileFD > STDOUT_FILENO);
 static_assert(FirstFileFD > STDERR_FILENO);
 
 static std::array<FileDesc, MaxOpenFiles> descriptors{};
+static std::array<DirDesc, MaxOpenDirs> dir_scriptors{};
 
 static int index(size_t fd) {
 	return fd - FirstFileFD;
@@ -30,14 +34,19 @@ int isatty(int fd) {
 }
 
 void init() {
-	for (auto &d : descriptors) {
-		d.fatfil = nullptr;
-		d.vol = Volume::MaxVolumes;
+	for (auto &f : descriptors) {
+		f.fatfil = nullptr;
+		f.vol = Volume::MaxVolumes;
+	}
+
+	for (auto &d : dir_scriptors) {
+		d.dir = nullptr;
+		d.cur_entry.d_name[0] = '\0';
 	}
 }
 
 std::optional<int> alloc_file() {
-	auto it = std::find_if(descriptors.begin(), descriptors.end(), [](auto &f) { return f.fatfil == nullptr; });
+	auto it = std::ranges::find_if(descriptors, [](auto &f) { return f.fatfil == nullptr; });
 
 	if (it != descriptors.end()) {
 		auto fd_idx = std::distance(descriptors.begin(), it);
@@ -52,6 +61,7 @@ void dealloc_file(size_t fd) {
 	if (fd_is_file(fd)) {
 		delete descriptors[index(fd)].fatfil;
 		descriptors[index(fd)].fatfil = nullptr;
+		descriptors[index(fd)].vol = Volume::MaxVolumes;
 	}
 }
 
@@ -61,6 +71,60 @@ FileDesc *filedesc(size_t fd) {
 	} else {
 		return nullptr;
 	}
+}
+
+DirDesc *alloc_dir() {
+	auto it = std::ranges::find(dir_scriptors, nullptr, &DirDesc::dir);
+
+	if (it != dir_scriptors.end()) {
+		auto d_idx = std::distance(dir_scriptors.begin(), it);
+		dir_scriptors[d_idx].dir = new DIR;
+		return &dir_scriptors[d_idx];
+	} else {
+		return nullptr;
+	}
+}
+
+bool dealloc_dir(DIR *dir) {
+	if (!dir)
+		return false;
+
+	auto it = std::ranges::find(dir_scriptors, dir, &DirDesc::dir);
+
+	if (it != dir_scriptors.end()) {
+		auto d_idx = std::distance(dir_scriptors.begin(), it);
+		if (d_idx >= 0 && d_idx < (int)dir_scriptors.size()) {
+			delete dir_scriptors[d_idx].dir;
+			dir_scriptors[d_idx].dir = nullptr;
+			dir_scriptors[d_idx].vol = Volume::MaxVolumes;
+			dir_scriptors[d_idx].cur_entry.d_name[0] = '\0';
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool dealloc_dir(DirDesc *dirdesc) {
+	if (!dirdesc)
+		return false;
+
+	return dealloc_dir(dirdesc->dir);
+}
+
+DirDesc *dirdesc(DIR *dir) {
+	if (!dir)
+		return nullptr;
+
+	auto it = std::ranges::find(dir_scriptors, dir, &DirDesc::dir);
+
+	if (it != dir_scriptors.end()) {
+		auto d_idx = std::distance(dir_scriptors.begin(), it);
+		if (d_idx >= 0 && d_idx < (int)dir_scriptors.size())
+			return &dir_scriptors[d_idx];
+	}
+
+	return nullptr;
 }
 
 }; // namespace MetaModule::FileDescManager

--- a/firmware/src/fs/syscall/filedesc_manager.hh
+++ b/firmware/src/fs/syscall/filedesc_manager.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "ff.h"
+#include "filesystem/dirent.h"
 #include "volumes.hh"
 #include <optional>
 
@@ -9,6 +10,12 @@ namespace MetaModule
 struct FileDesc {
 	FIL *fatfil = nullptr;
 	Volume vol{Volume::MaxVolumes};
+};
+
+struct DirDesc {
+	DIR *dir = nullptr;
+	Volume vol{Volume::MaxVolumes};
+	struct dirent cur_entry;
 };
 
 namespace FileDescManager
@@ -21,6 +28,12 @@ void dealloc_file(size_t fd);
 
 FileDesc *filedesc(size_t fd);
 int isatty(int fd);
+
+DirDesc *alloc_dir();
+bool dealloc_dir(DIR *dir);
+bool dealloc_dir(DirDesc *dirdesc);
+
+DirDesc *dirdesc(DIR *dir);
 
 } // namespace FileDescManager
 } // namespace MetaModule

--- a/firmware/src/fs/syscall/filesystem.hh
+++ b/firmware/src/fs/syscall/filesystem.hh
@@ -1,8 +1,10 @@
 #pragma once
+#include "dirent.h"
 #include "fat_file_io.hh"
 #include "ff.h"
 #include "filedesc_manager.hh"
 #include "fs_syscall_proxy.hh"
+#include "time_convert.hh"
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -23,6 +25,14 @@
 //           -> FSProxyImpl::
 //           -> Core M4 handler
 
+// TODO: make FsSyscallProxy and FatFileIO derive from DiskDevice (see TODO in fileio_t.hh)
+// then for each function, we can get the device like:
+// static DiskDevice *get_device(Volume volume) {
+// 		if (volume == Volume::RamDisk)
+// 			return mRamdisk;
+// 		else if (volume === Volume::SDCard || volume == USB)
+// 			return &fs_proxy;
+// }
 namespace MetaModule
 {
 
@@ -43,16 +53,15 @@ public:
 
 			auto [path, volume] = split_volume(filename);
 
-			if (volume == Volume::RamDisk) {
-				if (mRamdisk) {
-					if (mRamdisk->open(path, file->fatfil)) {
-						file->vol = volume;
-						return *fd;
-					}
+			if (volume == Volume::RamDisk && mRamdisk) {
+				if (mRamdisk->open(path, file->fatfil)) {
+					file->vol = volume;
+					return *fd;
 				}
 			}
 
-			if (volume == Volume::SDCard || volume == Volume::USB) {
+			else if (volume == Volume::SDCard || volume == Volume::USB)
+			{
 				if (fs_proxy.open(path, file->fatfil, FA_READ)) {
 					file->vol = volume;
 					return *fd;
@@ -72,13 +81,12 @@ public:
 	static int lseek(int fd, int offset, int whence) {
 		if (auto file = FileDescManager::filedesc(fd)) {
 
-			if (file->vol == Volume::RamDisk) {
-				if (mRamdisk) {
-					return mRamdisk->seek(file->fatfil, offset, whence);
-				}
+			if (file->vol == Volume::RamDisk && mRamdisk) {
+				return mRamdisk->seek(file->fatfil, offset, whence);
 			}
 
-			if (file->vol == Volume::SDCard || file->vol == Volume::USB) {
+			else if (file->vol == Volume::SDCard || file->vol == Volume::USB)
+			{
 				return fs_proxy.seek(file->fatfil, offset, whence);
 			}
 		}
@@ -90,14 +98,13 @@ public:
 
 			auto buff = std::span{ptr, (size_t)len};
 
-			if (file->vol == Volume::RamDisk) {
-				if (mRamdisk) {
-					const auto bytes_read = mRamdisk->read(file->fatfil, buff);
-					return bytes_read.value_or(-1);
-				}
+			if (file->vol == Volume::RamDisk && mRamdisk) {
+				const auto bytes_read = mRamdisk->read(file->fatfil, buff);
+				return bytes_read.value_or(-1);
 			}
 
-			if (file->vol == Volume::SDCard || file->vol == Volume::USB) {
+			else if (file->vol == Volume::SDCard || file->vol == Volume::USB)
+			{
 				auto bytes_read = fs_proxy.read(file->fatfil, buff);
 				return bytes_read.value_or(-1);
 			}
@@ -109,13 +116,12 @@ public:
 	static int close(int fd) {
 		if (auto file = FileDescManager::filedesc(fd)) {
 
-			if (file->vol == Volume::RamDisk) {
-				if (mRamdisk) {
-					mRamdisk->close(file->fatfil);
-				}
+			if (file->vol == Volume::RamDisk && mRamdisk) {
+				mRamdisk->close(file->fatfil);
 			}
 
-			if (file->vol == Volume::USB || file->vol == Volume::SDCard) {
+			else if (file->vol == Volume::USB || file->vol == Volume::SDCard)
+			{
 				fs_proxy.close(file->fatfil);
 			}
 
@@ -137,6 +143,8 @@ public:
 
 		} else if (FileDescManager::filedesc(fd)) {
 			st->st_mode = S_IFREG;
+			pr_trace(
+				"Warning: fstat not fully supported: only the return value is valid, and st_mode field is valid\n");
 			return 0;
 
 		} else {
@@ -144,24 +152,143 @@ public:
 		}
 	}
 
+	static int stat(const char *filename, struct stat *st) {
+		auto [path, volume] = split_volume(filename);
+
+		if (volume == Volume::RamDisk || volume == Volume::SDCard || volume == Volume::USB) {
+			FILINFO filinfo;
+
+			bool ok = false;
+			if (volume == Volume::RamDisk && mRamdisk)
+				ok = mRamdisk->get_fat_filinfo(path, filinfo);
+			else
+				ok = fs_proxy.stat(path, &filinfo);
+
+			if (ok) {
+				FatTime fattime{.date = filinfo.fdate, .time = filinfo.ftime};
+				auto tm = fattime_to_tm(fattime);
+				time_t secs = mktime(&tm);
+				st->st_mtim.tv_sec = secs; //since poweron
+				st->st_mtim.tv_nsec = secs * 1000;
+
+				/// we don't know created time, use last modification
+				st->st_ctim.tv_sec = secs;
+				st->st_ctim.tv_nsec = secs * 1000;
+
+				/// we don't know accessed time, use last modification
+				st->st_atim.tv_sec = secs;
+				st->st_atim.tv_nsec = secs * 1000;
+
+				st->st_size = filinfo.fsize;
+
+				st->st_mode = S_IFREG;
+				return 0;
+			}
+		}
+
+		pr_err("stat() on file %s on vol %d failed\n", filename, (int)volume);
+		return -1;
+	}
+
+	static DIR *opendir(std::string_view fullpath) {
+		if (auto dirdesc = FileDescManager::alloc_dir()) {
+
+			auto [path, volume] = split_volume(fullpath);
+
+			if (volume == Volume::RamDisk && mRamdisk) {
+				if (mRamdisk->opendir(path, dirdesc->dir)) {
+					dirdesc->vol = volume;
+					return dirdesc->dir;
+				}
+			}
+
+			if (volume == Volume::SDCard || volume == Volume::USB) {
+				if (fs_proxy.opendir(path, dirdesc->dir)) {
+					dirdesc->vol = volume;
+					return dirdesc->dir;
+				}
+			}
+
+			pr_err("Opening dir %s on vol %d failed\n", fullpath.data(), (int)volume);
+			FileDescManager::dealloc_dir(dirdesc);
+			return nullptr;
+
+		} else {
+			pr_err("Cannot open any more dirs\n");
+			return nullptr;
+		}
+	}
+
+	static dirent *readdir(DIR *dir) {
+		if (!dir)
+			return nullptr;
+
+		auto dirdesc = FileDescManager::dirdesc(dir);
+		if (!dirdesc)
+			return nullptr;
+
+		if (dirdesc->vol == Volume::RamDisk) {
+			//TODO
+		}
+
+		else if (dirdesc->vol == Volume::SDCard || dirdesc->vol == Volume::USB)
+		{
+			FILINFO info;
+			if (fs_proxy.readdir(dirdesc->dir, &info)) {
+				strncpy(dirdesc->cur_entry.d_name, info.fname, 255);
+				return &dirdesc->cur_entry;
+			}
+		}
+
+		return nullptr;
+	}
+
+	static void rewinddir(DIR *dir) {
+		if (!dir)
+			return;
+
+		auto dirdesc = FileDescManager::dirdesc(dir);
+		if (!dirdesc)
+			return;
+
+		if (dirdesc->vol == Volume::RamDisk) {
+			//TODO
+		}
+
+		else if (dirdesc->vol == Volume::SDCard || dirdesc->vol == Volume::USB)
+		{
+			fs_proxy.readdir(dirdesc->dir, nullptr);
+		}
+	}
+
+	static int closedir(DIR *dir) {
+		if (!dir)
+			return -1;
+
+		return FileDescManager::dealloc_dir(dir) ? 0 : -1;
+	}
+
 private:
 	static std::pair<std::string_view, Volume> split_volume(const char *filename) {
 		auto sv = std::string_view{filename};
+		return split_volume(sv);
+	}
 
-		if (sv.starts_with("ram:"))
-			return {sv, Volume::RamDisk};
+	static std::pair<std::string_view, Volume> split_volume(std::string_view filename) {
+		if (filename.starts_with("ram:"))
+			return {filename, Volume::RamDisk};
 
-		if (sv.starts_with("usb:"))
-			return {sv, Volume::USB};
+		if (filename.starts_with("usb:"))
+			return {filename, Volume::USB};
 
-		if (sv.starts_with("sdc:"))
-			return {sv, Volume::SDCard};
+		if (filename.starts_with("sdc:"))
+			return {filename, Volume::SDCard};
 
-		if (sv.starts_with("nor:"))
-			return {sv, Volume::NorFlash};
+		if (filename.starts_with("nor:"))
+			return {filename, Volume::NorFlash};
 
 		// Default (no volume given) is RamDisk
-		return {sv, Volume::RamDisk};
+		return {filename, Volume::RamDisk};
 	}
 };
 } // namespace MetaModule

--- a/firmware/src/fs/syscall/fs_syscall_proxy.cc
+++ b/firmware/src/fs/syscall/fs_syscall_proxy.cc
@@ -97,4 +97,75 @@ int FsSyscallProxy::close(FIL *fil) {
 	return -1;
 }
 
+bool FsSyscallProxy::stat(std::string_view path, FILINFO *info) {
+	auto msg = IntercoreModuleFS::Stat{
+		.path = path,
+		.info = *info, //copy to non-cacheable message
+	};
+
+	pr_trace("A7: stat %s => info %p\n", msg.path.data(), msg.info);
+
+	if (auto response = impl->get_response_or_timeout<IntercoreModuleFS::Stat>(msg, 3000)) {
+		pr_trace("A7: Stat response = %d\n", response->res);
+		*info = response->info; //copy back
+		return response->res == FR_OK;
+	}
+
+	pr_err("Failed to send Stat request\n");
+	return false;
+}
+
+bool FsSyscallProxy::opendir(std::string_view path, DIR *dir) {
+	auto msg = IntercoreModuleFS::OpenDir{
+		.dir = *dir, //copy to non-cacheable Message
+		.path = path,
+	};
+
+	pr_trace("A7: opendir %s => %p\n", msg.path.data(), msg.dir);
+
+	if (auto response = impl->get_response_or_timeout<IntercoreModuleFS::OpenDir>(msg, 3000)) {
+		pr_trace("A7: Opendir response = %d\n", response->res);
+		*dir = response->dir; //copy back
+		return response->res == FR_OK;
+	}
+
+	pr_err("Failed to send Opendir request\n");
+	return false;
+}
+
+bool FsSyscallProxy::closedir(DIR *dir) {
+	auto msg = IntercoreModuleFS::CloseDir{
+		.dir = *dir,
+	};
+
+	pr_trace("A7: closedir %p\n", dir);
+
+	if (auto response = impl->get_response_or_timeout<IntercoreModuleFS::CloseDir>(msg, 3000)) {
+		*dir = response->dir; //copy DIR back
+		return response->res;
+	}
+
+	pr_err("Failed to send closedir request\n");
+	return false;
+}
+
+bool FsSyscallProxy::readdir(DIR *dir, FILINFO *info) {
+	auto msg = IntercoreModuleFS::ReadDir{
+		.dir = *dir,   //copy
+		.info = *info, //copy to non-cacheable message
+	};
+
+	pr_trace("A7: ReadDir dir %p => info %p\n", dir, info);
+
+	if (auto response = impl->get_response_or_timeout<IntercoreModuleFS::ReadDir>(msg, 3000)) {
+		pr_trace("A7: ReadDir response = %d\n", response->res);
+		*dir = response->dir;	//copy back
+		*info = response->info; //copy back
+		return response->res == FR_OK;
+	}
+
+	pr_err("Failed to send ReadDir request\n");
+	return false;
+}
+
 } // namespace MetaModule

--- a/firmware/src/fs/syscall/fs_syscall_proxy.hh
+++ b/firmware/src/fs/syscall/fs_syscall_proxy.hh
@@ -7,6 +7,7 @@ namespace MetaModule
 
 // Goes between fs syscall wrappers and inter-core comunication.
 // For SD and USB, not for RamDisk
+// TODO: make this a DiskDevice* (see TODO in fileio_t.hh)
 class FsSyscallProxy {
 public:
 	FsSyscallProxy();
@@ -16,6 +17,12 @@ public:
 	int close(FIL *fil);
 	uint64_t seek(FIL *fil, int offset, int whence);
 	std::optional<size_t> read(FIL *fil, std::span<char> buffer);
+
+	bool stat(std::string_view path, FILINFO *info);
+
+	bool opendir(std::string_view path, DIR *dir);
+	bool closedir(DIR *dir);
+	bool readdir(DIR *dir, FILINFO *info);
 
 private:
 	std::unique_ptr<FsProxy> impl;

--- a/firmware/src/fs/syscall/syscalls.cc
+++ b/firmware/src/fs/syscall/syscalls.cc
@@ -26,4 +26,8 @@ int _fstat(int fd, struct stat *st) {
 int _isatty(int fd) {
 	return MetaModule::Filesystem::isatty(fd);
 }
+
+int _stat(const char *filename, struct stat *st) {
+	return MetaModule::Filesystem::stat(filename, st);
+}
 }

--- a/firmware/src/patch_file/patch_list_helper.hh
+++ b/firmware/src/patch_file/patch_list_helper.hh
@@ -132,14 +132,14 @@ private:
 		for (auto const &vol : patch_dir_list.vol_root) {
 			pr_dbg("\nVolume: %s:\n", vol.name.c_str());
 
-			for (auto const &f : vol.files) {
+			for ([[maybe_unused]] auto const &f : vol.files) {
 				pr_dbg(" %s\n", f.filename.c_str());
 			}
 
 			for (auto const &d : vol.dirs) {
 				pr_dbg(" %s (dir):\n", d.name.c_str());
 
-				for (auto const &f : d.files) {
+				for ([[maybe_unused]] auto const &f : d.files) {
 					pr_dbg("  %s\n", f.filename.c_str());
 				}
 			}

--- a/firmware/system/time.cc
+++ b/firmware/system/time.cc
@@ -15,3 +15,7 @@ void print_time() {
 			(unsigned long)HAL_GetTick(),
 			secs);
 }
+
+uint32_t get_ticks() {
+	return HAL_GetTick();
+}

--- a/firmware/system/time.hh
+++ b/firmware/system/time.hh
@@ -1,2 +1,5 @@
+#pragma once
+#include <cstdint>
 
 void print_time();
+uint32_t get_ticks();

--- a/firmware/vcv_plugin/export/CMakeLists.txt
+++ b/firmware/vcv_plugin/export/CMakeLists.txt
@@ -92,6 +92,7 @@ target_include_directories( vcv_plugin_export PUBLIC
     ${MM_ROOT}/firmware/src #for svg.cc to access gui/elements/..., and for console/pr_dbg.hh
     ${SHARED}
 	${MM_ROOT}/firmware/lib
+	${MM_ROOT}/firmware #for system/time.hh
 )
 
 target_compile_definitions(vcv_plugin_export PRIVATE METAMODULE)

--- a/firmware/vcv_plugin/export/src/keep-symbols.cc
+++ b/firmware/vcv_plugin/export/src/keep-symbols.cc
@@ -2,6 +2,7 @@
 #include "app/ModuleWidget.hpp"
 #include "app/SvgSlider.hpp"
 #include "app/SvgSwitch.hpp"
+#include "dirent.h"
 #include "random.hpp"
 #include "widget/TransformWidget.hpp"
 
@@ -83,4 +84,18 @@ void __attribute__((optimize("-O0"))) keep_register_module() {
 void __attribute__((optimize("-O0"))) keep_light_widget() {
 	rack::app::LightWidget x;
 	printf("%p\n", &x);
+}
+
+void keep_dirent() {
+	auto d = opendir(".");
+	auto e = readdir(d);
+	closedir(d);
+	alphasort({}, {});
+	[[maybe_unused]] auto x = dirfd({});
+	[[maybe_unused]] auto x2 = fdopendir(0);
+	[[maybe_unused]] auto x3 = readdir_r(d, e, {});
+	rewinddir(d);
+	[[maybe_unused]] auto x4 = scandir({}, {}, {}, {});
+	seekdir(d, 0);
+	telldir(d);
 }

--- a/firmware/vcv_plugin/export/src/system.cc
+++ b/firmware/vcv_plugin/export/src/system.cc
@@ -1,9 +1,153 @@
 #include "console/pr_dbg.hh"
+#include "system/time.hh"
+#include <filesystem>
 #include <system.hpp>
 
 namespace rack::system
 {
 
+namespace fs = std::filesystem;
+
+std::string join(const std::string &path1, const std::string &path2) {
+	return (fs::u8path(path1) / fs::u8path(path2)).string();
+}
+
+static void appendEntries(std::vector<std::string> &entries, const fs::path &dir, int depth) {
+	for (const auto &entry : fs::directory_iterator(dir)) {
+		entries.push_back(entry.path().string());
+		// Recurse if depth > 0 (limited recursion) or depth < 0 (infinite recursion).
+		if (depth != 0) {
+			if (entry.is_directory()) {
+				appendEntries(entries, entry.path(), depth - 1);
+			}
+		}
+	}
+}
+
+std::vector<std::string> getEntries(const std::string &dirPath, int depth) {
+	std::vector<std::string> entries;
+	appendEntries(entries, fs::u8path(dirPath), depth);
+	return entries;
+}
+
+bool exists(const std::string &path) {
+	return fs::exists(fs::u8path(path));
+}
+
+bool isFile(const std::string &path) {
+	return fs::is_regular_file(fs::u8path(path));
+}
+
+bool isDirectory(const std::string &path) {
+	return fs::is_directory(fs::u8path(path));
+}
+
+uint64_t getFileSize(const std::string &path) {
+	return fs::file_size(fs::u8path(path));
+}
+
+bool rename(const std::string &srcPath, const std::string &destPath) {
+	// fs is read-only
+	return false;
+	// fs::rename(fs::u8path(srcPath), fs::u8path(destPath));
+	// return true;
+}
+
+bool copy(const std::string &srcPath, const std::string &destPath) {
+	// fs is read-only
+	return false;
+	// fs::copy(fs::u8path(srcPath), fs::u8path(destPath), fs::copy_options::recursive | fs::copy_options::overwrite_existing);
+	// return true;
+}
+
+bool createDirectory(const std::string &path) {
+	// fs is read-only
+	return false;
+	// return fs::create_directory(fs::u8path(path));
+}
+
+bool createDirectories(const std::string &path) {
+	// fs is read-only
+	return false;
+	// return fs::create_directories(fs::u8path(path));
+}
+
+bool createSymbolicLink(const std::string &target, const std::string &link) {
+	// fs is read-only
+	return false;
+	// fs::create_symlink(fs::u8path(target), fs::u8path(link));
+	// return true;
+}
+
+bool remove(const std::string &path) {
+	// fs is read-only
+	return false;
+	// return fs::remove(fs::u8path(path));
+}
+
+int removeRecursively(const std::string &pathStr) {
+	// fs is read-only
+	return false;
+	// fs::path path = fs::u8path(pathStr);
+	// // Make all entries writable before attempting to remove
+	// for (auto &entry : fs::recursive_directory_iterator(path)) {
+	// 	fs::permissions(entry.path(), fs::perms::owner_write, fs::perm_options::add);
+	// }
+
+	// return fs::remove_all(path);
+}
+
+std::string getWorkingDirectory() {
+	// not supported
+	printf("Warning: rack::system::getWorkingDirectory() not supported\n");
+	return "";
+	// return fs::current_path().string();
+}
+
+void setWorkingDirectory(const std::string &path) {
+	// not supported
+	printf("Warning: rack::system::setWorkingDirectory() not supported\n");
+	// fs::current_path(fs::u8path(path));
+}
+
+std::string getTempDirectory() {
+	// not supported
+	printf("Warning: rack::system::getTempDirectory() not supported\n");
+	return "";
+	// return fs::temp_directory_path().string();
+}
+
+std::string getAbsolute(const std::string &path) {
+	// TODO: use fatfs to resolve path
+	printf("Warning: rack::system::getAbsolute() not supported\n");
+	return path;
+	// return fs::absolute(fs::u8path(path)).string();
+}
+
+std::string getCanonical(const std::string &path) {
+	// TODO: use fatfs to resolve path
+	printf("Warning: rack::system::getCanonical() not supported\n");
+	return path;
+	// return fs::canonical(fs::u8path(path)).string();
+}
+
+std::string getDirectory(const std::string &path) {
+	return fs::u8path(path).parent_path().string();
+}
+
+std::string getFilename(const std::string &path) {
+	return fs::u8path(path).filename().string();
+}
+
+std::string getStem(const std::string &path) {
+	return fs::u8path(path).stem().string();
+}
+
+std::string getExtension(const std::string &path) {
+	return fs::u8path(path).extension().string();
+}
+
+//// MetaModule impl:
 static FILE *openFile(std::string const &path) {
 	FILE *f = std::fopen(path.c_str(), "rb");
 	if (!f) {
@@ -58,6 +202,103 @@ uint8_t *readFile(const std::string &path, size_t *size) {
 		pr_err("rack::readFile(%s, sz) failed to open\n", path.c_str());
 		return nullptr;
 	}
+}
+
+void writeFile(const std::string &path, const std::vector<uint8_t> &data) {
+	// fs is read-only
+	return;
+	// FILE* f = std::fopen(path.c_str(), "wb");
+	// if (!f)
+	// 	return;
+	// DEFER({
+	// 	std::fclose(f);
+	// });
+
+	// std::fwrite(data.data(), 1, data.size(), f);
+}
+
+void archiveDirectory(const std::string &archivePath, const std::string &dirPath, int compressionLevel) {
+	// fs is read-only
+}
+
+std::vector<uint8_t> archiveDirectory(const std::string &dirPath, int compressionLevel) {
+	// not supported
+	return {};
+}
+
+void unarchiveToDirectory(const std::string &archivePath, const std::string &dirPath) {
+	// not supported
+}
+
+void unarchiveToDirectory(const std::vector<uint8_t> &archiveData, const std::string &dirPath) {
+	// not supported
+}
+
+int getLogicalCoreCount() {
+	return 1; // Not supported
+}
+
+void setThreadName(const std::string &name) {
+	//ignored
+}
+
+std::string getStackTrace() {
+	return "Stack trace not supported\n";
+}
+
+double getTime() {
+	auto ticks = get_ticks();
+	return (double)ticks / 1000.0;
+}
+
+double getUnixTime() {
+	auto duration = std::chrono::system_clock::now().time_since_epoch();
+	return std::chrono::duration<double>(duration).count();
+}
+
+void sleep(double time) {
+	//?
+}
+
+std::string getOperatingSystemInfo() {
+	return "MetaModule";
+}
+
+void openBrowser(const std::string &url) {
+	//not supported
+}
+
+void openDirectory(const std::string &path) {
+	//not supported
+}
+
+void runProcessDetached(const std::string &path) {
+	// not supported
+	// TODO: use async_thread
+}
+
+uint32_t getFpuFlags() {
+	//not supported
+	return 0;
+	// uint64_t fpscr;
+	// __asm__ volatile("vmrs %0, fpscr" : "=r"(fpscr));
+	// return fpscr;
+}
+
+void setFpuFlags(uint32_t flags) {
+	// not supported: modules cannot change FPU flags
+	// uint64_t fpscr = flags;
+	// __asm__ volatile("vmsr fpscr, %0" ::"r"(fpscr));
+}
+
+void resetFpuFlags() {
+	uint32_t flags = getFpuFlags();
+	// Set Flush-to-Zero
+	// flags |= 1 << 24;
+	// ARM64 always uses DAZ
+	// Round-to-nearest is default
+	// flags &= ~((1 << 22) | (1 << 23));
+	setFpuFlags(flags);
 }
 
 } // namespace rack::system

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -118,6 +118,8 @@ else()
 		stubs/random.cpp
 		stubs/memory/heap.cc
 		stubs/async_thread.cc
+		stubs/drivers/time.cc
+		stubs/fs/fs_proxy.cc
 
 		${FWDIR}/src/gui/elements/element_name.cc
 		${FWDIR}/src/gui/slsexport/ui_local.cc

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -1,7 +1,7 @@
 #include "ui.hh"
 #include "dynload/autoload_plugins.hh"
-#include "fs_proxy.hh"
 #include "gui/notify/queue.hh"
+#include "stubs/fs/fs_proxy.hh"
 
 namespace MetaModule
 {

--- a/simulator/stubs/drivers/time.cc
+++ b/simulator/stubs/drivers/time.cc
@@ -1,0 +1,8 @@
+#include <cstdint>
+#include <ctime>
+
+uint32_t get_ticks() {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)(ts.tv_nsec / 1000000) + ((uint64_t)ts.tv_sec * 1000ull);
+}

--- a/simulator/stubs/patch_file/file_storage_comm.hh
+++ b/simulator/stubs/patch_file/file_storage_comm.hh
@@ -7,7 +7,7 @@
 #include "host_file_io.hh"
 #include "patch_file/patch_dir_list.hh"
 #include "patch_file/patch_fileio.hh"
-#include "patch_file/patch_list_helper.hh"
+#include "patch_file/patch_list_helpers.hh"
 #include "patch_file/patch_location.hh"
 #include <cstdint>
 #include <string_view>

--- a/simulator/stubs/patch_file/file_storage_comm.hh
+++ b/simulator/stubs/patch_file/file_storage_comm.hh
@@ -1,13 +1,12 @@
 #pragma once
 #include "../src/core_intercom/intercore_message.hh"
 #include "dynload/plugin_file_scan.hh"
-#include "fat_file_io.hh"
+#include "fs/fatfs/fat_file_io.hh"
 #include "fs/volumes.hh"
 #include "fw_update/update_path.hh"
 #include "host_file_io.hh"
 #include "patch_file/patch_dir_list.hh"
 #include "patch_file/patch_fileio.hh"
-#include "patch_file/patch_list_helpers.hh"
 #include "patch_file/patch_location.hh"
 #include <cstdint>
 #include <string_view>


### PR DESCRIPTION
This adds support for the posix dirent.h functions:
opendir()
closedir()
readdir()
rewinddir()

These can be used to access the SD or USB drives.

The prefix `usb:/` designates the USB drive, and the prefix `sdc:/` designates the SD Card. `ram:/` is the Ramdisk, and `nor:/` is the internal NorFlash chip.
Without any prefix, the RAM disk is the default (plugin assets dirs)