### PR TITLE
Snap fixes

### DIFF
--- a/firmware/vcv_plugin/export/src/plugin/Model.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Model.cpp
@@ -26,9 +26,13 @@ void Model::move_strings() {
 				   element);
 
 		std::visit(overloaded{[](BaseElement &el) {},
-							  [this](Knob &el) {
+							  [this](Pot &el) {
 								  el.units = strings.emplace_back(el.units);
+							  }},
+				   element);
 
+		std::visit(overloaded{[](BaseElement &el) {},
+							  [this](Knob &el) {
 								  for (auto &pos_name : el.pos_names) {
 									  pos_name = strings.emplace_back(pos_name);
 								  }


### PR DESCRIPTION
Minor fixes to knob labeling:
- If a knob has a labeled position for the current value, then that should be used for the display value. This fixes Interzone LFO Wave knob, for example, which has a custom min/max range and also position labels.

- Unit strings were not always stored in the Model properly.