### PR TITLE
Various improvements: AsyncThread, File Browser, Simulator audio level

### DIFF
--- a/firmware/CMakePresets.json
+++ b/firmware/CMakePresets.json
@@ -37,8 +37,9 @@
         "OMIT_BRAND_nonlinearcircuits":  { "type": "BOOL", "value": "ON" },
         "OMIT_BRAND_eightfold":          { "type": "BOOL", "value": "ON" },
         "OMIT_BRAND_Valley":             { "type": "BOOL", "value": "ON" },
-        "OMIT_BRAND_RackCore":           { "type": "BOOL", "value": "ON" }
-      }
+        "OMIT_BRAND_RackCore":           { "type": "BOOL", "value": "ON" },
+		"LOG_LEVEL":                     { "type": "STRING", "value": "DEBUG" }
+	  }
     },
     {
       "name": "dyn-plugins",

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -95,14 +95,6 @@ endif()
 #
 add_subdirectory(${FWDIR}/src/gui/slsexport)
 
-#
-# Core Interface
-#
-
-if (NOT TARGET metamodule::core-interface)
-  add_subdirectory(${FWDIR}/metamodule-plugin-sdk/metamodule-core-interface metamodule-core-interface)
-endif()
-
 # CoreModules sources
 add_subdirectory(${FWDIR}/lib/CoreModules CoreModules)
 

--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -289,6 +289,8 @@ void AudioStream::process(CombinedAudioBlock &audio_block, ParamBlock &param_blo
 
 void AudioStream::process_nopatch(CombinedAudioBlock &audio_block, ParamBlock &param_block) {
 	player.sync();
+	handle_patch_mod_queue();
+
 	param_state.jack_senses = param_block.metaparams.jack_senses;
 
 	for (auto idx = 0u; auto const &in : audio_block.in_codec) {
@@ -383,15 +385,17 @@ void AudioStream::propagate_sense_pins(uint32_t jack_senses) {
 }
 
 void AudioStream::handle_patch_mod_queue() {
-	std::optional<bool> new_cal_state = std::nullopt;
+	if (player.is_loaded) {
+		std::optional<bool> new_cal_state = std::nullopt;
 
-	handle_patch_mods(patch_mod_queue, player, {&cal_stash, &ext_cal_stash}, new_cal_state);
+		handle_patch_mods(patch_mod_queue, player, {&cal_stash, &ext_cal_stash}, new_cal_state);
 
-	if (new_cal_state.has_value() && *new_cal_state == true)
-		re_enable_calibration();
+		if (new_cal_state.has_value() && *new_cal_state == true)
+			re_enable_calibration();
 
-	else if (new_cal_state == false)
-		disable_calibration();
+		else if (new_cal_state == false)
+			disable_calibration();
+	}
 }
 
 void AudioStream::disable_calibration() {

--- a/firmware/src/core_a7/async_thread_control.cc
+++ b/firmware/src/core_a7/async_thread_control.cc
@@ -67,7 +67,10 @@ void start_module_threads() {
 		.priority2 = 3,
 	};
 
-	task_runner.init(task_config, [=]() {
+	task_runner.init(task_config, [current_core = current_core]() {
+		auto &task_runner = current_core == 1 ? async_task_core1 : async_task_core0;
+		task_runner.pause();
+
 		// if (current_core == 0)
 		// 	Debug::Pin2::high();
 		// else
@@ -86,6 +89,8 @@ void start_module_threads() {
 		// 	Debug::Pin2::low();
 		// else
 		// 	Debug::Pin1::low();
+
+		task_runner.resume();
 	});
 	task_runner.start();
 }
@@ -97,7 +102,7 @@ void pause_module_threads() {
 
 void pause_module_threads(unsigned core_id) {
 	auto &task_runner = core_id == 1 ? async_task_core1 : async_task_core0;
-	task_runner.stop();
+	task_runner.pause();
 }
 
 void resume_module_threads() {
@@ -107,7 +112,7 @@ void resume_module_threads() {
 
 void resume_module_threads(unsigned core_id) {
 	auto &task_runner = core_id == 1 ? async_task_core1 : async_task_core0;
-	task_runner.start();
+	task_runner.resume();
 }
 
 void kill_module_threads() {

--- a/firmware/src/fs/helpers.cc
+++ b/firmware/src/fs/helpers.cc
@@ -9,7 +9,7 @@ std::vector<std::string> parse_extensions(std::string_view str, std::string cons
 
 	// Matching *.* means no filtering: return an empty vector
 	if (str.contains("*.*")) {
-		// pr_dbg("M4: filter contains *.*, ignoring filter\n");
+		pr_trace("M4: filter contains *.*, ignoring filter\n");
 		return tokens;
 	}
 
@@ -23,7 +23,7 @@ std::vector<std::string> parse_extensions(std::string_view str, std::string cons
 		if (str[last_pos] == ' ')
 			last_pos++;
 		auto s = std::string(str.substr(last_pos, pos - last_pos));
-		pr_dbg("M4: filter on '%s'\n", s.c_str());
+		pr_trace("M4: filter on '%s'\n", s.c_str());
 		tokens.push_back(s);
 
 		// Skip delimiters.

--- a/firmware/src/fs/helpers.hh
+++ b/firmware/src/fs/helpers.hh
@@ -64,11 +64,11 @@ get_dir_entries(auto &drive, std::string_view path, std::string_view filter_exts
 					for (auto const &ext : exts) {
 						if (name.ends_with(ext)) {
 							dir_tree->files.push_back({std::string(name), (uint32_t)size, (uint32_t)tm});
-							pr_dbg("Match: %s ends in %s\n", name.data(), ext.data());
+							pr_trace("Match: %s ends in %s\n", name.data(), ext.data());
 							break;
 						}
 					}
-					pr_dbg("No match: %s\n", name.data());
+					pr_trace("No match: %s\n", name.data());
 				}
 			}
 		});

--- a/firmware/src/gui/module_menu/plugin_module_menu.hh
+++ b/firmware/src/gui/module_menu/plugin_module_menu.hh
@@ -82,7 +82,6 @@ struct PluginModuleMenu {
 	void blur() {
 		if (plugin_menu) {
 			plugin_menu->close();
-			pr_dbg("plugin_menu.reset()\n");
 			plugin_menu.reset();
 		}
 	}

--- a/firmware/src/gui/pages/file_browser/file_browser.hh
+++ b/firmware/src/gui/pages/file_browser/file_browser.hh
@@ -53,15 +53,29 @@ struct FileBrowserDialog {
 		}
 	}
 
+	// Flags the browser to be shown.
+	// Safe to call from audio or AsyncThread context
 	void show(std::string_view start_dir, const std::function<void(char *)> action) {
-		parent_group = lv_indev_get_act()->group;
+		should_show = true;
+		this->action = action;
+		should_show_path.copy(start_dir);
+	}
+
+	// Actually shows the browser. Only called in the GUI context
+	void do_show() {
+		if (auto indev = lv_indev_get_next(nullptr))
+			parent_group = indev->group;
+
 		lv_group_activate(group);
 		lv_group_set_editing(group, true);
-		this->action = std::move(action);
+		lv_obj_set_parent(ui_FileBrowserCont, lv_layer_top());
+		lv_show(ui_FileBrowserCont);
 
 		visible = true;
 
 		refresh_state = RefreshState::TryingToRequest;
+
+		auto start_dir = std::string_view{should_show_path};
 
 		if (start_dir.length()) {
 			auto [start_path, start_vol] = split_volume(start_dir);
@@ -82,9 +96,6 @@ struct FileBrowserDialog {
 				show_path = std::filesystem::path(show_path).parent_path().string() + "/";
 			}
 		}
-
-		lv_obj_set_parent(ui_FileBrowserCont, lv_layer_top());
-		lv_show(ui_FileBrowserCont);
 	}
 
 	void back_event() {
@@ -102,6 +113,11 @@ struct FileBrowserDialog {
 	}
 
 	void update() {
+		if (should_show) {
+			do_show();
+			should_show = false;
+		}
+
 		switch (refresh_state) {
 			case RefreshState::Idle: {
 				//nothing
@@ -146,7 +162,7 @@ struct FileBrowserDialog {
 	}
 
 	bool is_visible() {
-		return visible;
+		return should_show || visible;
 	}
 
 private:
@@ -288,17 +304,18 @@ private:
 	}
 
 	static void roller_click_cb(lv_event_t *event) {
-		auto page = static_cast<FileBrowserDialog *>(event->user_data);
-		if (!page)
-			return;
-		page->roller_click();
+		if (auto page = static_cast<FileBrowserDialog *>(event->user_data))
+			page->roller_click();
 	}
 
 	FileStorageProxy &file_storage;
-	// NotificationQueue &notify_queue;
 
 	lv_group_t *group;
 	lv_group_t *parent_group = nullptr;
+
+	// Flag to indicate a non-GUI thread requested we show the browser
+	bool should_show = false;
+	StaticString<255> should_show_path = "";
 
 	std::function<void(char *)> action;
 

--- a/firmware/src/gui/pages/file_browser/file_save_dialog.hh
+++ b/firmware/src/gui/pages/file_browser/file_save_dialog.hh
@@ -4,6 +4,7 @@
 #include "gui/pages/patch_selector_subdir_panel.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "patch_file/file_storage_proxy.hh"
+#include <atomic>
 
 namespace MetaModule
 {
@@ -31,6 +32,11 @@ struct FileSaveDialog {
 	}
 
 	void update() {
+		if (should_show) {
+			do_show(should_show_vol, should_show_path, should_show_ext);
+			should_show = false;
+		}
+
 		if (mode == Mode::EditDir) {
 
 			//TODO: this state logic should be in PatchSelectorSubdirPanel
@@ -82,17 +88,29 @@ struct FileSaveDialog {
 			  std::string_view ext,
 			  lv_group_t *parent_group,
 			  std::function<void(Volume, std::string_view)> action) {
-		this->vcv_save_action = {};
-		this->save_action = action;
-		show(vol, fullpath, ext);
+		vcv_save_action = {};
+		save_action = action;
+		should_show_vol = vol;
+		should_show_path = fullpath;
+		should_show_ext = ext;
+
+		// TODO: this only has an effect if mode != Hidden when show is called
 		base_group = parent_group;
+
+		should_show = true;
 	}
 
 	void show(std::string_view fullpath, std::string_view ext, std::function<void(char *)> action) {
-		this->vcv_save_action = action;
-		this->save_action = {};
-		auto [path, vol] = split_volume(fullpath);
-		show(vol, fullpath, ext);
+		vcv_save_action = action;
+		save_action = {};
+		auto [_, vol] = split_volume(fullpath);
+		should_show_vol = vol;
+		should_show_path = fullpath;
+		should_show_ext = ext;
+
+		base_group = nullptr;
+
+		should_show = true;
 	}
 
 	void hide() {
@@ -112,7 +130,7 @@ struct FileSaveDialog {
 	}
 
 	bool is_visible() {
-		return mode != Mode::Hidden;
+		return should_show || (mode != Mode::Hidden);
 	}
 
 	void back_event() {
@@ -130,7 +148,7 @@ struct FileSaveDialog {
 	}
 
 private:
-	void show(Volume vol, std::string_view fullpath, std::string_view ext) {
+	void do_show(Volume vol, std::string_view fullpath, std::string_view ext) {
 
 		if (mode == Mode::Hidden) {
 
@@ -163,7 +181,9 @@ private:
 			lv_hide(ui_SaveDialogLeftCont);
 			lv_hide(ui_Keyboard);
 
-			base_group = lv_indev_get_act()->group;
+			// Set the base group if we didn't do it with the call to show()
+			if (!base_group)
+				base_group = lv_indev_get_next(nullptr)->group;
 			lv_group_activate(group);
 			lv_group_focus_obj(ui_SaveDialogFilename);
 			lv_group_set_editing(group, false);
@@ -337,6 +357,11 @@ private:
 
 	std::function<void(char *)> vcv_save_action;
 	std::function<void(Volume, std::string_view)> save_action;
+
+	std::atomic<bool> should_show = false;
+	Volume should_show_vol{};
+	StaticString<255> should_show_path{};
+	StaticString<8> should_show_ext{};
 };
 
 } // namespace MetaModule

--- a/firmware/src/patch_file/change_checker.hh
+++ b/firmware/src/patch_file/change_checker.hh
@@ -91,7 +91,7 @@ struct PatchFileChangeChecker {
 				}
 			}
 		} else {
-			pr_trace("check_playing_patch: file on disk matches file in memory\n");
+			pr_dump("check_playing_patch: file on disk matches file in memory\n");
 		}
 		return Status::OK;
 	}

--- a/firmware/src/patch_file/reload_patch.cc
+++ b/firmware/src/patch_file/reload_patch.cc
@@ -33,7 +33,7 @@ std::optional<ReloadPatch::FileTimeSize> ReloadPatch::get_file_info(PatchLocatio
 		}
 
 		if (msg.message_type == FileStorageProxy::PatchFileInfoFailed) {
-			pr_trace("ReloadPatch::get_file_info: get file info for '%s' failed \n", patch_loc.filename.c_str());
+			pr_dump("ReloadPatch::get_file_info: get file info for '%s' failed \n", patch_loc.filename.c_str());
 			return {};
 		}
 

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -1089,12 +1089,13 @@ public:
 				}
 
 				update_or_add_input_panel_conn(panel_jack_id, input_jack);
-				pr_dbg(" to jack: m=%d, p=%d\n", module_id, jack_id);
+				pr_trace(" to jack: m=%d, p=%d\n", module_id, jack_id);
 
 				// Handle MIDI->Hub and Hub->Hub cables by connecting Hub input to output
 				if (input_jack.module_id == 0) {
 					out_conns[input_jack.jack_id] = input_jack;
-					pr_dbg("Connect hub module out jack %d to panel out %d\n", input_jack.jack_id, input_jack.jack_id);
+					pr_trace(
+						"Connect hub module out jack %d to panel out %d\n", input_jack.jack_id, input_jack.jack_id);
 				}
 			}
 		}
@@ -1104,48 +1105,48 @@ public:
 			if (panel_jack_id >= out_conns.size())
 				break;
 			out_conns[panel_jack_id] = cable.out;
-			pr_dbg("Connect module %d out jack %d to panel out %d\n",
-				   cable.out.module_id,
-				   cable.out.jack_id,
-				   panel_jack_id);
+			pr_trace("Connect module %d out jack %d to panel out %d\n",
+					 cable.out.module_id,
+					 cable.out.jack_id,
+					 panel_jack_id);
 		}
 	}
 
 	void update_or_add_input_panel_conn(uint32_t panel_jack_id, Jack input_jack) {
-		pr_dbg("update_or_add_input_panel_conn: %x\n", panel_jack_id);
+		pr_trace("update_or_add_input_panel_conn: %x\n", panel_jack_id);
 		auto chan = Midi::midi_channel(panel_jack_id);
 
 		if (auto num = Midi::midi_note_pitch(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_pitch_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI note (poly %d) ch:%u", num.value(), chan);
+			pr_trace("MIDI note (poly %d) ch: %u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_note_gate(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_gate_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI gate (poly %d) ch:%u", num.value(), chan);
+			pr_trace("MIDI gate (poly %d) ch:% ch:%uu", num.value(), chan);
 
 		} else if (auto num = Midi::midi_note_vel(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_vel_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI vel (poly %d) ch:%u", num.value(), chan);
+			pr_trace("MIDI vel (poly %d) ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_note_aft(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_aft_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI aftertouch (poly %d) ch:%u", num.value(), chan);
+			pr_trace("MIDI aftertouch (poly %d) ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_note_retrig(panel_jack_id); num.has_value()) {
 			update_or_add(midi_note_retrig[num.value()].conns, input_jack, chan);
-			pr_dbg("MIDI retrig (poly %d) ch:%u", num.value(), chan);
+			pr_trace("MIDI retrig (poly %d) ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_gate(panel_jack_id); num.has_value()) {
 			update_or_add(midi_gate_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI note %d gate ch:%u", num.value(), chan);
+			pr_trace("MIDI note %d gate ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_cc(panel_jack_id); num.has_value()) {
 			update_or_add(midi_cc_conns[num.value()], input_jack, chan);
-			pr_dbg("MIDI CC/PW %d ch:%u", num.value(), chan);
+			pr_trace("MIDI CC/PW %d ch:%u", num.value(), chan);
 
 		} else if (auto num = Midi::midi_clk(panel_jack_id); num.has_value()) {
 			update_or_add(midi_pulses[TimingEvents::Clock].conns, input_jack);
-			pr_dbg("MIDI Clk");
+			pr_trace("MIDI Clk");
 
 		} else if (auto num = Midi::midi_divclk(panel_jack_id); num.has_value()) {
 			uint8_t div_event = *num == 0  ? Midi::DivClock1 :
@@ -1162,15 +1163,15 @@ public:
 				div_event = Midi::DivClock24;
 			}
 			update_or_add(midi_divclk_pulses[div_event].conns, input_jack);
-			pr_dbg("MIDI Div %d Clk", num.value() + 1);
+			pr_trace("MIDI Div %d Clk", num.value() + 1);
 
 		} else if (auto num = Midi::midi_transport(panel_jack_id); num.has_value()) {
 			update_or_add(midi_pulses[num.value() + TimingEvents::Start].conns, input_jack);
-			pr_dbg("MIDI %s", num.value() == 0 ? "Start" : num.value() == 1 ? "Stop" : "Cont");
+			pr_trace("MIDI %s", num.value() == 0 ? "Start" : num.value() == 1 ? "Stop" : "Cont");
 
 		} else if (panel_jack_id >= 0 && panel_jack_id < in_conns.size()) {
 			update_or_add(in_conns[panel_jack_id], input_jack);
-			pr_dbg("Map %d", panel_jack_id);
+			pr_trace("Map %d", panel_jack_id);
 
 		} else
 			pr_err("Bad panel jack mapping: panel_jack_id=%d", panel_jack_id);

--- a/firmware/vcv_plugin/export/src/app/ModuleWidget.cpp
+++ b/firmware/vcv_plugin/export/src/app/ModuleWidget.cpp
@@ -91,9 +91,11 @@ void ModuleWidget::setPanel(app::SvgPanel *newpanel) {
 				pr_err("Error: In ModuleWidget::setPanel, new panel's svg->getSize() != box.size\n");
 
 			if (first_panel) {
-				internal->adaptor->addModuleWidget(internal->graphic_display_idx, this);
-				internal->drawable_widgets.push_back({internal->graphic_display_idx, this});
-				internal->graphic_display_idx++;
+				if (internal->adaptor->addModuleWidget(internal->graphic_display_idx, this)) {
+					internal->drawable_widgets.push_back({internal->graphic_display_idx, this});
+					pr_trace("Added full-module graphic_display_idx %d\n", internal->graphic_display_idx);
+					internal->graphic_display_idx++;
+				}
 			}
 		}
 	}
@@ -200,8 +202,8 @@ void ModuleWidget::addChild(app::ModuleLightWidget *widget) {
 			internal->drawable_widgets.push_back({internal->graphic_display_idx, widget});
 			internal->graphic_display_idx++;
 
-			pr_trace("Add drawable (light) at (%f, %f) size (%f, %f) ", box.pos.x, box.pos.y, box.size.x, box.size.y);
-			pr_trace("idx %d (firstLightId = %d)\n", internal->graphic_display_idx - 1, widget->firstLightId);
+			pr_dbg("Add drawable (light) at (%f, %f) size (%f, %f) ", box.pos.x, box.pos.y, box.size.x, box.size.y);
+			pr_dbg("idx %d (firstLightId = %d)\n", internal->graphic_display_idx - 1, widget->firstLightId);
 		}
 	}
 }
@@ -266,8 +268,8 @@ void ModuleWidget::addChild(Widget *widget) {
 	internal->graphic_display_idx++;
 
 	auto box = widget->box;
-	pr_trace("Add drawable at (%f, %f) size (%f, %f) ", box.pos.x, box.pos.y, box.size.x, box.size.y);
-	pr_trace("idx %d\n", internal->graphic_display_idx - 1);
+	pr_dbg("Add drawable at (%f, %f) size (%f, %f) ", box.pos.x, box.pos.y, box.size.x, box.size.y);
+	pr_dbg("idx %d\n", internal->graphic_display_idx - 1);
 }
 
 void ModuleWidget::addChild(MetaModule::VCVTextDisplay *widget) {

--- a/firmware/vcv_plugin/export/src/resampler.cc
+++ b/firmware/vcv_plugin/export/src/resampler.cc
@@ -1,11 +1,10 @@
-#include "medium/debug_raw.h"
 #include <algorithm>
 #include <array>
-#include <cstdio>
+#include <cstdint>
 #include <cstring>
-#include <span>
 #include <speex/speex_resampler.h>
-#include <vector>
+
+// TODO: use core-interface/dsp/resampler.hh
 
 struct SpeexResamplerChan {
 	bool flush{true};
@@ -113,7 +112,7 @@ int speex_resampler_process_float(SpeexResamplerState *st,
 	}
 
 	*out_len = outpos / stc.output_stride;
-	*in_len = inpos / stc.output_stride;
+	*in_len = inpos / stc.input_stride;
 
 	return 0;
 }

--- a/simulator/plugin.cmake
+++ b/simulator/plugin.cmake
@@ -33,7 +33,7 @@ function(create_plugin)
 		VERBATIM
 	)
 
-	add_custom_target(${PLUGIN_OPTIONS_SOURCE_LIB}-assets
+	add_custom_target(${PLUGIN_OPTIONS_SOURCE_LIB}-assets ALL
 		DEPENDS "${ASSET_DIR}/${PLUGIN_OPTIONS_PLUGIN_NAME}" 
 	)
 

--- a/simulator/src/audio_stream.hh
+++ b/simulator/src/audio_stream.hh
@@ -109,7 +109,7 @@ public:
 			// Get outputs
 			for (auto [i, outjack] : enumerate(out.chan)) {
 				if (param_state.is_output_plugged(i)) {
-					outjack = player.get_panel_output(i);
+					outjack = player.get_panel_output(i) / volts_peak;
 					player.set_output_jack_patched_status(i, true);
 				} else {
 					outjack = 0;
@@ -181,6 +181,7 @@ public:
 	float output_fade_amt = -1.f;
 	float output_fade_delta = 0.f;
 	float sample_rate_ = 48000.f;
+	float volts_peak = 5.f;
 };
 
 } // namespace MetaModule

--- a/simulator/src/main.cc
+++ b/simulator/src/main.cc
@@ -33,6 +33,7 @@ int main(int argc, char *argv[]) {
 		MetaModule::LoadTest::test_module_brand(settings.test_brand, [](std::string_view csv_line) {});
 	}
 
+	ui.set_audio_fullscale(settings.fullscale_volts);
 	audio_out.set_callback([&ui](auto playback_buffer) { ui.play_patch(playback_buffer); });
 	audio_out.unpause();
 

--- a/simulator/src/settings.hh
+++ b/simulator/src/settings.hh
@@ -13,6 +13,7 @@ struct Settings {
 	std::string asset_file = "build/assets.uimg";
 	int audioout_dev = 0;
 	std::string test_brand = "";
+	float fullscale_volts = 5;
 
 	void parse(int argc, char *argv[]) {
 
@@ -41,6 +42,10 @@ struct Settings {
 			options.add_options()(
 				"t,test_brand", "Brand slug to run tests on", cxxopts::value<std::string>()->default_value(""));
 
+			options.add_options()("l,fullScaleVolts",
+								  "Volts (peak) which corresponds to full-scale signal sent to sound card",
+								  cxxopts::value<float>()->default_value("5"));
+
 			options.add_options()("h,help", "Print help");
 
 			auto args = options.parse(argc, argv);
@@ -62,6 +67,9 @@ struct Settings {
 
 			if (args.count("audioout") > 0)
 				audioout_dev = args["audioout"].as<int>();
+
+			if (args.count("fullScaleVolts") > 0)
+				fullscale_volts = args["fullScaleVolts"].as<float>();
 
 			if (args.count("help") || args.count("?") || args.count("h")) {
 				std::cout << options.help() << std::endl;

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -89,6 +89,10 @@ bool Ui::update() {
 	return keep_running;
 }
 
+void Ui::set_audio_fullscale(float volts_peak) {
+	audio_stream.volts_peak = volts_peak;
+}
+
 void Ui::play_patch(std::span<Frame> soundcard_out) {
 	// assert(soundcard_out.size() == out_buffer.size());
 

--- a/simulator/src/ui.hh
+++ b/simulator/src/ui.hh
@@ -33,6 +33,7 @@ public:
 
 	bool update();
 	void play_patch(std::span<Frame> buffer);
+	void set_audio_fullscale(float volts_peak);
 
 private:
 	PatchDirList patch_dir_list;


### PR DESCRIPTION
Various issues cherry-picked from dev branches:

- Async thread pauses timers while executing. This fixes the issue with Async Threads never restarting or being locked sometimes if processing takes too long.

- SpeexResampler: fix stride typo

- Performance improvement for modules with graphics: Don't step() a module widget with no custom step()

- Process patch mod queue when patch is paused, allowing user to add or modify maps when patch is paused

- Simulator volume was too high -- now defaults to equating 5V with full-scale signal. You can adjust this with the `-l` option (run `simulator -h` to see help)

- File browser and save dialog can be triggered from audio context to be run in the GUI context

- Various other cleanups
