### PR TITLE
Fix crash in PatchSelector

### DIFF
--- a/firmware/src/gui/helpers/lv_helpers.hh
+++ b/firmware/src/gui/helpers/lv_helpers.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "lvgl.h"
+#include <functional>
 #include <string>
 
 namespace MetaModule
@@ -43,13 +44,22 @@ inline void lv_disable_all_children(lv_obj_t *obj) {
 		lv_disable(lv_obj_get_child(obj, i));
 }
 
-inline void lv_foreach_child(lv_obj_t *obj, auto action) {
+// "forsome" is like "foreach" but will abort if action() returns false
+inline void lv_forsome_child(lv_obj_t *obj, std::function<bool(lv_obj_t *obj, unsigned i)> action) {
 	auto num_children = lv_obj_get_child_cnt(obj);
 	for (unsigned i = 0; i < num_children; i++) {
 		auto child = lv_obj_get_child(obj, i);
 		bool should_continue = action(child, i);
 		if (!should_continue)
 			break;
+	}
+}
+
+inline void lv_foreach_child(lv_obj_t *obj, std::function<void(lv_obj_t *obj, unsigned i)> action) {
+	auto num_children = lv_obj_get_child_cnt(obj);
+	for (unsigned i = 0; i < num_children; i++) {
+		auto child = lv_obj_get_child(obj, i);
+		action(child, i);
 	}
 }
 

--- a/firmware/src/gui/pages/file_browser/file_save_dialog.hh
+++ b/firmware/src/gui/pages/file_browser/file_save_dialog.hh
@@ -1,7 +1,7 @@
 #pragma once
 #include "fs/helpers.hh"
 #include "gui/helpers/lv_helpers.hh"
-#include "gui/pages/patch_selector_sidebar.hh"
+#include "gui/pages/patch_selector_subdir_panel.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "patch_file/file_storage_proxy.hh"
 
@@ -65,7 +65,10 @@ struct FileSaveDialog {
 				case RefreshState::ReloadingPatchList:
 					subdir_panel.populate(patch_storage.get_patch_list());
 					subdir_panel.hide_recent_files();
-					// hide_spinner();
+
+					EntryInfo selected_patch{.kind = DirEntryKind::Dir, .vol = file_vol, .path = file_path};
+					subdir_panel.refresh_highlighted_item(selected_patch);
+
 					subdir_panel.focus();
 					refresh_state = RefreshState::Idle;
 					break;
@@ -218,7 +221,7 @@ private:
 		};
 
 		EntryInfo selected_patch{.kind = DirEntryKind::Dir, .vol = file_vol, .path = file_path};
-		subdir_panel.refresh(selected_patch);
+		subdir_panel.refresh_highlighted_item(selected_patch);
 		subdir_panel.hide_recent_files();
 	}
 

--- a/firmware/src/gui/pages/knobset_view.hh
+++ b/firmware/src/gui/pages/knobset_view.hh
@@ -139,10 +139,7 @@ struct KnobSetViewPage : PageBase {
 			if (!num_maps[idx])
 				continue;
 
-			lv_foreach_child(pane, [this](lv_obj_t *cont, int idx) {
-				lv_group_add_obj(group, cont);
-				return true;
-			});
+			lv_foreach_child(pane, [this](lv_obj_t *cont, int idx) { lv_group_add_obj(group, cont); });
 		}
 
 		lv_group_focus_obj(focus);

--- a/firmware/src/gui/pages/module_list.hh
+++ b/firmware/src/gui/pages/module_list.hh
@@ -241,10 +241,7 @@ private:
 	}
 
 	void clear_module_canvas() {
-		lv_foreach_child(ui_ModuleListImage, [](auto *obj, int i) {
-			lv_obj_del_async(obj);
-			return true;
-		});
+		lv_foreach_child(ui_ModuleListImage, [](auto *obj, int i) { lv_obj_del_async(obj); });
 	}
 
 	enum class View { BrandRoller, ModuleRoller, ModuleOnly } view{View::BrandRoller};

--- a/firmware/src/gui/pages/module_view_action_menu.hh
+++ b/firmware/src/gui/pages/module_view_action_menu.hh
@@ -4,7 +4,6 @@
 #include "gui/notify/queue.hh"
 #include "gui/pages/module_view_automap.hh"
 #include "gui/pages/page_list.hh"
