### PR TITLE
Dg/bidirectional midi chan array

### DIFF
--- a/firmware/src/midi/midi_sync.hh
+++ b/firmware/src/midi/midi_sync.hh
@@ -2,153 +2,130 @@
 #include "midi_message.hh"
 #include "midi_queue.hh"
 #include "midi_router.hh"
-#include <cstdint>
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <optional>
-#include <unordered_map>
-#include <utility>
 
 namespace MetaModule
 {
 
 class MidiSync {
 private:
-    MidiQueue midi_out_queue;
-    bool queue_subscribed = false;
-    
-    // Store last sent values by channel and CC number
-    // Key: pair of (midi_chan, cc_num), Value: last sent CC value
-    using SyncKey = std::pair<uint8_t, uint8_t>;
-    
-    // Fixed-size arrays for CC and note gate tracking
-    struct CCValue {
-        std::optional<SyncKey> key;
-        uint8_t value;
-    };
-    std::array<CCValue, 128> cc_values;
-    
-    struct NoteGateValue {
-        std::optional<SyncKey> key;
-        bool value;
-    };
-    std::array<NoteGateValue, 128> note_gate_values;
+	MidiQueue midi_out_queue;
+	bool queue_subscribed = false;
 
-    struct PitchWheelValue {
-        std::optional<uint8_t> key;
-        uint16_t value;  // Changed to uint16_t for 14-bit resolution
-    };
-    std::array<PitchWheelValue, 16> pitchwheel_values;
+	// cc_values[midichan][ccnum]: valueless => not set, otherwise value is last value sent
+	std::array<std::array<std::optional<uint8_t>, 128>, 16> cc_values{};
+
+	// note_gate_values[midichan][note_num]
+	std::array<std::array<std::optional<uint8_t>, 128>, 16> note_gate_values{};
+
+	// pitchwheel_values[midichan]
+	std::array<std::optional<uint16_t>, 16> pitchwheel_values{};
 
 public:
-    MidiSync() {
-        if (!queue_subscribed) {
-            MetaModule::MidiRouter::subscribe_tx(&midi_out_queue);
-            queue_subscribed = true;
-        }
-        // Initialize arrays
-        cc_values.fill({std::nullopt, 0});
-        note_gate_values.fill({std::nullopt, false});
-        pitchwheel_values.fill({std::nullopt, 8192});  // Center position (0x2000)
-    }
+	MidiSync() {
+		if (!queue_subscribed) {
+			MetaModule::MidiRouter::subscribe_tx(&midi_out_queue);
+			queue_subscribed = true;
+		}
+	}
 
-    ~MidiSync() {
-        if (queue_subscribed) {
-            MetaModule::MidiRouter::unsubscribe_tx(&midi_out_queue);
-        }
-    }
-    
-    // Clear all stored last values
-    void clear_last_values() {
-        cc_values.fill({std::nullopt, 0});
-        note_gate_values.fill({std::nullopt, false});
-    }
-    
-    // Send MIDI CC message for parameter value change
-    // Only sends if the value has changed from last time
-    void sync_param_to_midi(float value, uint8_t midi_chan, uint8_t cc_num) {
-        if (cc_num >= 128) return;
-        
-        uint8_t cc_value = std::clamp(static_cast<int>(value * 127.0f), 0, 127);
-        
-        auto& cc_val = cc_values[cc_num];
-        bool should_send = !cc_val.key.has_value() || 
-                          cc_val.key->first != midi_chan || 
-                          cc_val.value != cc_value;
-        
-        if (should_send) {
-            MidiMessage cc_msg;
-            cc_msg.status = MidiStatusByte{MidiCommand::ControlChange, midi_chan};
-            cc_msg.data.byte[0] = cc_num;
-            cc_msg.data.byte[1] = cc_value;
-            
-            midi_out_queue.put(cc_msg);
-            
-            // Update stored value
-            cc_val.key = SyncKey(midi_chan, cc_num);
-            cc_val.value = cc_value;
-        }
-    }
+	~MidiSync() {
+		if (queue_subscribed) {
+			MetaModule::MidiRouter::unsubscribe_tx(&midi_out_queue);
+		}
+	}
 
-    void sync_param_to_midi_notegate(float value, uint8_t midi_chan, uint8_t note_num) {
-        if (midi_chan >= 16 || note_num >= 128) {
-            return;
-        }   
+	// Clear all stored last values
+	void clear_last_values() {
+		// Initialize arrays
+		for (auto &chan : cc_values)
+			chan.fill(std::nullopt);
 
-        bool gate_on = value > 0.5f;
-        auto& note_val = note_gate_values[note_num];
-        bool should_send = !note_val.key.has_value() || 
-                          note_val.key->first != midi_chan || 
-                          note_val.value != gate_on;
-        
-        if (should_send) {
-            if (gate_on) {
-                MidiMessage note_msg;
-                note_msg.status = MidiStatusByte{MidiCommand::NoteOn, midi_chan};
-                note_msg.data.byte[0] = note_num;
-                note_msg.data.byte[1] = 127;
-                midi_out_queue.put(note_msg);
-            } else {
-                MidiMessage note_msg;
-                note_msg.status = MidiStatusByte{MidiCommand::NoteOff, midi_chan};
-                note_msg.data.byte[0] = note_num;
-                note_msg.data.byte[1] = 0;
-                midi_out_queue.put(note_msg);
-            }
-            
-            // Update stored value
-            note_val.key = SyncKey(midi_chan, note_num);
-            note_val.value = gate_on;
-        }
-    }
+		for (auto &chan : note_gate_values)
+			chan.fill(std::nullopt);
 
-    void sync_param_to_midi_pitchwheel(float value, uint8_t midi_chan) {
-        if (midi_chan >= 16) return;
+		pitchwheel_values.fill(std::nullopt);
+	}
 
-        // Convert float [-1.0, 1.0] to 14-bit MIDI value [0, 16383]
-        // Center position is 8192 (0x2000)
-        uint16_t pitchwheel_value = std::clamp(
-            static_cast<int>((value + 1.0f) * 8191.5f),  // Scale to 0-16383
-            0, 16383
-        );
+	// Send MIDI CC message for parameter value change
+	// Only sends if the value has changed from last time
+	void sync_param_to_midi(float value, uint8_t midi_chan, uint8_t cc_num) {
+		if (midi_chan >= cc_values.size() || cc_num >= cc_values[midi_chan].size())
+			return;
 
-        auto& pitch_val = pitchwheel_values[midi_chan];
-        bool should_send = !pitch_val.key.has_value() || 
-                          pitch_val.value != pitchwheel_value;
+		uint8_t cc_value = std::clamp(static_cast<int>(value * 127.0f), 0, 127);
 
-        if (should_send) {
-            MidiMessage pitchwheel_msg;
-            pitchwheel_msg.status = MidiStatusByte{MidiCommand::PitchBend, midi_chan};
-            pitchwheel_msg.data.byte[0] = pitchwheel_value & 0x7F;
-            pitchwheel_msg.data.byte[1] = (pitchwheel_value >> 7) & 0x7F;
-            
-            midi_out_queue.put(pitchwheel_msg);
-            
-            // Update stored value
-            pitch_val.key = midi_chan;
-            pitch_val.value = pitchwheel_value;
-        }
-    }
+		auto &cc_val = cc_values[cc_num][midi_chan];
+
+		if (cc_val != cc_value) {
+			MidiMessage cc_msg;
+			cc_msg.status = MidiStatusByte{MidiCommand::ControlChange, midi_chan};
+			cc_msg.data.byte[0] = cc_num;
+			cc_msg.data.byte[1] = cc_value;
+
+			midi_out_queue.put(cc_msg);
+
+			// Update stored value
+			cc_val = cc_value;
+		}
+	}
+
+	void sync_param_to_midi_notegate(float value, uint8_t midi_chan, uint8_t note_num) {
+		if (midi_chan >= note_gate_values.size() || note_num >= note_gate_values[midi_chan].size())
+			return;
+
+		bool gate_on = value > 0.5f;
+		auto &note_val = note_gate_values[note_num][midi_chan];
+
+		if (note_val != gate_on) {
+			if (gate_on) {
+				MidiMessage note_msg;
+				note_msg.status = MidiStatusByte{MidiCommand::NoteOn, midi_chan};
+				note_msg.data.byte[0] = note_num;
+				note_msg.data.byte[1] = 127;
+				midi_out_queue.put(note_msg);
+			} else {
+				MidiMessage note_msg;
+				note_msg.status = MidiStatusByte{MidiCommand::NoteOff, midi_chan};
+				note_msg.data.byte[0] = note_num;
+				note_msg.data.byte[1] = 0;
+				midi_out_queue.put(note_msg);
+			}
+
+			// Update stored value
+			note_val = gate_on;
+		}
+	}
+
+	void sync_param_to_midi_pitchwheel(float value, uint8_t midi_chan) {
+		if (midi_chan >= 16)
+			return;
+
+		// Convert float [-1.0, 1.0] to 14-bit MIDI value [0, 16383]
+		// Center position is 8192 (0x2000)
+		uint16_t pitchwheel_value = std::clamp(static_cast<int>((value + 1.0f) * 8191.5f), // Scale to 0-16383
+											   0,
+											   16383);
+
+		auto &pitch_val = pitchwheel_values[midi_chan];
+
+		if (pitch_val != pitchwheel_value) {
+			MidiMessage pitchwheel_msg;
+			pitchwheel_msg.status = MidiStatusByte{MidiCommand::PitchBend, midi_chan};
+			pitchwheel_msg.data.byte[0] = pitchwheel_value & 0x7F;
+			pitchwheel_msg.data.byte[1] = (pitchwheel_value >> 7) & 0x7F;
+
+			midi_out_queue.put(pitchwheel_msg);
+
+			// Update stored value
+			pitch_val = pitchwheel_value;
+		}
+	}
 };
 
-} // namespace MetaModule 
+//8656
+
+} // namespace MetaModule

