### PR TITLE
Refactor snapped Knobs to maintain API consistancy

### DIFF
--- a/firmware/src/gui/elements/state_names.hh
+++ b/firmware/src/gui/elements/state_names.hh
@@ -5,112 +5,136 @@
 #include <charconv>
 #include <string>
 
-// TODO: there should be no dependency on a specific brand here
-#include "CoreModules/4ms/4ms_element_state_conversions.hh"
-
 namespace MetaModule
 {
+
+inline std::string custom_display_value_string(Pot const &el, float value, bool integral = false) {
+	std::string s;
+
+	float v = value * (el.max_value - el.min_value) + el.min_value;
+
+	if (integral)
+		v = std::round(v);
+
+	if (el.display_base < 0.f) {
+		v = std::log(v) / std::log(-el.display_base);
+	} else if (el.display_base > 0.f) {
+		v = std::pow(el.display_base, v);
+	}
+	v = v * el.display_mult + el.display_offset;
+
+	s.resize(32, '\0');
+	if (el.display_precision > 0) {
+		auto sz = std::snprintf(s.data(), s.size(), "%.*g", el.display_precision, v);
+		s.resize(sz);
+	} else {
+		auto res = std::to_chars(s.data(), s.data() + s.size(), v, std::chars_format::general, 5);
+		*res.ptr = '\0';
+		s.resize(res.ptr - s.data());
+	}
+
+	if (el.units.length()) {
+		s = s + std::string(el.units);
+	}
+
+	return s;
+}
+
+inline std::string percent_value_string(float value, float res) {
+	std::string s;
+	// No custom range or display: show it as a percentage
+	float v = std::clamp(value * 100.f, 0.f, 100.f);
+	char buf[16];
+	if (res <= 100)
+		std::snprintf(buf, sizeof buf, "%.0f", v);
+	else if (res <= 1000)
+		std::snprintf(buf, sizeof buf, "%.1f", v);
+	else
+		std::snprintf(buf, sizeof buf, "%.2f", v);
+	s = std::string(buf) + "%";
+
+	return s;
+}
+
+inline std::string snapped_value_string(Knob const &el, float value) {
+	std::string s;
+	unsigned v = std::round(std::clamp(value, 0.f, 1.f) * (float)(el.num_pos - 1));
+
+	if (v >= 0 && v < el.pos_names.size() && el.pos_names[v].length()) {
+		s = el.pos_names[v];
+	} else {
+		s.resize(16, '\0');
+		auto sz = std::snprintf(s.data(), s.size(), "(Pos. %u/%u)", v + 1, el.num_pos);
+		s.resize(sz);
+	}
+	return s;
+}
+
+inline bool has_custom_display(Pot const &el) {
+	return el.display_mult != 1 || el.display_offset != 0 || el.display_base != 0 || el.units.length() > 0;
+}
 
 inline std::string get_element_value_string(Element const &element, float value, float resolution) {
 	std::string s;
 
-	std::visit(overloaded{
-				   [value = value, res = resolution, &s](Pot const &el) {
-					if (el.min_value == 0 && el.max_value == 1 && el.display_mult == 1 && el.display_offset == 0 &&
-						   el.display_base == 0 && el.units.length() == 0)
-					   {
-						   // No custom range or display: show it as a percentage
-						   float v = std::clamp(value * 100.f, 0.f, 100.f);
-						   char buf[16];
-						   if (res <= 100)
-							   std::snprintf(buf, sizeof buf, "%.0f", v);
-						   else if (res <= 1000)
-							   std::snprintf(buf, sizeof buf, "%.1f", v);
-						   else
-							   std::snprintf(buf, sizeof buf, "%.2f", v);
-						   s = std::string(buf) + "%";
+	std::visit(
+		overloaded{
+			[value = value, res = resolution, &s](Slider const &el) {
+				if (has_custom_display(el) || el.min_value != 0 || el.max_value != 1)
+					s = custom_display_value_string(el, value);
+				else
+					s = percent_value_string(value, res);
+			},
 
-					  	} else if (el.integral && el.num_pos > 0 && el.display_mult == 1 && el.display_offset == 0 &&
-						   el.display_base == 0 && el.units.length() == 0) {
-						   unsigned v = std::round(std::clamp(value, 0.f, 1.f) * (float)(el.num_pos - 1));
+			[value = value, &s](Knob const &el) {
+				bool snap = el.num_pos > 0;
+				if (has_custom_display(el) || !snap) {
+					s = custom_display_value_string(el, value, snap);
+				} else {
+					s = snapped_value_string(el, value);
+				}
+			},
 
-						   if (v >= 0 && v < el.pos_names.size() && el.num_pos <= el.pos_names.size()) {
-							   s = el.pos_names[v];
-						   } else {
-								s.resize(16, '\0');
-								auto sz = std::snprintf(s.data(), s.size(), "#%u/%u", v + 1, el.num_pos);
-								s.resize(sz);
-							}
-						} 
-						
-						if (!s.size()) {
-						   // Scale it
-						   float v = value * (el.max_value - el.min_value) + el.min_value;
-						   if (el.integral)
-							   v = std::round(v);
-						   if (el.display_base < 0.f) {
-							   v = std::log(v) / std::log(-el.display_base);
-						   } else if (el.display_base > 0.f) {
-							   v = std::pow(el.display_base, v);
-						   }
-						   v = v * el.display_mult + el.display_offset;
+			[value = value, res = resolution, &s](ParamElement const &) { s = percent_value_string(value, res); },
 
-						   s.resize(32, '\0');
-						   if (el.display_precision > 0) {
-							   auto sz = std::snprintf(s.data(), s.size(), "%.*g", el.display_precision, v);
-							   s.resize(sz);
-						   } else {
-							   auto res = std::to_chars(s.data(), s.data() + s.size(), v); // automatic precision
-							   *res.ptr = '\0';
-							   s.resize(res.ptr - s.data());
-						   }
+			[value = value, &s](SlideSwitch const &el) {
+				auto v = StateConversion::convertState(el, value);
+				if (v >= 0 && v < el.pos_names.size() && el.pos_names[v].size())
+					s = el.pos_names[v];
+				else
+					s = std::to_string(v + 1) + std::string("/") + std::to_string(el.num_pos);
+			},
 
-						   if (el.units.length()) {
-							   s = s + std::string(el.units);
-						   }
-					   }
-				   },
+			[value = value, &s](FlipSwitch const &el) {
+				auto v = StateConversion::convertState(el, value);
+				if (v < el.pos_names.size())
+					s = el.pos_names[v];
+				else
+					s = std::to_string(v);
+			},
 
-				   [value = value, &s](ParamElement const &) { s = std::to_string((int)(value * 100.f)) + "%"; },
+			[value = value, &s](MomentaryButton const &) { s = value < 0.5f ? "Released" : "Pressed"; },
 
-				   [value = value, &s](SlideSwitch const &el) {
-					   auto v = StateConversion::convertState(el, value);
-					   if (v >= 0 && v < el.pos_names.size() && el.pos_names[v].size())
-						   s = el.pos_names[v];
-					   else
-						   s = std::to_string(v + 1) + std::string("/") + std::to_string(el.num_pos);
-				   },
+			[value = value, &s](LatchingButton const &) { s = value < 0.5f ? "Off" : "On"; },
 
-				   [value = value, &s](FlipSwitch const &el) {
-					   auto v = StateConversion::convertState(el, value);
-					   if (v < el.pos_names.size())
-						   s = el.pos_names[v];
-					   else
-						   s = std::to_string(v);
-				   },
+			[value = value, &s](AltParamContinuous const &) { s = std::to_string((int)(value * 100.f)) + "%"; },
 
-				   [value = value, &s](MomentaryButton const &) { s = value < 0.5f ? "Released" : "Pressed"; },
+			[value = value, &s](AltParamChoice const &el) {
+				auto v = StateConversion::convertState(el, value);
+				s = std::to_string(v + 1) + std::string("/") + std::to_string(el.num_pos);
+			},
 
-				   [value = value, &s](LatchingButton const &) { s = value < 0.5f ? "Off" : "On"; },
+			[value = value, &s](AltParamChoiceLabeled const &el) {
+				auto v = StateConversion::convertState(el, value);
+				if (v >= 0 && v < el.pos_names.size() && el.pos_names[v].size())
+					s = el.pos_names[v];
+				else
+					s = std::to_string(v + 1) + std::string("/") + std::to_string(el.num_pos);
+			},
 
-				   [value = value, &s](AltParamContinuous const &) { s = std::to_string((int)(value * 100.f)) + "%"; },
-
-				   [value = value, &s](AltParamChoice const &el) {
-					   auto v = StateConversion::convertState(el, value);
-					   s = std::to_string(v + 1) + std::string("/") + std::to_string(el.num_pos);
-				   },
-
-				   [value = value, &s](AltParamChoiceLabeled const &el) {
-					   auto v = StateConversion::convertState(el, value);
-					   if (v >= 0 && v < el.pos_names.size() && el.pos_names[v].size())
-						   s = el.pos_names[v];
-					   else
-						   s = std::to_string(v + 1) + std::string("/") + std::to_string(el.num_pos);
-				   },
-
-				   [](BaseElement const &) {},
-			   },
-			   element);
+			[](BaseElement const &) {},
+		},
+		element);
 
 	return s;
 }

--- a/firmware/vcv_plugin/export/src/plugin/Model.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Model.cpp
@@ -28,7 +28,7 @@ void Model::move_strings() {
 		std::visit(overloaded{[](BaseElement &el) {},
 							  [this](Knob &el) {
 								  el.units = strings.emplace_back(el.units);
-								  
+
 								  for (auto &pos_name : el.pos_names) {
 									  pos_name = strings.emplace_back(pos_name);
 								  }

--- a/firmware/vcv_plugin/internal/make_element.cc
+++ b/firmware/vcv_plugin/internal/make_element.cc
@@ -21,6 +21,10 @@ static void log_make_element_notes(std::string_view note1, std::string_view note
 	}
 }
 
+static const char *module_name(rack::app::ParamWidget *widget) {
+	return (widget && widget->module && widget->module->getModel()) ? widget->module->getModel()->slug.c_str() : "?";
+}
+
 static float getScaledDefaultValue(rack::app::ParamWidget *widget);
 static unsigned getDefaultValue(rack::app::ParamWidget *widget);
 
@@ -220,7 +224,7 @@ static Element make_slideswitch(rack::app::SvgSlider *widget) {
 	element.num_pos = pq->maxValue - pq->minValue + 1;
 
 	if (element.num_pos < 2 || element.num_pos > element.pos_names.size()) {
-		pr_warn("Warning: SvgSlider (max - min + 1) is %d, but must be 2..8\n", element.num_pos);
+		pr_warn("Warning: %s: SvgSlider max-min+1 is %d, but must be 2..8\n", module_name(widget), element.num_pos);
 		element.num_pos = std::clamp<size_t>(element.num_pos, 2, element.pos_names.size());
 	}
 
@@ -269,6 +273,9 @@ Element make_element(rack::app::SvgSlider *widget) {
 Element make_element(rack::app::SvgSlider *widget, rack::app::MultiLightWidget *light) {
 	log_make_element("SvgSlider, Light", widget->paramId);
 
+	if (widget->snap || (widget->getParamQuantity() && widget->getParamQuantity()->snapEnabled)) {
+		pr_warn("Warning: in '%s', snapped sliders with lights are not supported\n", module_name(widget));
+	}
 	SliderLight element;
 
 	element.default_value = getScaledDefaultValue(widget);
@@ -303,7 +310,7 @@ static MomentaryButton make_momentary(rack::app::SvgSwitch *widget) {
 			pr_info("Excess momentary button frames ignored\n");
 
 	} else {
-		pr_warn("Warning: SvgSwitch has no image frames\n");
+		pr_warn("Warning: In %s, SvgSwitch has no image frames\n", module_name(widget));
 	}
 
 	return element;
@@ -317,7 +324,9 @@ static SlideSwitch make_slideswitch(rack::app::SvgSwitch *widget) {
 		element.num_pos = pq->maxValue - pq->minValue + 1;
 
 		if (element.num_pos < 2 || element.num_pos > element.pos_names.size()) {
-			pr_warn("Warning: SvgSwitch as SlideSwitch (max - min + 1) is %d, but must be 2 - 8\n", element.num_pos);
+			pr_warn("Warning: In %s, SvgSwitch as SlideSwitch (max-min+1) is %d, but must be 2-8\n",
+					module_name(widget),
+					element.num_pos);
 			element.num_pos = std::clamp<size_t>(widget->frames.size(), 2, element.pos_names.size());
 		}
 
@@ -328,7 +337,8 @@ static SlideSwitch make_slideswitch(rack::app::SvgSwitch *widget) {
 	} else {
 		// Gracefully handle an unconfigured param:
 		element.num_pos = std::clamp<size_t>(widget->frames.size(), 2, element.pos_names.size());
-		pr_warn("Warning: SvgSwitch as SlideSwitch not configured with configParam or configSwitch\n");
+		pr_warn("Warning: In %s SvgSwitch as SlideSwitch not configured with configParam or configSwitch\n",
+				module_name(widget));
 	}
 
 	element.image_handle = "no-image";
@@ -345,7 +355,9 @@ static FlipSwitch make_flipswitch(rack::app::SvgSwitch *widget) {
 		element.num_pos = pq->maxValue - pq->minValue + 1;
 
 		if (element.num_pos < 2 || element.num_pos > FlipSwitch::MaxPositions) {
-			pr_warn("Warning: SvgSwitch (max - min + 1) is %d, but must be 2 - 4\n", element.num_pos);
+			pr_warn("Warning: In %s, SvgSwitch (max-min+1) is %d, but must be 2-10\n",
+					module_name(widget),
+					element.num_pos);
 			element.num_pos = std::clamp<size_t>(widget->frames.size(), 2, FlipSwitch::MaxPositions);
 		}
 
@@ -355,7 +367,7 @@ static FlipSwitch make_flipswitch(rack::app::SvgSwitch *widget) {
 	} else {
 		// Gracefully handle an unconfigured param:
 		element.num_pos = std::clamp<size_t>(widget->frames.size(), 2, element.pos_names.size());
-		pr_warn("Warning: SvgSwitch not configured with configParam or configSwitch\n");
+		pr_warn("Warning: In %s SvgSwitch not configured with configParam or configSwitch\n", module_name(widget));
 	}
 
 	for (unsigned i = 0; i < std::min<size_t>(FlipSwitch::MaxPositions, widget->frames.size()); i++) {
@@ -429,11 +441,12 @@ Element make_element(rack::app::SvgSwitch *widget, rack::app::MultiLightWidget *
 		getScaledDefaultValue(widget) > 0.5f ? LatchingButton::State_t::UP : LatchingButton::State_t::DOWN;
 
 	if (light->getNumColors() != 1 && light->getNumColors() != 3) {
-		pr_warn("SvgSwitch with MultiLightWidget with %d colors: only 1 and 3 colors are supported.\n",
+		pr_warn("In %s, SvgSwitch with MultiLightWidget with %d colors: only 1 and 3 colors are supported.\n",
+				module_name(widget),
 				light->getNumColors());
 	}
 	if (widget->frames.size() == 0) {
-		pr_err("Error: SvgSwitch with no frames\n");
+		pr_err("Error: In %s, SvgSwitch with no frames\n", module_name(widget));
 		widget->addFrame({});
 	}
 
@@ -583,7 +596,9 @@ Element make_element(rack::widget::Widget *widget) {
 }
 
 Element make_element(rack::app::ParamWidget *widget) {
-	pr_warn("ParamWidget (param id %d) without an SVG, using a blank ParamElement\n", widget->paramId);
+	pr_warn("In %s ParamWidget (param id %d) without an SVG, using a blank ParamElement\n",
+			module_name(widget),
+			widget->paramId);
 	ParamElement element{};
 	element.width_mm = to_mm(widget->box.size.x);
 	element.height_mm = to_mm(widget->box.size.y);


### PR DESCRIPTION
This refactors PR #507 to maintain the size of the Elements variant, and to not add fields to Pot, but instead add fields to Knob since no other class derives from Knob.

Without this, native CoreModule plugins such as Airwindows would crash on load