### PR TITLE
Fix snapped knobs, part 2

### DIFF
--- a/firmware/src/gui/pages/manual_control_popup.hh
+++ b/firmware/src/gui/pages/manual_control_popup.hh
@@ -111,19 +111,20 @@ private:
 					   },
 
 					   [this](const Knob &pot) {
-						   if (pot.num_pos > 0) {
+						   float cur_value = lv_arc_get_value(ui_ControlArc);
+						   auto cur_arc_range = lv_arc_get_max_value(ui_ControlArc);
+						   arc_range_idx = (arc_range_idx + 1) % arc_range_value.size();
+
+						   set_continuous_range(pot);
+
+						   auto new_arc_range = lv_arc_get_max_value(ui_ControlArc);
+						   lv_arc_set_value(ui_ControlArc,
+											std::round(cur_value / (float)cur_arc_range * (float)new_arc_range));
+					   },
+
+					   [this](const KnobSnapped &pot) {
+						   if (pot.num_pos > 0)
 							   increment_value();
-						   } else {
-							   float cur_value = lv_arc_get_value(ui_ControlArc);
-							   auto cur_arc_range = lv_arc_get_max_value(ui_ControlArc);
-							   arc_range_idx = (arc_range_idx + 1) % arc_range_value.size();
-
-							   set_continuous_range(pot);
-
-							   auto new_arc_range = lv_arc_get_max_value(ui_ControlArc);
-							   lv_arc_set_value(ui_ControlArc,
-												std::round(cur_value / (float)cur_arc_range * (float)new_arc_range));
-						   }
 					   },
 
 					   // switches: increment value, wrapping
@@ -175,8 +176,9 @@ private:
 		std::visit(overloaded{
 					   [](const BaseElement &) {},
 					   [](const ParamElement &) { lv_arc_set_range(ui_ControlArc, 0, 100); },
-					   [this](const Knob &knob) { set_knob_range(knob); },
+					   [this](const Knob &knob) { set_continuous_range(knob); },
 					   [this](const Slider &slider) { set_continuous_range(slider); },
+					   [this](const KnobSnapped &knob) { set_snapped_range(knob); },
 					   [](const Button &el) { lv_arc_set_range(ui_ControlArc, 0, 1); },
 					   [](const FlipSwitch &el) { lv_arc_set_range(ui_ControlArc, 0, el.num_pos - 1); },
 					   [](const SlideSwitch &el) { lv_arc_set_range(ui_ControlArc, 1, el.num_pos); },
@@ -203,7 +205,7 @@ private:
 		}
 	}
 