--- a/simulator/src/audio_stream.hh
+++ b/simulator/src/audio_stream.hh
@@ -69,6 +69,13 @@ public:
 				i++;
 			}
 
+			// MIDI output: print to console
+			{
+				if (auto msg = MidiRouter::pop_outgoing_message()) {
+					printf("MIDI TX: %06x\n", msg->raw());
+				}
+			}
+
 			// MIDI: random stream
 			{
 				static unsigned random_midi_ctr = 0;

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -110,6 +110,20 @@ void Ui::play_patch(std::span<Frame> soundcard_out) {
 		}
 	}
 
+	for (auto &p : patch_player.watched_params().active_watched_params()) {
+		if (p.is_active()) {
+			auto value = patch_player.get_param(p.module_id, p.param_id);
+			auto map = MappedKnob{.panel_knob_id = p.panel_knob_id};
+			if (map.is_midi_cc()) {
+				midi_sync.sync_param_to_midi(value, p.midi_chan, map.cc_num());
+			} else if (map.is_midi_notegate()) {
+				midi_sync.sync_param_to_midi_notegate(value, p.midi_chan, map.notegate_num());
+			} else if (p.panel_knob_id == MidiPitchWheelJack) {
+				midi_sync.sync_param_to_midi_pitchwheel(value, p.midi_chan);
+			}
+		}
+	}
+
 	for (size_t i = 0; auto &frame : out_buffer) {
 		auto &out = soundcard_out[i++];
 

--- a/simulator/src/ui.hh
+++ b/simulator/src/ui.hh
@@ -7,6 +7,7 @@
 #include "gui/pages/page_manager.hh"
 #include "internal_plugin_manager.hh"
 #include "lv_port_indev.h"
+#include "midi/midi_sync.hh"
 #include "patch_file/file_storage_proxy.hh"
 
 namespace MetaModule
@@ -51,6 +52,8 @@ private:
 	OpenPatchManager open_patches_manager;
 	PatchPlayLoader patch_playloader{file_storage_proxy, open_patches_manager, patch_player};
 	PatchModQueue patch_mod_queue;
+
+	MidiSync midi_sync;
 
 	UserSettings settings;
 	Screensaver screensaver{settings.screensaver};


### PR DESCRIPTION
Another approach to MIDI Sync, using a  2-d array for every MIDI channel and CC (or note num) combination. Each element of the array is an optional value, similar to the 1-d std::array approach.
This fixes the issue with having the same CC number mapped on different MIDI channels.

Total memory usage is a little over 8kB for the arrays (vs. a little over 1kB for the SequentialMap approach).
I haven't had a chance to profile it on hardware.