### PR TITLE
Use hand-rolled SequentialMap for MidiSync

### DIFF
--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -194,6 +194,7 @@ void AudioStream::handle_patch_just_loaded() {
 }
 
 void AudioStream::process(CombinedAudioBlock &audio_block, ParamBlock &param_block) {
+	player.sync();
 	handle_patch_mod_queue();
 
 	param_block.metaparams.midi_poly_chans = player.get_midi_poly_num();
@@ -287,6 +288,7 @@ void AudioStream::process(CombinedAudioBlock &audio_block, ParamBlock &param_blo
 }
 
 void AudioStream::process_nopatch(CombinedAudioBlock &audio_block, ParamBlock &param_block) {
+	player.sync();
 	param_state.jack_senses = param_block.metaparams.jack_senses;
 
 	for (auto idx = 0u; auto const &in : audio_block.in_codec) {

--- a/firmware/src/core_a7/aux_core_player.hh
+++ b/firmware/src/core_a7/aux_core_player.hh
@@ -1,12 +1,12 @@
 #pragma once
-#include "midi.hpp"
-#include "midi/midi_queue.hh"
-#include "midi/midi_router.hh"
-#include "midi/midi_sync.hh"
 #include "core_a7/smp_api.hh"
 #include "drivers/interrupt.hh"
 #include "drivers/smp.hh"
 #include "gui/ui.hh"
+#include "midi.hpp"
+#include "midi/midi_queue.hh"
+#include "midi/midi_router.hh"
+#include "midi/midi_sync.hh"
 #include "patch_play/patch_player.hh"
 #include "util/fixed_vector.hh"
 #include <atomic>
@@ -20,7 +20,7 @@ struct AuxPlayer {
 
 	FixedVector<unsigned, 64> module_ids;
 	unsigned midi_throttle_counter = 0;
-	
+
 	// MIDI sync instance
 	MidiSync midi_sync;
 
@@ -88,12 +88,15 @@ struct AuxPlayer {
 				}
 			}
 
+			Debug::Pin0::high();
 			for (auto &p : patch_player.watched_params().active_watched_params()) {
 				if (p.is_active()) {
 					auto value = patch_player.get_param(p.module_id, p.param_id);
 					auto map = MappedKnob{.panel_knob_id = p.panel_knob_id};
 					if (map.is_midi_cc()) {
+						Debug::Pin1::high();
 						midi_sync.sync_param_to_midi(value, p.midi_chan, map.cc_num());
+						Debug::Pin1::low();
 					} else if (map.is_midi_notegate()) {
 						midi_sync.sync_param_to_midi_notegate(value, p.midi_chan, map.notegate_num());
 					} else if (p.panel_knob_id == MidiPitchWheelJack) {
@@ -101,6 +104,7 @@ struct AuxPlayer {
 					}
 				}
 			}
+			Debug::Pin0::low();
 
 			ui.new_patch_data.store(true, std::memory_order_release);
 		}

--- a/firmware/src/midi/midi_sync.hh
+++ b/firmware/src/midi/midi_sync.hh
@@ -2,11 +2,10 @@
 #include "midi_message.hh"
 #include "midi_queue.hh"
 #include "midi_router.hh"
-#include <cstdint>
+#include "util/sequential_map.hh"
 #include <algorithm>
 #include <array>
-#include <optional>
-#include <unordered_map>
+#include <cstdint>
 #include <utility>
 
 namespace MetaModule
@@ -14,141 +13,122 @@ namespace MetaModule
 
 class MidiSync {
 private:
-    MidiQueue midi_out_queue;
-    bool queue_subscribed = false;
-    
-    // Store last sent values by channel and CC number
-    // Key: pair of (midi_chan, cc_num), Value: last sent CC value
-    using SyncKey = std::pair<uint8_t, uint8_t>;
-    
-    // Fixed-size arrays for CC and note gate tracking
-    struct CCValue {
-        std::optional<SyncKey> key;
-        uint8_t value;
-    };
-    std::array<CCValue, 128> cc_values;
-    
-    struct NoteGateValue {
-        std::optional<SyncKey> key;
-        bool value;
-    };
-    std::array<NoteGateValue, 128> note_gate_values;
+	MidiQueue midi_out_queue;
+	bool queue_subscribed = false;
 
-    struct PitchWheelValue {
-        std::optional<uint8_t> key;
-        uint16_t value;  // Changed to uint16_t for 14-bit resolution
-    };
-    std::array<PitchWheelValue, 16> pitchwheel_values;
+	// Store last sent values by channel and CC number
+	// Key: pair of (midi_chan, cc_num), Value: last sent CC value
+	using SyncKey = std::pair<uint8_t, uint8_t>;
+
+	// Map [CCnum, channel] -> 7-bit value
+	SequentialMap<SyncKey, uint8_t, 128> cc_values;
+
+	// Map [note, channel] -> on/off
+	SequentialMap<SyncKey, bool, 128> note_gate_values;
+
+	// Map channel -> pitchwheel
+	SequentialMap<uint8_t, uint16_t, 16> pitchwheel_values;
 
 public:
-    MidiSync() {
-        if (!queue_subscribed) {
-            MetaModule::MidiRouter::subscribe_tx(&midi_out_queue);
-            queue_subscribed = true;
-        }
-        // Initialize arrays
-        cc_values.fill({std::nullopt, 0});
-        note_gate_values.fill({std::nullopt, false});
-        pitchwheel_values.fill({std::nullopt, 8192});  // Center position (0x2000)
-    }
+	MidiSync() {
+		if (!queue_subscribed) {
+			MetaModule::MidiRouter::subscribe_tx(&midi_out_queue);
+			queue_subscribed = true;
+		}
+	}
 
-    ~MidiSync() {
-        if (queue_subscribed) {
-            MetaModule::MidiRouter::unsubscribe_tx(&midi_out_queue);
-        }
-    }
-    
-    // Clear all stored last values
-    void clear_last_values() {
-        cc_values.fill({std::nullopt, 0});
-        note_gate_values.fill({std::nullopt, false});
-    }
-    
-    // Send MIDI CC message for parameter value change
-    // Only sends if the value has changed from last time
-    void sync_param_to_midi(float value, uint8_t midi_chan, uint8_t cc_num) {
-        if (cc_num >= 128) return;
-        
-        uint8_t cc_value = std::clamp(static_cast<int>(value * 127.0f), 0, 127);
-        
-        auto& cc_val = cc_values[cc_num];
-        bool should_send = !cc_val.key.has_value() || 
-                          cc_val.key->first != midi_chan || 
-                          cc_val.value != cc_value;
-        
-        if (should_send) {
-            MidiMessage cc_msg;
-            cc_msg.status = MidiStatusByte{MidiCommand::ControlChange, midi_chan};
-            cc_msg.data.byte[0] = cc_num;
-            cc_msg.data.byte[1] = cc_value;
-            
-            midi_out_queue.put(cc_msg);
-            
-            // Update stored value
-            cc_val.key = SyncKey(midi_chan, cc_num);
-            cc_val.value = cc_value;
-        }
-    }
+	~MidiSync() {
+		if (queue_subscribed) {
+			MetaModule::MidiRouter::unsubscribe_tx(&midi_out_queue);
+		}
+	}
 
-    void sync_param_to_midi_notegate(float value, uint8_t midi_chan, uint8_t note_num) {
-        if (midi_chan >= 16 || note_num >= 128) {
-            return;
-        }   
+	// Clear all stored last values
+	void clear_last_values() {
+		cc_values.clear();
+		note_gate_values.clear();
+		pitchwheel_values.clear();
+	}
 
-        bool gate_on = value > 0.5f;
-        auto& note_val = note_gate_values[note_num];
-        bool should_send = !note_val.key.has_value() || 
-                          note_val.key->first != midi_chan || 
-                          note_val.value != gate_on;
-        
-        if (should_send) {
-            if (gate_on) {
-                MidiMessage note_msg;
-                note_msg.status = MidiStatusByte{MidiCommand::NoteOn, midi_chan};
-                note_msg.data.byte[0] = note_num;
-                note_msg.data.byte[1] = 127;
-                midi_out_queue.put(note_msg);
-            } else {
-                MidiMessage note_msg;
-                note_msg.status = MidiStatusByte{MidiCommand::NoteOff, midi_chan};
-                note_msg.data.byte[0] = note_num;
-                note_msg.data.byte[1] = 0;
-                midi_out_queue.put(note_msg);
-            }
-            
-            // Update stored value
-            note_val.key = SyncKey(midi_chan, note_num);
-            note_val.value = gate_on;
-        }
-    }
+	// Send MIDI CC message for parameter value change
+	// Only sends if the value has changed from last time
+	void sync_param_to_midi(float value, uint8_t midi_chan, uint8_t cc_num) {
+		if (midi_chan >= 16 || cc_num >= 128)
+			return;
 
-    void sync_param_to_midi_pitchwheel(float value, uint8_t midi_chan) {
-        if (midi_chan >= 16) return;
+		uint8_t cc_value = std::clamp(static_cast<int>(value * 127.0f), 0, 127);
 
-        // Convert float [-1.0, 1.0] to 14-bit MIDI value [0, 16383]
-        // Center position is 8192 (0x2000)
-        uint16_t pitchwheel_value = std::clamp(
-            static_cast<int>((value + 1.0f) * 8191.5f),  // Scale to 0-16383
-            0, 16383
-        );
+		SyncKey key(midi_chan, cc_num);
 
-        auto& pitch_val = pitchwheel_values[midi_chan];
-        bool should_send = !pitch_val.key.has_value() || 
-                          pitch_val.value != pitchwheel_value;
+		auto it = cc_values.find(key);
 
-        if (should_send) {
-            MidiMessage pitchwheel_msg;
-            pitchwheel_msg.status = MidiStatusByte{MidiCommand::PitchBend, midi_chan};
-            pitchwheel_msg.data.byte[0] = pitchwheel_value & 0x7F;
-            pitchwheel_msg.data.byte[1] = (pitchwheel_value >> 7) & 0x7F;
-            
-            midi_out_queue.put(pitchwheel_msg);
-            
-            // Update stored value
-            pitch_val.key = midi_chan;
-            pitch_val.value = pitchwheel_value;
-        }
-    }
+		if (it == cc_values.end() || it->second != cc_value) {
+			MidiMessage cc_msg;
+			cc_msg.status = MidiStatusByte{MidiCommand::ControlChange, midi_chan};
+			cc_msg.data.byte[0] = cc_num;
+			cc_msg.data.byte[1] = cc_value;
+
+			midi_out_queue.put(cc_msg);
+
+			// Update stored value, or create entry
+			cc_values[key] = cc_value;
+		}
+	}
+
+	void sync_param_to_midi_notegate(float value, uint8_t midi_chan, uint8_t note_num) {
+		if (midi_chan >= 16 || note_num >= 128)
+			return;
+
+		bool gate_on = value > 0.5f;
+
+		SyncKey key(midi_chan, note_num);
+
+		auto it = note_gate_values.find(key);
+
+		if (it == note_gate_values.end() || it->second != gate_on) {
+			if (gate_on) {
+				MidiMessage note_msg;
+				note_msg.status = MidiStatusByte{MidiCommand::NoteOn, midi_chan};
+				note_msg.data.byte[0] = note_num;
+				note_msg.data.byte[1] = 127;
+				midi_out_queue.put(note_msg);
+			} else {
+				MidiMessage note_msg;
+				note_msg.status = MidiStatusByte{MidiCommand::NoteOff, midi_chan};
+				note_msg.data.byte[0] = note_num;
+				note_msg.data.byte[1] = 0;
+				midi_out_queue.put(note_msg);
+			}
+
+			// Update stored value or create entry
+			note_gate_values[key] = gate_on;
+		}
+	}
+
+	void sync_param_to_midi_pitchwheel(float value, uint8_t midi_chan) {
+		if (midi_chan >= 16)
+			return;
+
+		// Convert float [-1.0, 1.0] to 14-bit MIDI value [0, 16383]
+		// Center position is 8192 (0x2000)
+		uint16_t pitchwheel_value = std::clamp(static_cast<int>((value + 1.0f) * 8191.5f), // Scale to 0-16383
+											   0,
+											   16383);
+
+		auto it = pitchwheel_values.find(midi_chan);
+
+		if (it == pitchwheel_values.end() || it->second != pitchwheel_value) {
+			MidiMessage pitchwheel_msg;
+			pitchwheel_msg.status = MidiStatusByte{MidiCommand::PitchBend, midi_chan};
+			pitchwheel_msg.data.byte[0] = pitchwheel_value & 0x7F;
+			pitchwheel_msg.data.byte[1] = (pitchwheel_value >> 7) & 0x7F;
+
+			midi_out_queue.put(pitchwheel_msg);
+
+			// Update stored value or create entry
+			pitchwheel_values[midi_chan] = pitchwheel_value;
+		}
+	}
 };
 
-} // namespace MetaModule 
+} // namespace MetaModule

--- a/firmware/src/midi/midi_sync.hh
+++ b/firmware/src/midi/midi_sync.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include "debug.hh"
 #include "midi_message.hh"
 #include "midi_queue.hh"
 #include "midi_router.hh"
@@ -63,6 +64,7 @@ public:
 		auto it = cc_values.find(key);
 
 		if (it == cc_values.end() || it->second != cc_value) {
+			Debug::Pin2::high();
 			MidiMessage cc_msg;
 			cc_msg.status = MidiStatusByte{MidiCommand::ControlChange, midi_chan};
 			cc_msg.data.byte[0] = cc_num;
@@ -72,6 +74,7 @@ public:
 
 			// Update stored value, or create entry
 			cc_values[key] = cc_value;
+			Debug::Pin2::low();
 		}
 	}
 

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -14,8 +14,8 @@
 #include "patch_play/balance_modules.hh"
 #include "patch_play/cable_cache.hh"
 #include "patch_play/multicore_play.hh"
