### PR TITLE
Fix MIDI for NI and other controllers

### DIFF
--- a/firmware/lib/stm32-usb-host-lib/Core/Src/usbh_core.c
+++ b/firmware/lib/stm32-usb-host-lib/Core/Src/usbh_core.c
@@ -711,19 +711,30 @@ USBH_StatusTypeDef USBH_Process(USBH_HandleTypeDef *phost)
           {
             continue;
           }
-			
-          USBH_UsrLog("Looking for classcode %x (%.16s)", phost->pClass[idx]->ClassCode, phost->pClass[idx]->Name);
+
+          USBH_UsrLog("Looking for classcode 0x%x (%.16s)", phost->pClass[idx]->ClassCode, phost->pClass[idx]->Name);
           for (unsigned itf = 0U; itf < phost->device.CfgDesc.bNumInterfaces; itf++)
           {
-			USBH_UsrLog("Found interface with %x classcode", phost->device.CfgDesc.Itf_Desc[itf].bInterfaceClass);
-			// TODO: keep a user preference table of phost->device.DevDesc.idVendor, idDevice and which itf to choose
-			// Double-check the chosen itf matches, otherwise fall back to picking the first one
-			// Also report back to A7 all the matching itf found
-            if (phost->pClass[idx]->ClassCode == phost->device.CfgDesc.Itf_Desc[itf].bInterfaceClass)
+            USBH_InterfaceDescTypeDef *interface = &phost->device.CfgDesc.Itf_Desc[itf]; 
+
+            // TODO: keep a user preference table of phost->device.DevDesc.idVendor, idDevice and which itf to choose
+            // Double-check the chosen itf matches, otherwise fall back to picking the first one
+            // Also report back to A7 all the matching itf found
+
+            if (phost->pClass[idx]->ClassCode == interface->bInterfaceClass)
             {
-			  if (phost->pActiveClass == NULL)
-				  phost->pActiveClass = phost->pClass[idx];
-              // break; // DEBUG: don't break on the first one found
+              USBH_UsrLog("Found interface #%u with same classcode, and %u endpoints", itf, interface->bNumEndpoints);
+              if (interface->bNumEndpoints > 0)
+              {
+                if (phost->pActiveClass == NULL)
+                  phost->pActiveClass = phost->pClass[idx];
+                  // break; // DEBUG: don't break on the first one found
+                else 
+                {
+                  USBH_UsrLog("Found multiple interfaces of classes we can host, with > 0 endpoints. Picked the first one");
+                  // phost->pActiveClass = phost->pClass[idx];
+                }
+              }
             }
           }
         }

--- a/firmware/lib/stm32-usb-host-lib/Core/Src/usbh_ctlreq.c
+++ b/firmware/lib/stm32-usb-host-lib/Core/Src/usbh_ctlreq.c
@@ -160,8 +160,6 @@ USBH_StatusTypeDef USBH_Get_CfgDesc(USBH_HandleTypeDef *phost, uint16_t length)
         status = USBH_ParseCfgDesc(phost, pData, length, PARSE_CFGDESC_NORMAL);
       }
 	}
-
-	USBH_UsrLog("Configuration parsing complete. status = %u", status);
   }
 
   return status;