-	void set_knob_range(Knob const &knob) {
+	void set_snapped_range(KnobSnapped const &knob) {
 		if (knob.num_pos > 0) {
 			lv_arc_set_range(ui_ControlArc, knob.min_value, knob.max_value);
 			hide_resolution_text();

--- a/firmware/vcv_plugin/export/src/plugin/Model.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Model.cpp
@@ -32,7 +32,7 @@ void Model::move_strings() {
 				   element);
 
 		std::visit(overloaded{[](BaseElement &el) {},
-							  [this](Knob &el) {
+							  [this](KnobSnapped &el) {
 								  for (auto &pos_name : el.pos_names) {
 									  pos_name = strings.emplace_back(pos_name);
 								  }

--- a/firmware/vcv_plugin/internal/make_element.cc
+++ b/firmware/vcv_plugin/internal/make_element.cc
@@ -2,6 +2,7 @@
 #include "CoreModules/elements/base_element.hh"
 #include "CoreModules/elements/units.hh"
 #include "console/pr_dbg.hh"
+#include "util/overloaded.hh"
 #include <concepts>
 
 namespace MetaModule
@@ -103,29 +104,31 @@ static void set_pot_display_params(Pot &element, rack::app::ParamWidget *widget)
 	}
 }
 
-static Knob create_base_knob(rack::app::Knob *widget) {
-	Knob element{};
-	element.default_value = getScaledDefaultValue(widget);
-	element.min_angle = radians_to_degrees(widget->minAngle);
-	element.max_angle = radians_to_degrees(widget->maxAngle);
+static Element create_base_knob(rack::app::Knob *widget) {
+	Knob knob{};
+	knob.default_value = getScaledDefaultValue(widget);
+	knob.min_angle = radians_to_degrees(widget->minAngle);
+	knob.max_angle = radians_to_degrees(widget->maxAngle);
 
-	set_pot_display_params(element, widget);
+	set_pot_display_params(knob, widget);
 
 	if (auto pq = widget->getParamQuantity(); pq && pq->snapEnabled) {
-		element.num_pos = pq->maxValue - pq->minValue + 1;
+		KnobSnapped snapped_knob{knob};
+		snapped_knob.num_pos = pq->maxValue - pq->minValue + 1;
 
-		auto clamped_num_pos = std::min<size_t>(pq->labels.size(), element.pos_names.size());
+		auto clamped_num_pos = std::min<size_t>(pq->labels.size(), snapped_knob.pos_names.size());
 
 		if (clamped_num_pos < pq->labels.size()) {
 			pr_warn("Warning: Snapped knob has %u labels, but only %u were used\n", pq->labels.size(), clamped_num_pos);
 		}
 
 		for (auto i = 0u; i < clamped_num_pos; i++) {
-			element.pos_names[i] = pq->labels[i];
+			snapped_knob.pos_names[i] = pq->labels[i];
 		}
+		return snapped_knob;
 	}
 
-	return element;
+	return knob;
 }
 
 Element make_element(rack::app::Knob *widget) {
@@ -134,13 +137,21 @@ Element make_element(rack::app::Knob *widget) {
 	return create_base_knob(widget);
 }
 
+void set_image(Element &element, std::string_view image) {
+	std::visit(overloaded{[](BaseElement &) {},
+						  [image](ImageElement &el) {
+							  el.image = image;
+						  }},
+			   element);
+}
+
 Element make_element(rack::componentlibrary::Rogan *widget) {
 	log_make_element("Rogan", widget->paramId);
 
-	Knob element = create_base_knob(widget);
+	Element element = create_base_knob(widget);
 
 	if (widget->sw->svg->filename().size()) {
-		element.image = widget->sw->svg->filename();
+		set_image(element, widget->sw->svg->filename());
 
 	} else {
 		pr_err("make_element(Rogan): No svg was set\n");
@@ -152,7 +163,7 @@ Element make_element(rack::componentlibrary::Rogan *widget) {
 Element make_element(rack::app::SvgKnob *widget) {
 	log_make_element("SvgKnob", widget->paramId);
 
-	Knob element = create_base_knob(widget);
+	Element element = create_base_knob(widget);
 
 	// Hack to support BefacoTinyKnobs:
 	// The main SVG is just the dot, either BefacoTinyPointWhite or BefacoTinyPointBlack.
@@ -179,12 +190,12 @@ Element make_element(rack::app::SvgKnob *widget) {
 
 	if (auto inner_img = find_inner_svg_widget(widget->fb); inner_img.size() > 0) {
 		log_make_element_notes("...found SvgWidget child of fb with an SVG %s\n", inner_img.data());
-		element.image = inner_img;
+		set_image(element, inner_img);
 
 	} else if (widget->sw->svg->filename().size() && widget->sw->box.size.isFinite() && !widget->sw->box.size.isZero())
 	{
 		log_make_element_notes("...use sw->svg %s\n", widget->sw->svg->filename().data());
-		element.image = widget->sw->svg->filename();
+		set_image(element, widget->sw->svg->filename());
 
 	} else {
 		pr_trace("SvgKnob with no sw->svg or inner child of fb at %f, %f\n", widget->box.pos.x, widget->box.pos.y);


### PR DESCRIPTION
This fixes another edge case in the API change. Airwindows could crash since it does not initialize the new fields.
Adding a new Element variant type fixes this because the fields won't be accessed unless the new variant index is set.

SDK Api bumped up to v2.0.3