### PR TITLE
Deinit plugin modules before removing (for Rack plugins, call onRemove)

### DIFF
--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(
   ${FWDIR}/src/gui/slsexport/prefs_pane_fs.cc
   ${FWDIR}/src/gui/fonts/fonts.cc
   ${FWDIR}/src/params/expanders.cc
+  ${FWDIR}/src/patch_play/plugin_module.cc
   #
   ${FWDIR}/src/dynload/dynloader.cc
   ${FWDIR}/metamodule-plugin-sdk/version.cc

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -12,6 +12,7 @@
 #include "patch/patch.hh"
 #include "patch/patch_data.hh"
 #include "patch_play/multicore_play.hh"
+#include "patch_play/plugin_module.hh"
 #include "pr_dbg.hh"
 #include "result_t.hh"
 #include "util/countzip.hh"
@@ -265,6 +266,7 @@ public:
 		smp.join();
 		is_loaded = false;
 		for (size_t i = 0; i < num_modules; i++) {
+			plugin_module_deinit(modules[i]);
 			modules[i].reset(nullptr);
 		}
 		pd.int_cables.clear();
@@ -712,6 +714,8 @@ public:
 		erase_and_squash_inner(midi_divclk_pulses);
 
 		pd.remove_module(module_idx);
+
+		plugin_module_deinit(modules[module_idx]);
 
 		std::move(std::next(modules.begin(), module_idx + 1), modules.end(), std::next(modules.begin(), module_idx));
 

--- a/firmware/src/patch_play/plugin_module.cc
+++ b/firmware/src/patch_play/plugin_module.cc
@@ -1,0 +1,19 @@
+#include "plugin_module.hh"
+
+#include "engine/Module.hpp"
+
+namespace MetaModule
+{
+
+static rack::engine::Module *get_rack_plugin_module(std::unique_ptr<CoreProcessor> &module) {
+	return dynamic_cast<rack::engine::Module *>(module.get());
+}
+
+void plugin_module_deinit(std::unique_ptr<CoreProcessor> &module) {
+	if (auto rack_module = get_rack_plugin_module(module)) {
+		rack::engine::Module::RemoveEvent rm{};
+		rack_module->onRemove(rm);
+	}
+}
+
+} // namespace MetaModule

--- a/firmware/src/patch_play/plugin_module.hh
+++ b/firmware/src/patch_play/plugin_module.hh
@@ -1,0 +1,10 @@
+#pragma once
+#include "CoreModules/CoreProcessor.hh"
+#include <memory>
+
+namespace MetaModule
+{
+
+void plugin_module_deinit(std::unique_ptr<CoreProcessor> &module);
+
+}

--- a/firmware/tests/Makefile
+++ b/firmware/tests/Makefile
@@ -27,6 +27,7 @@ TEST_SOURCES += src/fw_update/hash/hash_processor.cc
 TEST_SOURCES += lib/CoreModules/moduleFactory.cc
 TEST_SOURCES += tests/resampler_tests.cc
 TEST_SOURCES += vcv_plugin/export/src/resampler.cc
+TEST_SOURCES += tests/stubs/plugin_module.cc
 
 CXXFLAGS = 	-Wall \
 		 	-std=gnu++2b \

--- a/firmware/tests/stubs/plugin_module.cc
+++ b/firmware/tests/stubs/plugin_module.cc
@@ -1,0 +1,10 @@
+#include "CoreModules/CoreProcessor.hh"
+#include <memory>
+
+namespace MetaModule
+{
+
+void plugin_module_deinit(std::unique_ptr<CoreProcessor> &module) {
+}
+
+} // namespace MetaModule

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -112,6 +112,7 @@ else()
 		${FWDIR}/src/fw_update/updater_proxy.cc
 		${FWDIR}/src/patch_play/modules_helpers.cc
 		${FWDIR}/src/params/expanders.cc
+		${FWDIR}/src/patch_play/plugin_module.cc
         ${FWDIR}/src/patch_file/reload_patch.cc
 
 		#Fatfs:


### PR DESCRIPTION
This allows the memory leak fixed in Bogaudio to work (and probably other rack plugin module cleanup functions to work properly)