### PR TITLE
Small fixes: Module List brand merging, minor GUI stuff

### DIFF
--- a/firmware/src/gui/pages/knobmap.hh
+++ b/firmware/src/gui/pages/knobmap.hh
@@ -180,6 +180,9 @@ struct KnobMapPage : PageBase {
 					del_popup.show([this](bool ok) { save_knob_alias(ok); }, "Do you want to keep your edits?", "Keep");
 			} else if (del_popup.is_visible()) {
 				del_popup.hide();
+			} else if (lv_dropdown_is_open(ui_EditMapMidiChannelDropdown)) {
+				lv_dropdown_close(ui_EditMapMidiChannelDropdown);
+				lv_group_set_editing(group, false);
 			} else {
 				page_list.request_last_page();
 			}

--- a/firmware/src/gui/pages/plugin_popup.hh
+++ b/firmware/src/gui/pages/plugin_popup.hh
@@ -15,7 +15,7 @@ namespace MetaModule
 struct PluginPopup {
 	PluginPopup()
 		: group{lv_group_create()} {
-		auto p = create_labeled_check_obj(ui_DelMapPopUpPanel, "Autoload");
+		auto p = create_labeled_check_obj(ui_DelMapPopUpPanel, "Pre-load");
 		lv_obj_move_to_index(p, 1);
 		check = lv_obj_get_child(p, -1);
 		lv_obj_add_event_cb(check, toggle_callback, LV_EVENT_VALUE_CHANGED, this);

--- a/firmware/src/load_test/test_modules.hh
+++ b/firmware/src/load_test/test_modules.hh
@@ -32,10 +32,10 @@ inline void test_all_modules(auto append_file) {
 
 	auto brands = ModuleFactory::getAllBrands();
 	for (auto brand : brands) {
-		auto slugs = ModuleFactory::getAllSlugs(brand);
+		auto slugs = ModuleFactory::getAllModuleSlugs(brand);
 		for (auto slug : slugs) {
 			ModuleEntry entry;
-			entry.slug = brand + ":" + slug;
+			entry.slug = std::string(brand) + ":" + std::string(slug);
 			pr_info("Testing %s\n", entry.slug.c_str());
 			lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.slug.c_str());
 


### PR DESCRIPTION
- Module List was not handling the case when two plugins each have a distinct brand slug but have the same display name (e.g. Stellare Modular, and Stellare Modular Creative Suite)
- MIDI channel dropdown menu would not close if you pressed Back on the Edit Map page
- Plugin info pop-up contained the old working "autoload", which should be "pre-load"