-#include "gui/pages/patch_selector_sidebar.hh"
 #include "gui/pages/roller_popup.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/slsexport/ui_local.h"

--- a/firmware/src/gui/pages/module_view_automap.hh
+++ b/firmware/src/gui/pages/module_view_automap.hh
@@ -188,13 +188,11 @@ private:
 		lv_foreach_child(ui_AutoMapKnobCont, [](lv_obj_t *obj, unsigned id) {
 			if (id > 0)
 				lv_obj_del_async(obj);
-			return true;
 		});
 
 		lv_foreach_child(ui_AutoMapJackCont, [](lv_obj_t *obj, unsigned id) {
 			if (id > 0)
 				lv_obj_del_async(obj);
-			return true;
 		});
 	}
 

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -7,7 +7,7 @@
 #include "gui/pages/base.hh"
 #include "gui/pages/make_cable.hh"
 #include "gui/pages/page_list.hh"
-#include "gui/pages/patch_selector_sidebar.hh"
+#include "gui/pages/patch_selector_subdir_panel.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/styles.hh"
 #include "patch_file/reload_patch.hh"
@@ -106,7 +106,7 @@ struct PatchSelectorPage : PageBase {
 	void refresh_subdir_panel() {
 		auto idx = lv_roller_get_selected(ui_PatchListRoller);
 		if (idx < roller_item_infos.size()) {
-			subdir_panel.refresh(roller_item_infos[idx]);
+			subdir_panel.refresh_highlighted_item(roller_item_infos[idx]);
 		}
 	}
 

--- a/firmware/src/gui/pages/patch_selector_sidebar.hh
+++ b/firmware/src/gui/pages/patch_selector_sidebar.hh
@@ -15,12 +15,14 @@ namespace MetaModule
 
 struct PatchSelectorSubdirPanel {
 
-	void set_parent(lv_obj_t *parent, unsigned zindex) {
-		lv_obj_set_parent(ui_DrivesPanel, parent);
-		lv_obj_move_to_index(ui_DrivesPanel, zindex);
+	PatchSelectorSubdirPanel() {
+		group = lv_group_create();
 
 		for (auto vol_cont : vol_conts) {
 			auto vol_item = lv_obj_get_child(vol_cont, 0);
+
+			lv_obj_add_style(vol_item, &Gui::subdir_panel_item_sel_blurred_style, LV_STATE_USER_2);
+
 			while (lv_obj_remove_event_cb(vol_item, nullptr)) {
 			}
 			lv_obj_add_event_cb(vol_item, subdir_click_cb, LV_EVENT_CLICKED, this);
@@ -29,30 +31,35 @@ struct PatchSelectorSubdirPanel {
 		}
 	}
 
+	void set_parent(lv_obj_t *parent, unsigned zindex) {
+		lv_obj_set_parent(ui_DrivesPanel, parent);
+		lv_obj_move_to_index(ui_DrivesPanel, zindex);
+	}
+
 	void populate(PatchDirList const &patchfiles) {
-		if (group == nullptr)
-			group = lv_group_create();
+		lv_group_remove_all_objs(group);
 
 		// populate side bar with volumes and dirs
 		for (auto [vol_cont, root] : zip(vol_conts, patchfiles.vol_root)) {
 
 			// Delete existing dir labels (except first one, which is the volume root)
-			if (auto num_children = lv_obj_get_child_cnt(vol_cont); num_children > 1) {
-				for (unsigned i = 1; i < num_children; i++) {
-					auto child = lv_obj_get_child(vol_cont, i);
-					if (child == nullptr)
-						continue;
+			// if (auto num_children = lv_obj_get_child_cnt(vol_cont); num_children > 1) {
+			// 	for (unsigned i = 1; i < num_children; i++) {
+			// 		auto child = lv_obj_get_child(vol_cont, i);
+			// 		if (child == nullptr)
+			// 			continue;
 
-					if (last_subdir_sel == lv_obj_get_child(vol_cont, i)) {
-						last_subdir_sel = nullptr; //prevent dangling pointer
-					}
+			// 		if (last_subdir_sel == lv_obj_get_child(vol_cont, i)) {
+			// 			last_subdir_sel = nullptr; //prevent dangling pointer
+			// 		}
 
-					lv_obj_del(child);
-				}
-			}
+			// 		lv_obj_del(child);
+			// 	}
+			// }
+
+			// lv_obj_refresh_style(vol_cont, LV_PART_MAIN, LV_STYLE_PROP_ANY);
 
 			auto vol_item = lv_obj_get_child(vol_cont, 0);
-			lv_obj_add_style(vol_item, &Gui::subdir_panel_item_sel_blurred_style, LV_STATE_USER_2);
 
 			// No need to scan if no files or dirs: disable it
 			if (root.files.size() == 0 && root.dirs.size() == 0) {
@@ -67,8 +74,8 @@ struct PatchSelectorSubdirPanel {
 			lv_group_add_obj(group, vol_item);
 
 			// Add all dirs on volume
-			for (auto &dir : root.dirs)
-				add_subdir_to_panel(dir, vol_cont);
+			// for (auto &dir : root.dirs)
+			// 	add_subdir_to_panel(dir, vol_cont);
 
 			lv_enable(vol_cont);
 			lv_enable_all_children(vol_cont);

--- a/firmware/src/gui/pages/patch_selector_sidebar.hh
+++ b/firmware/src/gui/pages/patch_selector_sidebar.hh
@@ -39,10 +39,15 @@ struct PatchSelectorSubdirPanel {
 			// Delete existing dir labels (except first one, which is the volume root)
 			if (auto num_children = lv_obj_get_child_cnt(vol_cont); num_children > 1) {
 				for (unsigned i = 1; i < num_children; i++) {
+					auto child = lv_obj_get_child(vol_cont, i);
+					if (child == nullptr)
+						continue;
+
 					if (last_subdir_sel == lv_obj_get_child(vol_cont, i)) {
 						last_subdir_sel = nullptr; //prevent dangling pointer
 					}
-					lv_obj_del_async(lv_obj_get_child(vol_cont, i));
+
+					lv_obj_del(child);
 				}
 			}
 

--- a/firmware/src/gui/pages/patch_selector_subdir_panel.hh
+++ b/firmware/src/gui/pages/patch_selector_subdir_panel.hh
@@ -3,11 +3,9 @@
 #include "gui/helpers/lv_helpers.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/styles.hh"
-#include "lvgl.h"
 #include "patch_file/patch_dir_list.hh"
 #include "pr_dbg.hh"
-#include "util/countzip.hh"
-#include "util/zip.hh"
+#include <cstring>
 #include <functional>
 
 namespace MetaModule
@@ -47,8 +45,10 @@ struct PatchSelectorSubdirPanel {
 			// No need to scan if no files or dirs: disable it
 			if (root.files.size() == 0 && root.dirs.size() == 0) {
 				lv_disable(vol_cont);
-				lv_disable_all_children(vol_cont);
-				lv_obj_clear_state(vol_cont, LV_STATE_FOCUSED);
+				lv_foreach_child(vol_cont, [](lv_obj_t *child, unsigned i) {
+					lv_show(child, i == 0);
+					lv_disable(child);
+				});
 				continue;
 			}
 
@@ -56,9 +56,14 @@ struct PatchSelectorSubdirPanel {
 			lv_obj_set_user_data(vol_item, (void *)&root);
 			lv_group_add_obj(group, vol_item);
 
-			// Add all dirs on volume
+			// Add all dirs with files
 			auto num_existing_subdir_items = lv_obj_get_child_cnt(vol_cont) - 1;
 			for (auto i = 0u; auto &dir : root.dirs) {
+				if (dir.files.size() == 0) {
+					continue;
+				}
+
+				// Use existing lvgl entry object, or add a new one if needed
 				if (i < num_existing_subdir_items) {
 					overwrite_subdir(dir, lv_obj_get_child(vol_cont, i + 1));
 				} else {
@@ -87,40 +92,42 @@ struct PatchSelectorSubdirPanel {
 		lv_show(vol_conts[0]);
 	}
 
-	void refresh(EntryInfo const &selected_patch) {
+	void refresh_highlighted_item(EntryInfo const &selected_patch) {
 		// TODO: check if list was re-populated, or if entry info dir name changed, and only refresh if so
 
 		for (auto [vol, vol_name, vol_cont] : zip(PatchDirList::vols, PatchDirList::vol_name, vol_conts)) {
-			if (vol != selected_patch.vol)
+
+			// Clear highlighting styles on all entries
+			lv_obj_clear_state(vol_cont, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY | LV_STATE_USER_2);
+			lv_foreach_child(vol_cont, [](lv_obj_t *child, unsigned i) {
+				lv_obj_clear_state(child, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY | LV_STATE_USER_2);
+				label_clips(child);
+			});
+
+			if (vol != selected_patch.vol) {
 				continue;
+			}
 
 			lv_obj_t *dir_obj = nullptr;
 
+			// Find the entry that matches the current patch's volume and path
 			lv_foreach_child(vol_cont, [selected_patch, vol_name = vol_name, &dir_obj](lv_obj_t *obj, unsigned i) {
-				auto label_child = (i == 0) ? 1 : 0;
-				const char *txt = lv_label_get_text(lv_obj_get_child(obj, label_child));
+				auto label_child = lv_obj_get_child(obj, (i == 0) ? 1 : 0);
+				const char *txt = lv_label_get_text(label_child);
 				const char *roller_path = (i == 0) ? vol_name : selected_patch.path.c_str();
-				if (txt == nullptr)
-					return true; //continue
-
-				if (strcmp(txt, roller_path) == 0) {
-					dir_obj = obj;
+				if (txt != nullptr) {
+					if (strcmp(txt, roller_path) == 0)
+						dir_obj = obj;
 				}
-				return true;
 			});
 
-			if (dir_obj && last_subdir_sel != dir_obj) {
-				if (last_subdir_sel) {
-					lv_obj_clear_state(last_subdir_sel, LV_STATE_FOCUSED);
-					lv_obj_clear_state(last_subdir_sel, LV_STATE_FOCUS_KEY);
-					lv_obj_clear_state(last_subdir_sel, LV_STATE_USER_2);
-					label_clips(last_subdir_sel);
-				}
-
+			if (dir_obj) {
 				if (lv_obj_has_state(ui_DrivesPanel, LV_STATE_FOCUSED)) {
 					lv_obj_add_state(dir_obj, LV_STATE_FOCUSED);
+					lv_obj_clear_state(dir_obj, LV_STATE_USER_2);
 				} else {
 					lv_obj_add_state(dir_obj, LV_STATE_USER_2);
+					lv_obj_clear_state(dir_obj, LV_STATE_FOCUSED | LV_STATE_FOCUS_KEY);
 				}
 				label_scrolls(dir_obj);
 				lv_obj_scroll_to_view_recursive(dir_obj, LV_ANIM_ON);
@@ -136,8 +143,16 @@ struct PatchSelectorSubdirPanel {
 		lv_group_activate(group);
 
 		if (last_subdir_sel) {
-			lv_obj_clear_state(last_subdir_sel, LV_STATE_USER_2);
-			lv_group_focus_obj(last_subdir_sel);
+			if (lv_obj_has_flag(last_subdir_sel, LV_OBJ_FLAG_HIDDEN)) {
+				if (group) {
+					lv_obj_clear_state(last_subdir_sel, LV_STATE_USER_2);
+					lv_group_focus_next(group);
+					last_subdir_sel = lv_group_get_focused(group);
+				}
+			} else {
+				lv_obj_clear_state(last_subdir_sel, LV_STATE_USER_2);
+				lv_group_focus_obj(last_subdir_sel);
+			}
 		} else {
 			if (group)
 				lv_group_focus_next(group);

--- a/firmware/src/gui/pages/plugin_tab.hh
+++ b/firmware/src/gui/pages/plugin_tab.hh
@@ -141,28 +141,16 @@ private:
 		lv_group_remove_all_objs(group);
 		lv_group_add_obj(group, lv_tabview_get_tab_btns(ui_SystemMenuTabView));
 		lv_group_add_obj(group, ui_PluginScanButton);
-		lv_foreach_child(ui_PluginsFoundCont, [this](auto *obj, unsigned) {
-			lv_group_add_obj(this->group, obj);
-			return true;
-		});
-		lv_foreach_child(ui_PluginsLoadedCont, [this](auto *obj, unsigned) {
-			lv_group_add_obj(this->group, obj);
-			return true;
-		});
+		lv_foreach_child(ui_PluginsFoundCont, [this](auto *obj, unsigned) { lv_group_add_obj(this->group, obj); });
+		lv_foreach_child(ui_PluginsLoadedCont, [this](auto *obj, unsigned) { lv_group_add_obj(this->group, obj); });
 	}
 
 	void clear_loaded_list() {
-		lv_foreach_child(ui_PluginsLoadedCont, [](auto *obj, unsigned) {
-			lv_obj_del_async(obj);
-			return true;
-		});
+		lv_foreach_child(ui_PluginsLoadedCont, [](auto *obj, unsigned) { lv_obj_del_async(obj); });
 	}
 
 	void clear_found_list() {
-		lv_foreach_child(ui_PluginsFoundCont, [](auto *obj, unsigned) {
-			lv_obj_del_async(obj);
-			return true;
-		});
+		lv_foreach_child(ui_PluginsFoundCont, [](auto *obj, unsigned) { lv_obj_del_async(obj); });
 	}
 
 	void populate_loaded_list() {

--- a/firmware/src/gui/styles.hh
+++ b/firmware/src/gui/styles.hh
@@ -5,7 +5,6 @@
 #include "slsexport/meta5/ui.h"
 #include <array>
 #include <charconv>
-#include <span>
 #include <string>
 
 // lvgl has prop1 and has_group fields out of order, thus not C++ friendly

--- a/firmware/src/patch_file/open_patch_manager.hh
+++ b/firmware/src/patch_file/open_patch_manager.hh
@@ -74,7 +74,7 @@ public:
 			if (first == open_patches_.end()) {
 				return false;
 			} else {
-				open_patches_.remove(first);
+				open_patches_.remove(first->loc_hash);
 				num_to_remove--;
 			}
 		}

--- a/firmware/src/patch_file/open_patches.hh
+++ b/firmware/src/patch_file/open_patches.hh
@@ -69,10 +69,6 @@ struct OpenPatchList {
 		// return (std::find(list.begin(), list.end(), patch) != list.end());
 	}
 
-	void remove(std::list<OpenPatch>::iterator item) {
-		list.erase(item);
-	}
-
 	void remove_last() {
 		list.pop_back();
 	}

--- a/firmware/src/patch_file/patch_dir_list.hh
+++ b/firmware/src/patch_file/patch_dir_list.hh
@@ -35,7 +35,7 @@ struct PatchDirList {
 	}
 
 	std::array<PatchDir, 4> vol_root{};
-	static constexpr std::array<const char *, 4> vol_name = {"Open Patches", "USB", "Card", "Internal"};
+	static constexpr std::array<const char *, 4> vol_name = {"Recent", "USB", "Card", "Internal"};
 	static constexpr std::array<Volume, 4> vols{Volume::RamDisk, Volume::USB, Volume::SDCard, Volume::NorFlash};
 	std::array<bool, 4> mounted{};
 

--- a/firmware/src/patch_file/reload_patch.cc
+++ b/firmware/src/patch_file/reload_patch.cc
@@ -7,7 +7,7 @@
 namespace MetaModule
 {
 
-static constexpr unsigned max_open_patches = 20;
+static constexpr unsigned max_open_patches = 5;
 
 ReloadPatch::ReloadPatch(FileStorageProxy &patch_storage, OpenPatchManager &patches)
 	: patch_storage{patch_storage}


### PR DESCRIPTION
Fixes a memory corruption error in the PatchSelector page that can cause a crash when opening lots (> 20) patches. It happens with increased frequency if the patches consume lots of memory (especially the GUI buffers for graphic screens).

The number of Recent patches is now reduced to 5, but in a future PR it'll become a user settings option.

There also is an unrelated crash happening when the PatchSelector page is displayed more than 32 times. It was infrequent but memory pressure increased the chance of it happening.