### PR TITLE
Allow widgets to be changed after ModuleWidget::addOutput/addInput/addParam/addChild

### DIFF
--- a/firmware/src/gui/pages/module_view.hh
+++ b/firmware/src/gui/pages/module_view.hh
@@ -219,7 +219,7 @@ struct ModuleViewPage : PageBase {
 
 			opts.append(" ");
 			// Display up to the first newline (if any)
-			opts.append(base.short_name.substr(0, base.short_name.find_first_of('\n')));
+			opts.append(base.short_name.substr(0, base.short_name.find_first_of("\0\n")));
 
 			if (gui_el.mapped_panel_id) {
 				append_panel_name(opts, drawn_element.element, gui_el.mapped_panel_id.value());

--- a/firmware/vcv_plugin/export/src/make_element_names.hh
+++ b/firmware/vcv_plugin/export/src/make_element_names.hh
@@ -17,7 +17,7 @@ static void remove_extended_chars(std::string &name) {
 
 inline std::string_view getParamName(rack::engine::Module *module, int id) {
 	if (auto pq = module->getParamQuantity(id)) {
-		if (pq->name.size()) {
+		if (pq->name.size() && pq->name != " ") {
 			remove_extended_chars(pq->name);
 			return pq->name;
 		} else {

--- a/firmware/vcv_plugin/export/src/module_widget_adaptor.hh
+++ b/firmware/vcv_plugin/export/src/module_widget_adaptor.hh
@@ -1,5 +1,4 @@
 #include "../../internal/make_element.hh"
-#include "CoreModules/elements/element_sort.hh"
 #include "CoreModules/elements/units.hh"
 #include "console/pr_dbg.hh"
 #include "make_element_names.hh"
@@ -12,7 +11,12 @@ struct ModuleWidgetAdaptor {
 
 	static constexpr inline bool LogWidgetNames = false;
 
-	std::vector<std::pair<MetaModule::Element, ElementCount::Indices>> elem_idx;
+	using WidgetType = std::variant<rack::app::ParamWidget *,
+									rack::app::PortWidget *,
+									rack::app::ModuleLightWidget *,
+									rack::widget::Widget *>;
+
+	std::vector<std::tuple<MetaModule::Element, ElementCount::Indices, WidgetType>> elem_idx;
 
 	std::deque<std::string> temp_names;
 
@@ -37,11 +41,10 @@ struct ModuleWidgetAdaptor {
 	{
 		if (widget) {
 			Element element = make_element(widget);
-			assign_element_fields(widget, getParamName(widget->module, widget->paramId), element);
 
 			ElementCount::Indices indices = clear();
 			indices.param_idx = widget->paramId;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("param", indices.param_idx, widget, element);
 		} else
@@ -53,11 +56,10 @@ struct ModuleWidgetAdaptor {
 	{
 		if (widget) {
 			Element element = make_element(widget);
-			assign_element_fields(widget, getInputName(widget->module, widget->portId), element);
 
 			ElementCount::Indices indices = clear();
 			indices.input_idx = widget->portId;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("input", indices.input_idx, widget, element);
 		} else
@@ -69,11 +71,10 @@ struct ModuleWidgetAdaptor {
 	{
 		if (widget) {
 			Element element = make_element(widget);
-			assign_element_fields(widget, getOutputName(widget->module, widget->portId), element);
 
 			ElementCount::Indices indices = clear();
 			indices.output_idx = widget->portId;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("output", indices.output_idx, widget, element);
 		} else
@@ -85,11 +86,10 @@ struct ModuleWidgetAdaptor {
 	{
 		if (widget) {
 			Element element = make_element(widget);
-			assign_element_fields(widget, getLightName(widget->module, widget->firstLightId), element);
 
 			ElementCount::Indices indices = clear();
 			indices.light_idx = widget->firstLightId;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("light", indices.light_idx, widget, element);
 		} else
@@ -102,12 +102,11 @@ struct ModuleWidgetAdaptor {
 	{
 		if (widget) {
 			Element element = make_element(widget, light);
-			assign_element_fields(widget, getParamName(widget->module, widget->paramId), element);
 
 			ElementCount::Indices indices = clear();
 			indices.light_idx = light->firstLightId;
 			indices.param_idx = widget->paramId;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("light param: param", indices.param_idx, widget, element);
 			log_widget("light param: light", indices.light_idx, widget, element);
@@ -118,11 +117,10 @@ struct ModuleWidgetAdaptor {
 	void addSvgLight(rack::app::ModuleLightWidget *widget, std::string_view image) {
 		if (widget) {
 			Element element = make_element(widget, image);
-			assign_element_fields(widget, getLightName(widget->module, widget->firstLightId), element);
 
 			ElementCount::Indices indices = clear();
 			indices.light_idx = widget->firstLightId;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("SvgLight:", indices.light_idx, widget, element);
 		} else
@@ -132,10 +130,9 @@ struct ModuleWidgetAdaptor {
 	void addImage(rack::widget::SvgWidget *widget) {
 		if (widget) {
 			Element element = make_element(widget);
-			assign_element_fields(widget, "", element);
 
 			ElementCount::Indices indices = clear();
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("SvgWidget (image):", 0, widget, element);
 		} else
@@ -146,11 +143,10 @@ struct ModuleWidgetAdaptor {
 		if (widget) {
 			if (widget->firstLightId >= 0) {
 				Element element = make_element(widget);
-				assign_element_fields(widget, "", element);
 
 				ElementCount::Indices indices = clear();
 				indices.light_idx = widget->firstLightId;
-				elem_idx.emplace_back(element, indices);
+				elem_idx.emplace_back(element, indices, widget);
 
 				log_widget("VCVTextDisplay:", widget->firstLightId, widget, element);
 			} else {
@@ -194,7 +190,10 @@ struct ModuleWidgetAdaptor {
 			// Make sure widget width or height is not 0, or else it won't be drawn.
 			mw->box.size.x = std::max(1.f, mw->box.size.x);
 			mw->box.size.y = std::max(1.f, mw->box.size.y);
-			assign_element_fields(mw, "", element);
+
+			ElementCount::Indices indices = clear();
+			indices.light_idx = graphic_display_idx;
+			elem_idx.emplace_back(element, indices, mw);
 
 			pr_trace("Widget with size %g x %g has a custom draw() or drawLayer()\n", mw->box.size.x, mw->box.size.y);
 
@@ -204,15 +203,18 @@ struct ModuleWidgetAdaptor {
 
 			rack::widget::Widget zero_size_widget;
 			zero_size_widget.box = {{0, 0}, {0, 0}};
+
+			ElementCount::Indices indices = clear();
+			indices.light_idx = graphic_display_idx;
+
+			// Assign a zero sized box
 			assign_element_fields(&zero_size_widget, "", element);
+			// nullptr ==> Do not call assign_element_fields later, we already did it
+			elem_idx.emplace_back(element, indices, (rack::widget::Widget *)nullptr);
 
 			pr_trace(
 				"Widget with size %g x %g has no draw() or drawLayer() override\n", mw->box.size.x, mw->box.size.y);
 		}
-
-		ElementCount::Indices indices = clear();
-		indices.light_idx = graphic_display_idx;
-		elem_idx.emplace_back(element, indices);
 
 		log_widget("ModuleWidget:", graphic_display_idx, mw, element);
 	}
@@ -231,11 +233,12 @@ struct ModuleWidgetAdaptor {
 			}
 
 			auto &name = temp_names.emplace_back("Display " + std::to_string(graphic_display_idx - first_graphic_idx));
+			// Set the name now, because it won't be set later
 			assign_element_fields(widget, name, element);
 
 			ElementCount::Indices indices = clear();
 			indices.light_idx = graphic_display_idx;
-			elem_idx.emplace_back(element, indices);
+			elem_idx.emplace_back(element, indices, widget);
 
 			log_widget("Widget (as Graphic Display buffer):", graphic_display_idx, widget, element);
 		}
@@ -244,10 +247,73 @@ struct ModuleWidgetAdaptor {
 	void populate_elements_indices(std::vector<MetaModule::Element> &elements,
 								   std::vector<ElementCount::Indices> &indices) {
 
-		populate_sorted_elements_indices(elem_idx, elements, indices);
+		for (auto &[element, idx, widget] : elem_idx) {
+			std::visit(overloaded{
+						   [&](rack::app::ParamWidget *w) {
+							   assign_element_fields(w, getParamName(w->module, w->paramId), element);
+						   },
+						   [&](rack::app::PortWidget *w) {
+							   if (w->type == rack::engine::Port::Type::INPUT)
+								   assign_element_fields(w, getInputName(w->module, w->portId), element);
+
+							   else if (w->type == rack::engine::Port::Type::OUTPUT)
+								   assign_element_fields(w, getOutputName(w->module, w->portId), element);
+						   },
+						   [&](rack::app::ModuleLightWidget *w) {
+							   assign_element_fields(w, getLightName(w->module, w->firstLightId), element);
+						   },
+						   [&](rack::widget::Widget *w) {
+							   if (w) {
+								   // Don't change the name: Graphic displays already set their name and all others have no name
+								   assign_element_fields(w, std::nullopt, element);
+							   }
+						   },
+					   },
+					   widget);
+		}
+
+		// populate_sorted_elements_indices(elem_idx, elements, indices);
+		std::sort(elem_idx.begin(), elem_idx.end(), [](auto const &a, auto const &b) {
+			auto const &aidx = std::get<1>(a);
+			auto const &bidx = std::get<1>(b);
+
+			if (aidx.param_idx < bidx.param_idx)
+				return true;
+			else if (aidx.param_idx > bidx.param_idx)
+				return false;
+
+			else if (aidx.input_idx < bidx.input_idx)
+				return true;
+			else if (aidx.input_idx > bidx.input_idx)
+				return false;
+
+			else if (aidx.output_idx < bidx.output_idx)
+				return true;
+			else if (aidx.output_idx > bidx.output_idx)
+				return false;
+
+			else if (aidx.light_idx < bidx.light_idx)
+				return true;
+
+			else
+				return false;
+		});
+
+		elements.clear();
+		indices.clear();
+
+		auto num_elems = elem_idx.size();
+		elements.reserve(num_elems);
+		indices.reserve(num_elems);
+
+		for (auto &elemidx : elem_idx) {
+			elements.push_back(std::get<0>(elemidx));
+			indices.push_back(std::get<1>(elemidx));
+		}
 	}
 
-	static void assign_element_fields(rack::widget::Widget *widget, std::string_view name, Element &element) {
+	static void
+	assign_element_fields(rack::widget::Widget const *widget, std::optional<std::string_view> name, Element &element) {
 		std::visit(
 			[&name, &widget](BaseElement &el) {
 				el.x_mm = to_mm(widget->box.pos.x);
@@ -255,8 +321,11 @@ struct ModuleWidgetAdaptor {
 				el.width_mm = to_mm(widget->box.size.x);
 				el.height_mm = to_mm(widget->box.size.y);
 				el.coords = Coords::TopLeft;
-				el.short_name = name;
-				el.long_name = name;
+
+				if (name) {
+					el.short_name = *name;
+					el.long_name = *name;
+				}
 			},
 			element);
 	}


### PR DESCRIPTION
This fixes the problem when using the VCV Rack adaptor layer, that if a widget is modified after the call to ModuleWidget::addParam()  (or addOutput, etc), then the changes won't be copied into the Element.
E.g. this:
```
addParam(knob);
knob->box.pos = Vec(20, 20);

addInput(triggerjack);
module->configInput(TRIG_JACK, "Trigger");
```
wouldn't set the box position correctly in the first case, or set the jack name correctly in the second case.

This PR fixes this issue by assigning the element fields after the ModuleWidget is finished being constructed. So, it still doesn't work to modify a widget's box size or associated name fields while the module is running.