@@ -496,7 +494,7 @@ static USBH_StatusTypeDef USBH_ParseCfgDesc(USBH_HandleTypeDef *phost, uint8_t *
 
         pif = &cfg_desc->Itf_Desc[if_ix];
         USBH_ParseInterfaceDesc(pif, (uint8_t *)(void *)pdesc);
-		USBH_UsrLog("Found interface %u: class %u, sub-class %u, protocol %u, endpts %u", 
+		USBH_DbgLog("Found interface %u: class %u, sub-class %u, protocol %u, endpts %u", 
 				if_ix, pif->bInterfaceClass, pif->bInterfaceSubClass, pif->bInterfaceProtocol, pif->bNumEndpoints);
 
         ep_ix = 0U;
@@ -506,10 +504,8 @@ static USBH_StatusTypeDef USBH_ParseCfgDesc(USBH_HandleTypeDef *phost, uint8_t *
         {
           pdesc = USBH_GetNextDesc((uint8_t *)(void *)pdesc, &ptr);
 
-		  USBH_UsrLog("Found descriptor type %u (5=EP), len %u", pdesc->bDescriptorType, pdesc->bLength);
-
 		  if (pdesc->bLength == 0) {
-			  USBH_UsrLog("Descriptor invalid (length 0), aborting");
+			  USBH_DbgLog("Descriptor invalid (length 0), aborting");
 			  break;
 		  }
 
@@ -523,7 +519,7 @@ static USBH_StatusTypeDef USBH_ParseCfgDesc(USBH_HandleTypeDef *phost, uint8_t *
               /* Check if it is supporting the USB AUDIO 01 class specification */
               if ((pif->bInterfaceProtocol == 0x00U) && (pdesc->bLength != 0x09U) && (pdesc->bLength != 0x07U))
               {
-				USBH_ErrLog("Setting audio streaming subclass length to 9 (was %d) for ep %d\n", pdesc->bLength, ep_ix);
+				USBH_UsrLog("Setting audio streaming subclass length to 9 (was %d) for ep %d\n", pdesc->bLength, ep_ix);
                 pdesc->bLength = 0x09U;
               }
             }

--- a/firmware/lib/stm32-usb-host-lib/Core/Src/usbh_ctlreq.c
+++ b/firmware/lib/stm32-usb-host-lib/Core/Src/usbh_ctlreq.c
@@ -496,6 +496,8 @@ static USBH_StatusTypeDef USBH_ParseCfgDesc(USBH_HandleTypeDef *phost, uint8_t *
 
         pif = &cfg_desc->Itf_Desc[if_ix];
         USBH_ParseInterfaceDesc(pif, (uint8_t *)(void *)pdesc);
+		USBH_UsrLog("Found interface %u: class %u, sub-class %u, protocol %u, endpts %u", 
+				if_ix, pif->bInterfaceClass, pif->bInterfaceSubClass, pif->bInterfaceProtocol, pif->bNumEndpoints);
 
         ep_ix = 0U;
         pep = (USBH_EpDescTypeDef *)NULL;
@@ -504,18 +506,22 @@ static USBH_StatusTypeDef USBH_ParseCfgDesc(USBH_HandleTypeDef *phost, uint8_t *
         {
           pdesc = USBH_GetNextDesc((uint8_t *)(void *)pdesc, &ptr);
 
+		  USBH_UsrLog("Found descriptor type %u (5=EP), len %u", pdesc->bDescriptorType, pdesc->bLength);
+
 		  if (pdesc->bLength == 0) {
 			  USBH_UsrLog("Descriptor invalid (length 0), aborting");
 			  break;
 		  }
+
           if (pdesc->bDescriptorType == USB_DESC_TYPE_ENDPOINT)
           {
+
             /* Check if the endpoint is appartening to an audio streaming interface */
             if (fix_audio_subclass_length && (pif->bInterfaceClass == 0x01U) &&
                 ((pif->bInterfaceSubClass == 0x02U) || (pif->bInterfaceSubClass == 0x03U)))
             {
               /* Check if it is supporting the USB AUDIO 01 class specification */
-              if ((pif->bInterfaceProtocol == 0x00U) && (pdesc->bLength != 0x09U))
+              if ((pif->bInterfaceProtocol == 0x00U) && (pdesc->bLength != 0x09U) && (pdesc->bLength != 0x07U))
               {
 				USBH_ErrLog("Setting audio streaming subclass length to 9 (was %d) for ep %d\n", pdesc->bLength, ep_ix);
                 pdesc->bLength = 0x09U;

--- a/firmware/src/usb/usb_host_helper.hh
+++ b/firmware/src/usb/usb_host_helper.hh
@@ -11,9 +11,9 @@
 #include "usbh_core.h"
 
 struct EndPoint {
-	uint8_t addr;
-	uint8_t size;
-	uint8_t pipe;
+	uint16_t addr;
+	uint16_t size;
+	uint16_t pipe;
 };
 
 enum class EndPointType : uint8_t {

--- a/firmware/src/usb/usbh_midi.cc
+++ b/firmware/src/usb/usbh_midi.cc
@@ -24,6 +24,7 @@
  */
 
 #include "usbh_midi.hh"
+#include "usbh_midi_jacks.hh"
 
 static void MIDI_ProcessTransmission(USBH_HandleTypeDef *phost);
 static void MIDI_ProcessReception(USBH_HandleTypeDef *phost);
@@ -75,6 +76,9 @@ USBH_StatusTypeDef USBH_MIDI_InterfaceInit(USBH_HandleTypeDef *phost)
 	if (status != USBH_OK)
 		return USBH_FAIL;
 
+	// Print info about class-specific descriptors
+	// Here is where we could store the various jacks found
+	// scan_all_descriptors(phost);
 	if (host.is_in_ep(interface, 0))
 		host.link_endpoint_pipe(MSHandle->DataItf.InEP, interface, 0);
 	else

--- a/firmware/src/usb/usbh_midi_jacks.cc
+++ b/firmware/src/usb/usbh_midi_jacks.cc
@@ -1,0 +1,176 @@
+#include "usbh_ctlreq.h"
+#include "usbh_def.h"
+#include <cstdint>
+
+// TODO: Make these functions store useful information about
+// the MIDI topology (possibly letting the user choose a different
+// endpoint/jack combo.
+//
+// Right now these functions just print detailed info about the
+// descriptors found.
+
+constexpr uint16_t as_le_u16(uint16_t x) {
+	// reinterpret_cast of midi bytes works as-is on cortex-a7
+	return x;
+	// on some other system, perhaps this is needed?
+	// return (x << 8) | (x >> 8);
+}
+
+void parse_audiocontrol_itf_desc(USBH_DescHeader_t const *pdesc) {
+	struct __attribute__((packed)) AudioControlInterfaceDescriptor {
+		uint8_t len;
+		uint8_t type;
+		uint8_t subtype;
+		uint16_t class_revision;
+		uint16_t class_specific_desc_total_size;
+		uint8_t num_midi_itfs;
+		uint8_t our_midi_itf_id;
+	};
+
+	auto *d = reinterpret_cast<AudioControlInterfaceDescriptor const *>(pdesc);
+
+	printf("AudioControl interface (len %u, expected %zu): ", d->len, sizeof(AudioControlInterfaceDescriptor));
+	printf("class_revision: %u\n", as_le_u16(d->class_revision));
+	printf("class_specific_desc_total_size: %u\n", as_le_u16(d->class_specific_desc_total_size));
+	printf("num_midi_itfs: %u\n", d->num_midi_itfs);
+	printf("our_midi_itf_id: %u\n", d->our_midi_itf_id);
+	printf("\n");
+}
+
+void parse_midistream_itf_desc(USBH_DescHeader_t const *pdesc) {
+	struct __attribute__((packed)) MidiStreamInterfaceDescriptor {
+		uint8_t len;
+		uint8_t type;
+		uint8_t subtype;
+		uint16_t class_revision;
+		uint16_t class_specific_desc_total_size;
+	};
+	auto *d = reinterpret_cast<MidiStreamInterfaceDescriptor const *>(pdesc);
+
+	printf("MidiStreaming interface (len %u, expected %zu): ", d->len, sizeof(MidiStreamInterfaceDescriptor));
+	printf("class_revision: %u\n", as_le_u16(d->class_revision));
+	printf("class_specific_desc_total_size: %u\n", as_le_u16(d->class_specific_desc_total_size));
+	printf("\n");
+}
+
+void parse_midistream_injack_desc(USBH_DescHeader_t const *pdesc) {
+	struct __attribute__((packed)) MidiInJackDescriptor {
+		uint8_t len;
+		uint8_t type;
+		uint8_t subtype;
+		enum class JackType : uint8_t { Embedded = 1, External = 2 };
+		JackType jack_type;
+		uint8_t jack_id;
+		uint8_t jack_string_idx;
+	};
+	auto *d = reinterpret_cast<MidiInJackDescriptor const *>(pdesc);
+
+	printf("MidiInJackDescriptor interface (len %u, expected %zu): ", d->len, sizeof(MidiInJackDescriptor));
+	printf("jack_type: %u (emb=1, ext=2)\n", d->jack_type);
+	printf("jack_id: %u\n", d->jack_id);
+	printf("jack_string_idx: %u\n", d->jack_string_idx);
+	printf("\n");
+}
+
+void parse_midistream_outjack_desc(USBH_DescHeader_t const *pdesc) {
+	struct __attribute__((packed)) MidiOutJackDescriptor {
+		uint8_t len;
+		uint8_t type;
+		uint8_t subtype;
+		enum class JackType : uint8_t { Embedded = 1, External = 2 };
+		JackType jack_type;
+		uint8_t jack_id;
+		uint8_t num_input_pins;
+		uint8_t connected_to_entity_id;
+		uint8_t connected_to_entity_pin;
+		uint8_t jack_string_idx;
+	};
+	auto *d = reinterpret_cast<MidiOutJackDescriptor const *>(pdesc);
+
+	printf("MidiOutJackDescriptor interface (len %u, expected %zu): ", d->len, sizeof(MidiOutJackDescriptor));
+	printf("jack_type: %u (emb=1, ext=2)\n", d->jack_type);
+	printf("jack_id: %u\n", d->jack_id);
+	printf("num_input_pins: %u\n", d->num_input_pins);
+	printf("connected_to_entity_id: %u\n", d->connected_to_entity_id);
+	printf("connected_to_entity_pin: %u\n", d->connected_to_entity_pin);
+	printf("jack_string_idx: %u\n", d->jack_string_idx);
+	printf("\n");
+}
+
+void parse_bulk_ep_desc(USBH_DescHeader_t const *pdesc) {
+	struct __attribute__((packed)) EPDescriptor {
+		uint8_t len;
+		uint8_t type; //0x05
+		uint8_t addr;
+		uint8_t ep_type; //0x02
+		uint16_t max_packet_size;
+		uint8_t interval_ignore;
+		uint8_t refresh_ignore;
+		uint8_t sync_addr_ignore;
+	};
+	auto *d = reinterpret_cast<EPDescriptor const *>(pdesc);
+
+	printf("EPDescriptor interface (len %u, expected %zu): \n", d->len, sizeof(EPDescriptor));
+	if (d->type != 0x5 || d->ep_type != 0x2)
+		printf("Type 0x%x (expected 0x5), ep_type %u (expected 2=bulk)\n", d->type, d->ep_type);
+
+	printf("addr: %u (%s)\n", d->addr & 0x7F, (d->addr & 0x80) ? "In" : "Out");
+	printf("max_packet_size: %u\n", d->max_packet_size);
+	printf("\n");
+}
+
+void parse_midistream_cs_bulk_ep_desc(USBH_DescHeader_t const *pdesc) {
+	struct __attribute__((packed)) MidiEPDescriptor {
+		uint8_t len;
+		uint8_t type;	 //0x25
+		uint8_t subtype; //1
+		uint8_t num_embedded_midi_in_jacks;
+		uint8_t associated_jack_id[];
+	};
+	auto *d = reinterpret_cast<MidiEPDescriptor const *>(pdesc);
+
+	printf("MidiEPDescriptor interface (len %u, min 5): \n", d->len);
+	if (d->type != 0x25 || d->subtype != 0x1)
+		printf("Type 0x%x (expected 0x25), subtype %u (expected 1)\n", d->type, d->subtype);
+	printf("num_embedded_midi_in_jacks: %u\n", d->num_embedded_midi_in_jacks);
+	for (auto i = 0u; i < d->num_embedded_midi_in_jacks; i++)
+		printf("associated_jack_id %u: %u\n", i, d->associated_jack_id[i]);
+	printf("\n");
+}
+
+void scan_all_descriptors(USBH_HandleTypeDef const *phost) {
+	unsigned desc_total_length = phost->device.CfgDesc.wTotalLength;
+	auto *pdesc = reinterpret_cast<USBH_DescHeader_t const *>(phost->device.CfgDesc_Raw);
+	uint16_t ptr = USB_LEN_CFG_DESC;
+
+	while (ptr < desc_total_length) {
+		pdesc = USBH_GetNextDesc((uint8_t *)(void *)pdesc, &ptr);
+
+		printf("desc: len %u, type 0x%x (ptr=%u): ", pdesc->bLength, pdesc->bDescriptorType, ptr);
+		for (unsigned i = 0; i < pdesc->bLength; i++) {
+			printf("%02x ", (unsigned)*((uint8_t *)(pdesc) + i));
+		}
+		printf("\n");
+
+		if (pdesc->bDescriptorType == 0x24) //Class-specific descriptor
+		{
+			uint8_t subtype = ((uint8_t *)pdesc)[2];
+			if (subtype == 1) { //MS_HEADER
+				if (pdesc->bLength == 0x9)
+					parse_audiocontrol_itf_desc(pdesc);
+				else
+					parse_midistream_itf_desc(pdesc);
+			} else if (subtype == 0x02) {
+				parse_midistream_injack_desc(pdesc);
+			} else if (subtype == 0x03) {
+				parse_midistream_outjack_desc(pdesc);
+			}
+
+		} else if (pdesc->bDescriptorType == 0x25) { //Class-specific endpoint desc
+			parse_midistream_cs_bulk_ep_desc(pdesc);
+
+		} else if (pdesc->bDescriptorType == 0x5) { //Standard endpoint desc
+			parse_bulk_ep_desc(pdesc);
+		}
+	}
+}

--- a/firmware/src/usb/usbh_midi_jacks.hh
+++ b/firmware/src/usb/usbh_midi_jacks.hh
@@ -1,0 +1,21 @@
+#pragma once
+#include "usbh_def.h"
+
+void parse_midistream_itf_desc(USBH_DescHeader_t const *pdesc);
+void parse_midistream_injack_desc(USBH_DescHeader_t const *pdesc);
+void parse_midistream_outjack_desc(USBH_DescHeader_t const *pdesc);
+void parse_bulk_ep_desc(USBH_DescHeader_t const *pdesc);
+void parse_midistream_cs_bulk_ep_desc(USBH_DescHeader_t const *pdesc);
+void scan_all_descriptors(USBH_HandleTypeDef const *phost);
+
+// Notes of MIDI devices with multiple "ports":
+// One MIDI device might have multiple MIDI Out Jacks or In Jacks.
+// Each Jack has a MIDIIn/OutJackDescriptor, which provides the jack_id and
+// a string index for the name.
+// When a controller is used on a computer, the app will display these jacks names, e.g.
+// "Kontrol DAW", "Kontrol Main", "Kontrol Ext."
+//
+// We should collect the names and jack IDs, and store that in the MIDI class handle.
+// Then the GUI could allow the user to display, browse, and choose a Jack.
+//
+// TODO: figure out how to change jacks? It seems like they all have the same endpoint addr?

--- a/firmware/vcv_plugin/export/src/module_widget_adaptor.hh
+++ b/firmware/vcv_plugin/export/src/module_widget_adaptor.hh
@@ -222,19 +222,11 @@ struct ModuleWidgetAdaptor {
 			Element element = DynamicGraphicDisplay{};
 
 			if (widget->box.size.y > 400 || widget->box.size.y == 0) {
-				pr_trace("Widget graph_disp_idx %d @ %f box size y invalid: %f. Fix=>%f - @\n",
-						 graphic_display_idx,
-						 widget->box.pos.y,
-						 widget->box.size.y,
-						 widget->parent->box.size.y);
+				pr_trace("Widget graph_disp_idx %d box size.y invalid: %f\n", graphic_display_idx, widget->box.size.y);
 				widget->box.size.y = widget->parent->box.size.y - widget->box.pos.y;
 			}
 			if (widget->box.size.x > 400 || widget->box.size.x == 0) {
-				pr_trace("Widget graph_disp_idx %d @ %f box size x invalid: %f. Fix=>%f - @\n",
-						 graphic_display_idx,
-						 widget->box.pos.x,
-						 widget->box.size.x,
-						 widget->parent->box.size.x);
+				pr_trace("Widget graph_disp_idx %d box size.x invalid: %f\n", graphic_display_idx, widget->box.size.x);
 				widget->box.size.x = widget->parent->box.size.x - widget->box.pos.x;
 			}
 


### PR DESCRIPTION
This provides a fix for USB MIDI devices with vendor ID of Native Instruments, by not attempting to correct non-standard descriptor lengths. It also is more immune to crashing when encountering non-standard descriptors.
This also fixes a bug in the MM firmware that ignored MIDI from devices with large endpoint transfer sizes (>=256 bytes). 