### PR TITLE
Fix crash when unloading a plugin, then loading a different version of same plugin

### DIFF
--- a/firmware/src/conf/hsem_conf.hh
+++ b/firmware/src/conf/hsem_conf.hh
@@ -12,6 +12,7 @@ enum SemaphoreLocks {
 	ParamCacheLock,
 	RamDiskLock,
 	SharedI2CLock,
+	InvalidateICache,
 };
 
 } // namespace MetaModule

--- a/firmware/src/core_a7/hsem_handler.hh
+++ b/firmware/src/core_a7/hsem_handler.hh
@@ -6,8 +6,10 @@ namespace MetaModule
 {
 struct HWSemaphoreCoreHandler : public mdrivlib::HWSemaphoreGlobalBase {
 	static void enable_global_ISR(uint32_t pri1, uint32_t pri2) {
-		mdrivlib::InterruptManager::register_and_start_isr(
-			HSEM_IT1_IRQn, pri1, pri2, [&]() { handle_isr<RamDiskLock>(); });
+		mdrivlib::InterruptManager::register_and_start_isr(HSEM_IT1_IRQn, pri1, pri2, [&]() {
+			handle_isr<RamDiskLock>();
+			handle_isr<InvalidateICache>();
+		});
 	}
 };
 } // namespace MetaModule

--- a/firmware/src/core_a7/main.cc
+++ b/firmware/src/core_a7/main.cc
@@ -3,6 +3,7 @@
 #include "calibrate/calibration_data_reader.hh"
 #include "core_a7/a7_shared_memory.hh"
 #include "core_a7/static_buffers.hh"
+#include "core_intercom/semaphore_action.hh"
 #include "core_intercom/shared_memory.hh"
 #include "coreproc_plugin/async_thread_control.hh"
 #include "debug.hh"
@@ -86,6 +87,8 @@ int main() {
 
 	// prevents M4 from using it as a USBD device:
 	mdrivlib::HWSemaphore<MetaModule::RamDiskLock>::lock(0);
+	// Invalidate our I cache when plugin code is loaded
+	SemaphoreActionOnUnlock<InvalidateICache> clean_cache([] { mdrivlib::SystemCache::invalidate_icache(); });
 
 	start_module_threads();
 

--- a/firmware/tests/stubs/drivers/cache.hh
+++ b/firmware/tests/stubs/drivers/cache.hh
@@ -7,6 +7,9 @@ namespace mdrivlib::SystemCache
 inline void invalidate_dcache() {
 }
 
+inline void invalidate_icache() {
+}
+
 template<typename ptr>
 inline void invalidate_dcache_by_addr(ptr addr) {
 }


### PR DESCRIPTION
The problem was the instruction cache was not invalidated on both cores after loading the changed code segments. So  after loading new code into the data cache, the instruction cache on either core might still contain old instructions. This led to very strange crashes with seemingly impossible backtraces.