### PR TITLE
Track on Equal mode can notify user or jump an out-of-range value

### DIFF
--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -211,7 +211,7 @@ public:
 		if (auto panel_knob_id = info.patch_playloader.is_panel_knob_catchup_inaccessible()) {
 			std::string msg =
 				"Knob " + std::string(PanelDef::get_map_param_name(*panel_knob_id)) +
-				" cannot reach the mapped knob. Adjust the mapping's Min/Max values or disable Track on Equal mode.";
+				" cannot reach the mapped parameter's value. Adjust the Min/Max or your Knob Catchup preferences.";
 			DisplayNotification::show({msg, Notification::Priority::Info, 3000});
 		}
 	}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -207,6 +207,13 @@ public:
 		}
 
 		DisplayNotification::flash_overload(info.metaparams.audio_overruns);
+
+		if (auto panel_knob_id = info.patch_playloader.is_panel_knob_catchup_inaccessible()) {
+			std::string msg =
+				"Knob " + std::string(PanelDef::get_map_param_name(*panel_knob_id)) +
+				" cannot reach the mapped knob. Adjust the mapping's Min/Max values or disable Track on Equal mode.";
+			DisplayNotification::show({msg, Notification::Priority::Info, 3000});
+		}
 	}
 
 	void handle_audio_errors() {

--- a/firmware/src/gui/slsexport/prefs_pane_catchup.cc
+++ b/firmware/src/gui/slsexport/prefs_pane_catchup.cc
@@ -8,9 +8,9 @@ lv_obj_t *ui_SystemPrefsCatchupTitle;
 lv_obj_t *ui_SystemPrefsCatchupModeCont;
 lv_obj_t *ui_SystemPrefsCatchupModeLabel;
 lv_obj_t *ui_SystemPrefsCatchupModeDropdown;
-lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCont;
-lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsLabel;
-lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCheck;
+lv_obj_t *ui_SystemPrefsCatchupAllowJumpOutofRangeCont;
+lv_obj_t *ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel;
+lv_obj_t *ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck;
 
 void init_SystemPrefsCatchupPane(lv_obj_t *parentTab) {
 
@@ -118,75 +118,75 @@ void init_SystemPrefsCatchupPane(lv_obj_t *parentTab) {
 	lv_obj_set_style_bg_opa(
 		lv_dropdown_get_list(ui_SystemPrefsCatchupModeDropdown), 255, LV_PART_SELECTED | LV_STATE_CHECKED);
 
-	ui_SystemPrefsCatchupExcludeButtonsCont = lv_obj_create(parentTab);
-	lv_obj_remove_style_all(ui_SystemPrefsCatchupExcludeButtonsCont);
-	lv_obj_set_width(ui_SystemPrefsCatchupExcludeButtonsCont, lv_pct(100));
-	lv_obj_set_height(ui_SystemPrefsCatchupExcludeButtonsCont, LV_SIZE_CONTENT); /// 1
-	lv_obj_set_align(ui_SystemPrefsCatchupExcludeButtonsCont, LV_ALIGN_CENTER);
-	lv_obj_set_flex_flow(ui_SystemPrefsCatchupExcludeButtonsCont, LV_FLEX_FLOW_ROW);
-	lv_obj_set_flex_align(ui_SystemPrefsCatchupExcludeButtonsCont,
+	ui_SystemPrefsCatchupAllowJumpOutofRangeCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsCatchupAllowJumpOutofRangeCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(ui_SystemPrefsCatchupAllowJumpOutofRangeCont,
 						  LV_FLEX_ALIGN_SPACE_BETWEEN,
 						  LV_FLEX_ALIGN_CENTER,
 						  LV_FLEX_ALIGN_CENTER);
-	lv_obj_clear_flag(ui_SystemPrefsCatchupExcludeButtonsCont,
+	lv_obj_clear_flag(ui_SystemPrefsCatchupAllowJumpOutofRangeCont,
 					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
-	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupExcludeButtonsCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupExcludeButtonsCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupExcludeButtonsCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupExcludeButtonsCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupAllowJumpOutofRangeCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-	ui_SystemPrefsCatchupExcludeButtonsLabel = lv_label_create(ui_SystemPrefsCatchupExcludeButtonsCont);
-	lv_obj_set_width(ui_SystemPrefsCatchupExcludeButtonsLabel, LV_SIZE_CONTENT);
-	lv_obj_set_height(ui_SystemPrefsCatchupExcludeButtonsLabel, LV_SIZE_CONTENT);
-	lv_obj_set_align(ui_SystemPrefsCatchupExcludeButtonsLabel, LV_ALIGN_CENTER);
-	lv_label_set_text(ui_SystemPrefsCatchupExcludeButtonsLabel, "Switches always track:");
+	ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel = lv_label_create(ui_SystemPrefsCatchupAllowJumpOutofRangeCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel, LV_SIZE_CONTENT);
+	lv_obj_set_height(ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel, "Allow jumping\nout-of-range params:");
 	lv_obj_set_style_text_font(
-		ui_SystemPrefsCatchupExcludeButtonsLabel, &ui_font_MuseoSansRounded70014, LV_PART_MAIN | LV_STATE_DEFAULT);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel, &ui_font_MuseoSansRounded70014, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-	ui_SystemPrefsCatchupExcludeButtonsCheck = lv_switch_create(ui_SystemPrefsCatchupExcludeButtonsCont);
-	lv_obj_set_width(ui_SystemPrefsCatchupExcludeButtonsCheck, 35);
-	lv_obj_set_height(ui_SystemPrefsCatchupExcludeButtonsCheck, 20);
-	lv_obj_set_align(ui_SystemPrefsCatchupExcludeButtonsCheck, LV_ALIGN_TOP_RIGHT);
-	lv_obj_add_flag(ui_SystemPrefsCatchupExcludeButtonsCheck, LV_OBJ_FLAG_SCROLL_ON_FOCUS); /// Flags
-	lv_obj_clear_flag(ui_SystemPrefsCatchupExcludeButtonsCheck,
+	ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck = lv_switch_create(ui_SystemPrefsCatchupAllowJumpOutofRangeCont);
+	lv_obj_set_width(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 35);
+	lv_obj_set_height(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 20);
+	lv_obj_set_align(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, LV_ALIGN_TOP_RIGHT);
+	lv_obj_add_flag(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, LV_OBJ_FLAG_SCROLL_ON_FOCUS); /// Flags
+	lv_obj_clear_flag(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck,
 					  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE); /// Flags
-	lv_obj_set_style_radius(ui_SystemPrefsCatchupExcludeButtonsCheck, 20, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_radius(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 20, LV_PART_MAIN | LV_STATE_DEFAULT);
 	lv_obj_set_style_bg_color(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0x202328), LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, lv_color_hex(0x202328), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 	lv_obj_set_style_outline_color(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED);
-	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_MAIN | LV_STATE_FOCUSED);
-	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupExcludeButtonsCheck, 2, LV_PART_MAIN | LV_STATE_FOCUSED);
-	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupExcludeButtonsCheck, 1, LV_PART_MAIN | LV_STATE_FOCUSED);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 255, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 2, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 1, LV_PART_MAIN | LV_STATE_FOCUSED);
 	lv_obj_set_style_outline_color(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupExcludeButtonsCheck, 2, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupExcludeButtonsCheck, 1, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_color(ui_SystemPrefsCatchupExcludeButtonsCheck,
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_opa(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 255, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_width(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 2, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_pad(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 1, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_color(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck,
 								   lv_color_hex(0xFD8B18),
 								   LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
 	lv_obj_set_style_outline_opa(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, 200, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 200, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
 	lv_obj_set_style_outline_width(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, 2, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 2, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
 	lv_obj_set_style_outline_pad(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, 1, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 1, LV_PART_MAIN | LV_STATE_CHECKED | LV_STATE_FOCUSED);
 
-	lv_obj_set_style_radius(ui_SystemPrefsCatchupExcludeButtonsCheck, 20, LV_PART_INDICATOR | LV_STATE_CHECKED);
+	lv_obj_set_style_radius(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 20, LV_PART_INDICATOR | LV_STATE_CHECKED);
 	lv_obj_set_style_bg_color(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0x4067D3), LV_PART_INDICATOR | LV_STATE_CHECKED);
-	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_INDICATOR | LV_STATE_CHECKED);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, lv_color_hex(0x4067D3), LV_PART_INDICATOR | LV_STATE_CHECKED);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 255, LV_PART_INDICATOR | LV_STATE_CHECKED);
 
-	lv_obj_set_style_radius(ui_SystemPrefsCatchupExcludeButtonsCheck, 20, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_radius(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 20, LV_PART_KNOB | LV_STATE_DEFAULT);
 	lv_obj_set_style_bg_color(
-		ui_SystemPrefsCatchupExcludeButtonsCheck, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupExcludeButtonsCheck, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupExcludeButtonsCheck, -4, LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupExcludeButtonsCheck, -6, LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupExcludeButtonsCheck, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupExcludeButtonsCheck, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
+		ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_left(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, -4, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, -6, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
 }
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_pane_catchup.hh
+++ b/firmware/src/gui/slsexport/prefs_pane_catchup.hh
@@ -7,9 +7,9 @@ extern lv_obj_t *ui_SystemPrefsCatchupTitle;
 extern lv_obj_t *ui_SystemPrefsCatchupModeCont;
 extern lv_obj_t *ui_SystemPrefsCatchupModeLabel;
 extern lv_obj_t *ui_SystemPrefsCatchupModeDropdown;
-extern lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCont;
-extern lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsLabel;
-extern lv_obj_t *ui_SystemPrefsCatchupExcludeButtonsCheck;
+extern lv_obj_t *ui_SystemPrefsCatchupAllowJumpOutofRangeCont;
+extern lv_obj_t *ui_SystemPrefsCatchupAllowJumpOutOfRangeLabel;
+extern lv_obj_t *ui_SystemPrefsCatchupAllowJumpOutOfRangeCheck;
 
 void init_SystemPrefsCatchupPane(lv_obj_t *parentTab);
 

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -72,7 +72,7 @@ public:
 
 		patch_playloader.request_new_audio_settings(
 			settings.audio.sample_rate, settings.audio.block_size, settings.audio.max_overrun_retries);
-		patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.button_exclude);
+		patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.allow_jump_outofrange);
 
 		tvg::Initializer::init(0, tvg::CanvasEngine::Sw);
 	}

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -108,12 +108,12 @@ public:
 	}
 
 private:
-	std::optional<T> update_resume_equal(T phys_val, T module_val) {
+	std::optional<T> update_resume_equal(T scaled_phys_val, T module_val) {
 		// Exit catchup mode if module and physical values are close
-		printf("update_resume_equal: phys %f, module_val %f. Tol = %f\n", phys_val, module_val, Tolerance);
-		if (MathTools::abs_diff(module_val, phys_val) < Tolerance) {
+		printf("update_resume_equal: phys %f, module_val %f. Tol = %f\n", scaled_phys_val, module_val, Tolerance);
+		if (MathTools::abs_diff(module_val, scaled_phys_val) < Tolerance) {
 			printf("enter tracking\n");
-			return enter_tracking(phys_val);
+			return enter_tracking(scaled_phys_val);
 		}
 		return {};
 	}

--- a/firmware/src/params/catchup_param.hh
+++ b/firmware/src/params/catchup_param.hh
@@ -41,7 +41,6 @@ public:
 
 		if (state == State::Tracking) {
 			// Change to Catchup mode if module changes value
-			printf("update(): tracking: last_module_val = %f, cur_module_val = %f\n", last_module_val, cur_module_val);
 			if (MathTools::abs_diff(last_module_val, cur_module_val) >= Tolerance) {
 				enter_catchup();
 				return {};
@@ -110,9 +109,7 @@ public:
 private:
 	std::optional<T> update_resume_equal(T scaled_phys_val, T module_val) {
 		// Exit catchup mode if module and physical values are close
-		printf("update_resume_equal: phys %f, module_val %f. Tol = %f\n", scaled_phys_val, module_val, Tolerance);
 		if (MathTools::abs_diff(module_val, scaled_phys_val) < Tolerance) {
-			printf("enter tracking\n");
 			return enter_tracking(scaled_phys_val);
 		}
 		return {};

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -915,11 +915,7 @@ public:
 	}
 
 	// Set mode for all maps
-	void set_catchup_mode(CatchupParam::Mode mode);
-
-	// Set mode for one knobset only.
-	// If knob_set_idx is out of range, then active knob set will be changed.
-	void set_catchup_mode(CatchupParam::Mode mode, int knob_set_idx);
+	void set_catchup_mode(CatchupParam::Mode mode, bool allow_jump_outofrange);
 
 	// Set mode for one mapping only
 	void set_catchup_mode(int knob_set_idx, unsigned module_id, unsigned param_id, CatchupParam::Mode mode);

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -929,6 +929,8 @@ public:
 
 	bool is_param_tracking(unsigned module_id, unsigned param_id);
 
+	std::optional<unsigned> panel_knob_catchup_inaccessible();
+
 private:
 	static inline Jack disconnected_jack = {0xFFFF, 0xFFFF};
 

--- a/firmware/src/patch_play/patch_player_catchup.cc
+++ b/firmware/src/patch_play/patch_player_catchup.cc
@@ -70,4 +70,12 @@ bool PatchPlayer::is_param_tracking(unsigned module_id, unsigned param_id) {
 	return false;
 }
 
+std::optional<unsigned> PatchPlayer::panel_knob_catchup_inaccessible() {
+	for (auto panel_knob_id = 0u; panel_knob_id < PanelDef::NumKnobs; panel_knob_id++) {
+		if (catchup_manager.is_out_of_range(panel_knob_id))
+			return panel_knob_id;
+	}
+	return {};
+}
+
 } // namespace MetaModule

--- a/firmware/src/patch_play/patch_player_catchup.cc
+++ b/firmware/src/patch_play/patch_player_catchup.cc
@@ -4,27 +4,14 @@ namespace MetaModule
 {
 
 // Set mode for all maps
-void PatchPlayer::set_catchup_mode(CatchupParam::Mode mode) {
-	catchup_manager.set_default_mode(mode);
+void PatchPlayer::set_catchup_mode(CatchupParam::Mode mode, bool allow_jump_outofrange) {
+	catchup_manager.set_default_mode(mode, allow_jump_outofrange);
 
 	for (auto &knobset : knob_maps) {
 		for (auto &knob : knobset) {
 			for (auto &map : knob) {
 				map.catchup.set_mode(mode);
 			}
-		}
-	}
-}
-
-// Set mode for one knobset only.
-// If knob_set_idx is out of range, then active knob set will be changed.
-void PatchPlayer::set_catchup_mode(CatchupParam::Mode mode, int knob_set_idx) {
-	if (knob_set_idx < 0 || knob_set_idx >= (int)knob_maps.size())
-		knob_set_idx = active_knob_set;
-
-	for (auto &knob : knob_maps[knob_set_idx]) {
-		for (auto &map : knob) {
-			map.catchup.set_mode(mode);
 		}
 	}
 }

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -160,6 +160,10 @@ struct PatchPlayLoader {
 		audio_overrun_ = false;
 	}
 
+	std::optional<unsigned> is_panel_knob_catchup_inaccessible() {
+		return player_.panel_knob_catchup_inaccessible();
+	}
+
 	// Concurrency: Called from UI thread
 	Result handle_file_events() {
 		if (loading_new_patch_ && audio_is_muted_) {

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -278,7 +278,7 @@ struct PatchPlayLoader {
 		return player_.is_param_tracking(module_id, param_id);
 	}
 
-	void set_all_param_catchup_mode(CatchupParam::Mode mode, bool exclude_buttons) {
+	void set_all_param_catchup_mode(CatchupParam::Mode mode, bool allow_jump_outofrange) {
 		// if (exclude_buttons) {
 
 		// 	for (auto module_id = 0u; auto slug : patches_.get_view_patch()->module_slugs) {
@@ -306,7 +306,7 @@ struct PatchPlayLoader {
 		// 	}
 
 		// } else {
-		player_.set_catchup_mode(mode);
+		player_.set_catchup_mode(mode, allow_jump_outofrange);
 		// }
 	}
 

--- a/firmware/src/user_settings/catchup_settings.hh
+++ b/firmware/src/user_settings/catchup_settings.hh
@@ -18,10 +18,10 @@ struct CatchupSettings {
 		Option{CatchupParam::Mode::LinearFade, "Linear fade"},
 	};
 	static constexpr CatchupParam::Mode DefaultMode = CatchupParam::Mode::ResumeOnMotion;
-	static constexpr bool DefaultButtonExclude = true;
+	static constexpr bool DefaultAllowJump = true;
 
 	CatchupParam::Mode mode = DefaultMode;
-	bool button_exclude = DefaultButtonExclude;
+	bool allow_jump_outofrange = DefaultAllowJump;
 
 	void make_valid() {
 
@@ -34,10 +34,10 @@ struct CatchupSettings {
 			mode = DefaultMode;
 
 		// Check if deserialized data contains a value other than 0 or 1
-		if (*reinterpret_cast<uint8_t *>(&button_exclude) != 0)
-			button_exclude = true;
+		if (*reinterpret_cast<uint8_t *>(&allow_jump_outofrange) != 0)
+			allow_jump_outofrange = true;
 		else
-			button_exclude = false;
+			allow_jump_outofrange = false;
 	}
 };
 

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -109,7 +109,7 @@ static bool read(ryml::ConstNodeRef const &node, CatchupSettings *settings) {
 		settings->mode = CatchupParam{}.mode;
 	}
 
-	read_or_default(node, "exclude_buttons", settings, &CatchupSettings::button_exclude);
+	read_or_default(node, "allow_jump_outofrange", settings, &CatchupSettings::allow_jump_outofrange);
 	settings->make_valid();
 
 	return true;

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -64,7 +64,7 @@ static void write(ryml::NodeRef *n, CatchupSettings const &s) {
 								s.mode == LinearFade	 ? "LinearFade" :
 														   "ResumeOnMotion";
 	n->append_child() << ryml::key("mode") << mode_string;
-	n->append_child() << ryml::key("exclude_buttons") << s.button_exclude;
+	n->append_child() << ryml::key("allow_jump_outofrange") << s.allow_jump_outofrange;
 }
 
 static void write(ryml::NodeRef *n, FilesystemSettings const &s) {

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -54,7 +54,7 @@ TEST_CASE("Parse settings file") {
 
   catchup:
     mode: ResumeOnEqual
-    exclude_buttons: 0
+    allow_jump_outofrange: 0
 
   filesystem:
     auto_reload_patch_file: false
@@ -102,7 +102,7 @@ TEST_CASE("Parse settings file") {
 	CHECK(settings.screensaver.knobs_can_wake == true);
 
 	CHECK(settings.catchup.mode == MetaModule::CatchupParam::Mode::ResumeOnEqual);
-	CHECK(settings.catchup.button_exclude == false);
+	CHECK(settings.catchup.allow_jump_outofrange == false);
 
 	CHECK(settings.filesystem.auto_reload_patch_file == false);
 	CHECK(settings.filesystem.max_open_patches == 7);
@@ -180,7 +180,7 @@ TEST_CASE("Get default settings if file is missing fields") {
 	SUBCASE("Bad catchup settings:") {
 		yaml = R"(Settings:
   catchup:
-    exclude_buttons: 2
+    allow_jump_outofrange: 2
 )";
 	}
 	SUBCASE("Bad filesystem settings:") {
@@ -231,7 +231,7 @@ TEST_CASE("Get default settings if file is missing fields") {
 	CHECK(settings.screensaver.knobs_can_wake == true);
 
 	CHECK(settings.catchup.mode == MetaModule::CatchupParam::Mode::ResumeOnMotion);
-	CHECK(settings.catchup.button_exclude == true);
+	CHECK(settings.catchup.allow_jump_outofrange == true);
 
 	CHECK(settings.filesystem.auto_reload_patch_file == true);
 	CHECK(settings.filesystem.max_open_patches == 15);
@@ -277,7 +277,7 @@ TEST_CASE("Serialize settings") {
 	settings.screensaver.timeout_ms = 2;
 
 	settings.catchup.mode = MetaModule::CatchupParam::Mode::LinearFade;
-	settings.catchup.button_exclude = false;
+	settings.catchup.allow_jump_outofrange = false;
 
 	settings.filesystem.max_open_patches = 8;
 	settings.filesystem.auto_reload_patch_file = false;
@@ -326,7 +326,7 @@ TEST_CASE("Serialize settings") {
     knobs_can_wake: 0
   catchup:
     mode: LinearFade
-    exclude_buttons: 0
+    allow_jump_outofrange: 0
   filesystem:
     auto_reload_patch_file: 0
     max_open_patches: 8

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -62,7 +62,7 @@ Ui::Ui(std::string_view sdcard_path, std::string_view flash_path, std::string_vi
 	params.set_output_plugged(cur_outchan_left, true);
 	params.set_output_plugged(cur_outchan_right, true);
 
-	patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.button_exclude);
+	patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.allow_jump_outofrange);
 }
 
 // "Scheduler" for UI tasks


### PR DESCRIPTION
See https://forum.4ms.info/t/track-when-equal-not-picking-up-with-push-module-buttons/1208

In track on equal mode, if the min/max of the mapping does not overlap the param's current value, then the knob can never be made to be equal. Therefore you cannot start tracking (aka "pickup") a param that's not already tracking. Therefore the param is stuck.
Two solutions are presented here and a user setting (`Allow jumping out-of-range params`) to select which one.
- Allow jumping off: Display a notification when you move the panel knob to the extreme that's closest to where the mapped param's value is.
- Allow jumping on: Automatically pickup (start tracking) the param when the knob is as close as it can be.