### PR TITLE
Midi size fix

### DIFF
--- a/firmware/src/audio/midi.hh
+++ b/firmware/src/audio/midi.hh
@@ -35,6 +35,7 @@ struct AudioStreamMidi {
 			return;
 
 		// Transfer MIDI RX message to router (from hardware)
+		// Ignore active-sensing
 		if (raw_msg->status != 0xfe && raw_msg->status != 0) {
 			// 50ns with no listeners + ~100ns additional per listener
 			MidiRouter::push_incoming_message(*raw_msg);

--- a/firmware/src/core_a7/aux_core_player.hh
+++ b/firmware/src/core_a7/aux_core_player.hh
@@ -75,7 +75,8 @@ struct AuxPlayer {
 				if (d.is_active()) {
 					auto text = std::span<char>(d.text._data, d.text.capacity);
 					auto sz = patch_player.get_display_text(d.module_id, d.light_id, text);
-					d.text._data[sz] = '\0';
+					if (sz)
+						d.text._data[sz] = '\0';
 				}
 			}
 

--- a/firmware/src/midi/midi_message.hh
+++ b/firmware/src/midi/midi_message.hh
@@ -169,6 +169,16 @@ struct MidiMessage {
 		return ((int16_t)data.byte[0] | ((int16_t)data.byte[1] << 7)) - 8192;
 	}
 
+	unsigned message_size() const {
+		if (is_timing_transport()) {
+			return 1;
+		} else if (status.command == MidiCommand::ChannelPressure) {
+			return 2;
+		} else {
+			return 3;
+		}
+	}
+
 	static void print(MidiMessage msg) {
 #if defined(MIDIDEBUG)
 		using enum MidiCommand;

--- a/firmware/vcv_plugin/export/src/midi_input_queue.cpp
+++ b/firmware/vcv_plugin/export/src/midi_input_queue.cpp
@@ -27,10 +27,14 @@ void InputQueue::onMessage(const Message &message) {
 }
 
 bool InputQueue::tryPop(rack::midi::Message *messageOut, int64_t maxFrame) {
+	if (!messageOut)
+		return false;
+
 	if (auto msg = internal->queue.get()) {
 		// Convert to rack::midi::Message
 		if (msg->status & 0x80) { // status byte
 			if (channel < 0 || (channel == msg->status.channel)) {
+				messageOut->setSize(msg->message_size());
 				messageOut->bytes[0] = msg->status;
 				messageOut->bytes[1] = msg->data.byte[0];
 				messageOut->bytes[2] = msg->data.byte[1];

--- a/firmware/vcv_plugin/export/src/midi_message.cc
+++ b/firmware/vcv_plugin/export/src/midi_message.cc
@@ -83,6 +83,11 @@ std::string toPrettyMultilineString(std::span<uint8_t, 3> bytes) {
 		s = "Stop";
 	}
 
+	else if (msg.is_system_realtime<TimingClock>())
+	{
+		// Do not print clock
+	}
+
 	else
 	{
 		// s += std::to_string(bytes[0]) + " " + std::to_string(bytes[1]) + "\n" + std::to_string(bytes[2]);


### PR DESCRIPTION
Fixes Rack MIDI messages not always having their size set (would sometimes be 0 even if the message really was 3).

Also cleans up the History screen on the MIDI_CV module