-#include "patch_play/patch_player_query_patch.hh"
 #include "patch_play/param_watch.hh"
+#include "patch_play/patch_player_query_patch.hh"
 #include "patch_play/plugin_module.hh"
 #include "pr_dbg.hh"
 #include "result_t.hh"
@@ -313,6 +313,9 @@ public:
 
 	void trigger_reading_gui_elements() {
 		smp.read_patch_gui_elements();
+	}
+
+	void sync() {
 		smp.join();
 	}
 

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -1107,11 +1107,11 @@ public:
 
 		if (auto num = Midi::midi_note_pitch(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_pitch_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI note (poly %d) ch: %u", num.value(), chan);
+			pr_dbg("MIDI note (poly %d) ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_note_gate(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_gate_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI gate (poly %d) ch:% ch:%uu", num.value(), chan);
+			pr_dbg("MIDI gate (poly %d) ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_note_vel(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_vel_conns[num.value()], input_jack, chan);


### PR DESCRIPTION
This is an implementation that avoids dynamic allocations, and tries to be efficient about memory usage by having a limit on the number of CC's and Note-Gates that can be synced (128 each, including all channels).

It's basically @Ericxgao 's original implementation with std::unordered_map, but it uses a non-allocating SequentialMap which I made to almost conform to the std::unordered_map interface (at least the parts that we're using here).