### PR TITLE
Patch file can override audio settings

### DIFF
--- a/firmware/src/gui/helpers/load_meter.hh
+++ b/firmware/src/gui/helpers/load_meter.hh
@@ -18,6 +18,7 @@ inline void update_load_text(MetaParams const &metaparams,
 	if (settings.show_samplerate) {
 		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
 
+		// 68% ^aaaaaa48k/64^
 		lv_label_set_text_fmt(meter,
 							  "%d%% %s%uk/%u%c",
 							  metaparams.audio_load,

--- a/firmware/src/gui/helpers/load_meter.hh
+++ b/firmware/src/gui/helpers/load_meter.hh
@@ -16,7 +16,7 @@ inline void update_load_text(MetaParams const &metaparams,
 
 	if (settings.show_samplerate) {
 		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
-		lv_label_set_text_fmt(meter, "%d%% [%u/%u]", metaparams.audio_load, cur_sr / 1000, cur_bs);
+		lv_label_set_text_fmt(meter, "%d%% [%uk/%u]", metaparams.audio_load, cur_sr / 1000, cur_bs);
 	} else {
 		lv_label_set_text_fmt(meter, "%d%%", metaparams.audio_load);
 	}

--- a/firmware/src/gui/helpers/load_meter.hh
+++ b/firmware/src/gui/helpers/load_meter.hh
@@ -16,7 +16,7 @@ inline void update_load_text(MetaParams const &metaparams,
 
 	if (settings.show_samplerate) {
 		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
-		lv_label_set_text_fmt(meter, "%d%% [%uk/%u]", metaparams.audio_load, cur_sr / 1000, cur_bs);
+		lv_label_set_text_fmt(meter, "%d%% %uk/%u", metaparams.audio_load, cur_sr / 1000, cur_bs);
 	} else {
 		lv_label_set_text_fmt(meter, "%d%%", metaparams.audio_load);
 	}

--- a/firmware/src/gui/helpers/load_meter.hh
+++ b/firmware/src/gui/helpers/load_meter.hh
@@ -4,15 +4,22 @@
 #include "gui/slsexport/meta5/ui.h"
 #include "lvgl.h"
 #include "metaparams.hh"
+#include "patch_play/patch_playloader.hh"
 
 namespace MetaModule
 {
 
-inline void update_load_text(MetaParams const &metaparams, lv_obj_t *meter) {
-	lv_label_set_text_fmt(meter, "%d%%", metaparams.audio_load);
-	lv_obj_set_style_text_color(meter, lv_color_hex(0xFD8B18), LV_PART_MAIN);
-	lv_obj_set_style_outline_opa(meter, LV_OPA_0, LV_PART_MAIN);
-	lv_obj_set_style_bg_opa(meter, LV_OPA_0, LV_PART_MAIN);
+inline void update_load_text(MetaParams const &metaparams,
+							 PatchPlayLoader &patch_playloader,
+							 ModuleDisplaySettings const &settings,
+							 lv_obj_t *meter) {
+
+	if (settings.show_samplerate) {
+		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
+		lv_label_set_text_fmt(meter, "%d%% [%u/%u]", metaparams.audio_load, cur_sr / 1000, cur_bs);
+	} else {
+		lv_label_set_text_fmt(meter, "%d%%", metaparams.audio_load);
+	}
 	lv_show(meter);
 }
 

--- a/firmware/src/gui/helpers/load_meter.hh
+++ b/firmware/src/gui/helpers/load_meter.hh
@@ -18,30 +18,6 @@ inline void update_load_text(MetaParams const &metaparams,
 	if (settings.show_samplerate) {
 		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
 
-		// std::array<char, 32> txt;
-		// char *p = txt.begin();
-
-		// auto [new_p, ec] = std::to_chars(p, txt.end(), metaparams.audio_load);
-		// p = new_p;
-
-		// *p++ = '%';
-		// *p++ = ' ';
-		// p = std::copy(Gui::grey_color_html.begin(), Gui::grey_color_html.end(), p);
-
-		// auto [new_p2, ec2] = std::to_chars(p, txt.end(), cur_sr / 1000);
-		// p = new_p2;
-
-		// *p++ = 'k';
-		// *p++ = '/';
-
-		// auto [new_p3, ec3] = std::to_chars(p, txt.end(), cur_bs);
-		// p = new_p3;
-
-		// *p++ = LV_TXT_COLOR_CMD[0];
-		// *p++ = '\0';
-
-		// lv_label_set_text(meter, txt.data());
-
 		lv_label_set_text_fmt(meter,
 							  "%d%% %s%uk/%u%c",
 							  metaparams.audio_load,

--- a/firmware/src/gui/helpers/load_meter.hh
+++ b/firmware/src/gui/helpers/load_meter.hh
@@ -2,6 +2,7 @@
 #include "delay.hh"
 #include "gui/helpers/lv_helpers.hh"
 #include "gui/slsexport/meta5/ui.h"
+#include "gui/styles.hh"
 #include "lvgl.h"
 #include "metaparams.hh"
 #include "patch_play/patch_playloader.hh"
@@ -16,7 +17,38 @@ inline void update_load_text(MetaParams const &metaparams,
 
 	if (settings.show_samplerate) {
 		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
-		lv_label_set_text_fmt(meter, "%d%% %uk/%u", metaparams.audio_load, cur_sr / 1000, cur_bs);
+
+		// std::array<char, 32> txt;
+		// char *p = txt.begin();
+
+		// auto [new_p, ec] = std::to_chars(p, txt.end(), metaparams.audio_load);
+		// p = new_p;
+
+		// *p++ = '%';
+		// *p++ = ' ';
+		// p = std::copy(Gui::grey_color_html.begin(), Gui::grey_color_html.end(), p);
+
+		// auto [new_p2, ec2] = std::to_chars(p, txt.end(), cur_sr / 1000);
+		// p = new_p2;
+
+		// *p++ = 'k';
+		// *p++ = '/';
+
+		// auto [new_p3, ec3] = std::to_chars(p, txt.end(), cur_bs);
+		// p = new_p3;
+
+		// *p++ = LV_TXT_COLOR_CMD[0];
+		// *p++ = '\0';
+
+		// lv_label_set_text(meter, txt.data());
+
+		lv_label_set_text_fmt(meter,
+							  "%d%% %s%uk/%u%c",
+							  metaparams.audio_load,
+							  Gui::grey_color_html.data(),
+							  cur_sr / 1000,
+							  cur_bs,
+							  LV_TXT_COLOR_CMD[0]);
 	} else {
 		lv_label_set_text_fmt(meter, "%d%%", metaparams.audio_load);
 	}

--- a/firmware/src/gui/pages/description_panel.hh
+++ b/firmware/src/gui/pages/description_panel.hh
@@ -152,8 +152,8 @@ private:
 		lv_obj_set_style_pad_ver(ui_DescSuggestSRCont, 4, LV_STATE_DEFAULT);
 		lv_obj_set_style_pad_ver(ui_DescSuggestBSCont, 4, LV_STATE_DEFAULT);
 
-		lv_label_set_text(ui_DescSuggestSRLabel, "Sample Rate:");
-		lv_label_set_text(ui_DescSuggestBSLabel, "Block Size:");
+		lv_label_set_text(ui_DescSuggestSRLabel, "Patch Sample Rate:");
+		lv_label_set_text(ui_DescSuggestBSLabel, "Patch Block Size:");
 		lv_obj_set_style_text_font(ui_DescSuggestSRLabel, &ui_font_MuseoSansRounded50014, LV_STATE_DEFAULT);
 		lv_obj_set_style_text_font(ui_DescSuggestBSLabel, &ui_font_MuseoSansRounded50014, LV_STATE_DEFAULT);
 
@@ -168,7 +168,7 @@ private:
 
 	void set_suggested_audio_dropdowns() {
 		// Samplerate dropdown
-		std::string opts = "None\n";
+		std::string opts = "Any\n";
 		for (auto item : AudioSettings::ValidSampleRates) {
 			opts += std::to_string(item / 1000) + "kHz\n";
 		}
@@ -178,7 +178,7 @@ private:
 		if (patch && patch->suggested_samplerate) {
 			for (size_t i = 0; i < AudioSettings::ValidSampleRates.size(); i++) {
 				if (AudioSettings::ValidSampleRates[i] == patch->suggested_samplerate) {
-					sel = i + 1; // shift by 1 due to None
+					sel = i + 1; // shift by 1 due to Any
 					break;
 				}
 			}
@@ -186,7 +186,7 @@ private:
 		lv_dropdown_set_selected(ui_DescSuggestSRDrop, sel);
 
 		// Blocksize dropdown
-		opts = "None\n";
+		opts = "Any\n";
 		for (auto item : AudioSettings::ValidBlockSizes) {
 			opts += std::to_string(item) + "\n";
 		}
@@ -196,7 +196,7 @@ private:
 		if (patch && patch->suggested_blocksize) {
 			for (size_t i = 0; i < AudioSettings::ValidBlockSizes.size(); i++) {
 				if (AudioSettings::ValidBlockSizes[i] == patch->suggested_blocksize) {
-					sel = i + 1; // shift by 1 due to None
+					sel = i + 1; // shift by 1 due to Any
 					break;
 				}
 			}

--- a/firmware/src/gui/pages/description_panel.hh
+++ b/firmware/src/gui/pages/description_panel.hh
@@ -5,6 +5,7 @@
 #include "patch/patch_data.hh"
 #include "pr_dbg.hh"
 #include "src/core/lv_event.h"
+#include <string>
 
 namespace MetaModule
 {
@@ -34,6 +35,10 @@ struct PatchDescriptionPanel {
 
 		lv_obj_add_event_cb(ui_DescriptionEditSaveButton, save_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_DescriptionEditCancelButton, cancel_cb, LV_EVENT_CLICKED, this);
+
+		ui_DescSuggestedAudioLabel = lv_label_create(ui_DescriptionPanel);
+		lv_obj_set_width(ui_DescSuggestedAudioLabel, LV_SIZE_CONTENT);
+		lv_obj_set_height(ui_DescSuggestedAudioLabel, LV_SIZE_CONTENT);
 	}
 
 	void prepare_focus(lv_group_t *base_group) {
@@ -91,6 +96,21 @@ struct PatchDescriptionPanel {
 			lv_label_set_text_fmt(ui_DescMIDIPolyNumLabel, "MIDI Poly Chans: %u", (unsigned)patch->midi_poly_num);
 		else
 			lv_label_set_text(ui_DescMIDIPolyNumLabel, "");
+
+		std::string sugg_txt;
+		if (patch->suggested_samplerate) {
+			sugg_txt += "Suggested Samplerate: ";
+			sugg_txt += std::to_string(patch->suggested_samplerate);
+			sugg_txt += " Hz";
+		}
+		if (patch->suggested_blocksize) {
+			if (!sugg_txt.empty())
+				sugg_txt += ", ";
+			sugg_txt += "Suggested Blocksize: ";
+			sugg_txt += std::to_string(patch->suggested_blocksize);
+		}
+
+		lv_label_set_text(ui_DescSuggestedAudioLabel, sugg_txt.c_str());
 
 		set_content_max_height(ui_DescriptionPanel, 230);
 	}
@@ -223,6 +243,9 @@ private:
 	bool edit_panel_visible = false;
 	bool kb_visible = false;
 	bool did_save = false;
+
+	// Created on demand inside show()
+	lv_obj_t *ui_DescSuggestedAudioLabel = nullptr;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/description_panel.hh
+++ b/firmware/src/gui/pages/description_panel.hh
@@ -39,6 +39,7 @@ struct PatchDescriptionPanel {
 		ui_DescSuggestedAudioLabel = lv_label_create(ui_DescriptionPanel);
 		lv_obj_set_width(ui_DescSuggestedAudioLabel, LV_SIZE_CONTENT);
 		lv_obj_set_height(ui_DescSuggestedAudioLabel, LV_SIZE_CONTENT);
+		lv_obj_set_style_text_font(ui_DescSuggestedAudioLabel, &ui_font_MuseoSansRounded50016, LV_PART_MAIN);
 	}
 
 	void prepare_focus(lv_group_t *base_group) {
@@ -105,7 +106,7 @@ struct PatchDescriptionPanel {
 		}
 		if (patch->suggested_blocksize) {
 			if (!sugg_txt.empty())
-				sugg_txt += ", ";
+				sugg_txt += "\n";
 			sugg_txt += "Suggested Blocksize: ";
 			sugg_txt += std::to_string(patch->suggested_blocksize);
 		}

--- a/firmware/src/gui/pages/main_menu.hh
+++ b/firmware/src/gui/pages/main_menu.hh
@@ -73,7 +73,7 @@ struct MainMenuPage : PageBase {
 				load_patch_view_page();
 		}
 
-		update_load_text(metaparams, ui_MainMenuLoadMeter);
+		update_load_text(metaparams, patch_playloader, settings.patch_view, ui_MainMenuLoadMeter);
 
 		poll_patch_file_changed();
 	}

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -72,7 +72,8 @@ struct PatchSelectorPage : PageBase {
 			lv_label_set_text(ui_LoadMeter, "");
 		} else {
 			lv_label_set_text_fmt(ui_NowPlayingName, "%.31s", playing_patch->patch_name.c_str());
-			lv_label_set_text_fmt(ui_LoadMeter, "%d%%", metaparams.audio_load);
+
+			update_load_text(metaparams, patch_playloader, settings.patch_view, ui_LoadMeter);
 		}
 
 		is_populating_subdir_panel = true;
@@ -299,7 +300,7 @@ struct PatchSelectorPage : PageBase {
 					last_refresh_check_tm = now;
 					state = State::TryingToRequestPatchList;
 
-					update_load_text(metaparams, ui_LoadMeter);
+					update_load_text(metaparams, patch_playloader, settings.module_view, ui_LoadMeter);
 				} else {
 					// Poll for patch file changes in between polling for patch list updates
 					poll_patch_file_changed();

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -408,6 +408,9 @@ struct PatchViewPage : PageBase {
 			}
 
 			update_load_text(metaparams, ui_LoadMeter2);
+			auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
+			lv_label_set_text_fmt(ui_LoadMeter2, "%uk/%u %d%%", cur_sr / 1000, cur_bs, metaparams.audio_load);
+			lv_obj_set_width(ui_LoadMeter2, LV_SIZE_CONTENT);
 
 		} else {
 			if (lv_obj_has_state(ui_PlayButton, LV_STATE_USER_2)) {

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -30,6 +30,7 @@ struct PatchViewPage : PageBase {
 		, cable_drawer{modules_cont, drawn_elements}
 		, page_settings{settings.patch_view}
 		, settings_menu{settings.patch_view, gui_state}
+		, desc_panel{patch_playloader, patches}
 		, file_menu{patch_playloader,
 					patch_storage,
 					patches,
@@ -756,7 +757,6 @@ private:
 
 	void show_desc_panel() {
 		desc_panel.set_patch(patch);
-		desc_panel.set_patch_loader(patch_playloader);
 		desc_panel.set_filename(patches.get_view_patch_filename());
 		desc_panel.show();
 	}

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -756,6 +756,7 @@ private:
 
 	void show_desc_panel() {
 		desc_panel.set_patch(patch);
+		desc_panel.set_patch_loader(patch_playloader);
 		desc_panel.set_filename(patches.get_view_patch_filename());
 		desc_panel.show();
 	}

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -328,12 +328,14 @@ struct PatchViewPage : PageBase {
 			page_list.set_active_knobset(active_knobset);
 			patch_mod_queue.put(ChangeKnobSet{active_knobset});
 			redraw_map_rings();
+			update_title_bar();
 		}
 
 		if (is_patch_playloaded && active_knobset != page_list.get_active_knobset()) {
 			args.view_knobset_id = page_list.get_active_knobset();
 			active_knobset = page_list.get_active_knobset();
 			redraw_map_rings();
+			update_title_bar();
 		}
 
 		if (gui_state.force_redraw_patch) {

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -77,8 +77,7 @@ struct PatchViewPage : PageBase {
 		is_patch_playloaded = patch_is_playing(args.patch_loc_hash);
 
 		if (is_patch_playloaded && !patch_playloader.is_audio_muted()) {
-			lv_label_set_text_fmt(ui_LoadMeter2, "%d%%", metaparams.audio_load);
-			lv_show(ui_LoadMeter2);
+			update_load_text(metaparams, patch_playloader, settings.patch_view, ui_LoadMeter2);
 			lv_obj_add_state(ui_PlayButton, LV_STATE_USER_2);
 		} else {
 			lv_label_set_text(ui_LoadMeter2, "");
@@ -408,10 +407,7 @@ struct PatchViewPage : PageBase {
 				lv_obj_add_state(ui_PlayButton, LV_STATE_USER_2);
 			}
 
-			update_load_text(metaparams, ui_LoadMeter2);
-			auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
-			lv_label_set_text_fmt(ui_LoadMeter2, "%uk/%u %d%%", cur_sr / 1000, cur_bs, metaparams.audio_load);
-			lv_obj_set_width(ui_LoadMeter2, LV_SIZE_CONTENT);
+			update_load_text(metaparams, patch_playloader, settings.patch_view, ui_LoadMeter2);
 
 		} else {
 			if (lv_obj_has_state(ui_PlayButton, LV_STATE_USER_2)) {

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -482,37 +482,23 @@ private:
 	}
 
 	void update_title_bar() {
+		lv_label_set_text(ui_PatchName, patch->patch_name.c_str());
+
 		if (settings.patch_view.show_knobset_name) {
-			lv_obj_set_style_text_font(ui_PatchName, &ui_font_MuseoSansRounded70014, LV_STATE_DEFAULT);
-			lv_obj_set_style_text_font(ui_KnobSetName, &ui_font_MuseoSansRounded50014, LV_STATE_DEFAULT);
-
-			// Vertical:
-			// std::string txt = patch->patch_name;
-			// txt.append("\n");
-			// txt.append(std::string_view(patch->knob_sets[active_knobset].name));
-			// lv_label_set_text(ui_PatchName, txt.c_str());
-			// lv_obj_set_height(ui_PatchName, LV_SIZE_CONTENT);
-			// lv_hide(ui_KnobSetName);
-
-			// Horizontal:
-			lv_label_set_text(ui_KnobSetName, patch->knob_sets[active_knobset].name.c_str());
+			lv_label_set_text(ui_KnobSetName, patch->valid_knob_set_name(active_knobset));
 			lv_show(ui_KnobSetName);
 		} else {
-			lv_obj_set_style_text_font(ui_PatchName, &ui_font_MuseoSansRounded70016, LV_STATE_DEFAULT);
-			lv_label_set_text(ui_PatchName, patch->patch_name.c_str());
-
-			// Vertical:
-			// lv_obj_set_height(ui_PatchName, 20);
-
-			// Horizontal:
 			lv_hide(ui_KnobSetName);
 		}
 
 		if (settings.patch_view.float_loadmeter) {
+			lv_show(ui_LoadMeter2);
 			lv_obj_set_parent(ui_LoadMeter2, lv_layer_sys());
 			lv_obj_set_style_bg_opa(ui_LoadMeter2, LV_OPA_80, 0);
 		} else {
-			lv_obj_set_parent(ui_LoadMeter2, lv_obj_get_parent(ui_PatchName));
+			lv_show(ui_LoadMeter2);
+			lv_obj_set_parent(ui_LoadMeter2, ui_PatchViewPage);
+			lv_obj_move_to_index(ui_LoadMeter2, 2);
 			lv_obj_set_style_bg_opa(ui_LoadMeter2, LV_OPA_0, 0);
 		}
 	}

--- a/firmware/src/gui/pages/patch_view_settings_menu.hh
+++ b/firmware/src/gui/pages/patch_view_settings_menu.hh
@@ -1,7 +1,6 @@
 #pragma once
-#include "gui/elements/map_ring_animate.hh"
+#include "gui/gui_state.hh"
 #include "gui/helpers/lv_helpers.hh"
-#include "gui/pages/base.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/slsexport/ui_local.h"
 #include "lvgl.h"
@@ -37,6 +36,11 @@ struct PatchViewSettingsMenu {
 		lv_obj_move_to_index(graphics_settings, 2);
 		lv_obj_move_to_index(graphics_update_rate_label, 3);
 
+		auto show_samplerate_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Show Audio Settings");
+		show_samplerate_check = lv_obj_get_child(show_samplerate_cont, 1);
+
+		lv_obj_move_to_index(show_samplerate_cont, 4);
+
 		lv_obj_set_parent(ui_PVSettingsMenu, lv_layer_top());
 		lv_obj_add_event_cb(ui_SettingsButton, settings_button_cb, LV_EVENT_CLICKED, this);
 
@@ -63,12 +67,16 @@ struct PatchViewSettingsMenu {
 
 		lv_obj_add_event_cb(graphics_show_check, scroll_menu_down_cb, LV_EVENT_FOCUSED, this);
 
+		lv_obj_add_event_cb(show_samplerate_check, show_titlebar_cb, LV_EVENT_VALUE_CHANGED, this);
+
 		lv_group_remove_all_objs(settings_menu_group);
 		lv_group_set_editing(settings_menu_group, false);
 		lv_group_add_obj(settings_menu_group, ui_PVSettingsCloseButton);
 
 		lv_group_add_obj(settings_menu_group, graphics_show_check);
 		lv_group_add_obj(settings_menu_group, graphics_update_rate_slider);
+
+		lv_group_add_obj(settings_menu_group, show_samplerate_check);
 
 		lv_group_add_obj(settings_menu_group, ui_PVShowControlMapsCheck);
 		lv_group_add_obj(settings_menu_group, ui_PVControlMapTranspSlider);
@@ -348,12 +356,31 @@ private:
 		lv_obj_scroll_to_view_recursive(page->graphics_update_rate_slider, LV_ANIM_ON);
 	}
 
+	static void show_titlebar_cb(lv_event_t *event) {
+		if (!event || !event->user_data)
+			return;
+
+		auto page = static_cast<PatchViewSettingsMenu *>(event->user_data);
+
+		auto show_samplerate = lv_obj_has_state(page->show_samplerate_check, LV_STATE_CHECKED);
+		page->settings.show_samplerate = show_samplerate;
+
+		// auto show_knobset_name = lv_obj_has_state(page->show_knobset_name_check, LV_STATE_CHECKED);
+		// page->settings.show_knobset_name = show_knobset_name;
+
+		page->settings.changed = true;
+		page->changed_while_visible = true;
+	}
+
 	lv_group_t *base_group = nullptr;
 	lv_group_t *settings_menu_group = nullptr;
 
 	lv_obj_t *graphics_show_check;
 	lv_obj_t *graphics_update_rate_label;
 	lv_obj_t *graphics_update_rate_slider;
+
+	lv_obj_t *show_samplerate_check;
+	// lv_obj_t *show_knobset_name_check;
 
 	bool visible = false;
 	bool changed_while_visible = false;

--- a/firmware/src/gui/pages/patch_view_settings_menu.hh
+++ b/firmware/src/gui/pages/patch_view_settings_menu.hh
@@ -38,8 +38,15 @@ struct PatchViewSettingsMenu {
 
 		auto show_samplerate_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Show Audio Settings");
 		show_samplerate_check = lv_obj_get_child(show_samplerate_cont, 1);
-
 		lv_obj_move_to_index(show_samplerate_cont, 4);
+
+		auto float_samplerate_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Keep Status on top");
+		float_audioload_check = lv_obj_get_child(float_samplerate_cont, 1);
+		lv_obj_move_to_index(float_samplerate_cont, 5);
+
+		auto show_knobset_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Show KnobSet Name");
+		show_knobset_name_check = lv_obj_get_child(show_knobset_cont, 1);
+		lv_obj_move_to_index(show_knobset_cont, 6);
 
 		lv_obj_set_parent(ui_PVSettingsMenu, lv_layer_top());
 		lv_obj_add_event_cb(ui_SettingsButton, settings_button_cb, LV_EVENT_CLICKED, this);
@@ -68,6 +75,8 @@ struct PatchViewSettingsMenu {
 		lv_obj_add_event_cb(graphics_show_check, scroll_menu_down_cb, LV_EVENT_FOCUSED, this);
 
 		lv_obj_add_event_cb(show_samplerate_check, show_titlebar_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(float_audioload_check, show_titlebar_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(show_knobset_name_check, show_titlebar_cb, LV_EVENT_VALUE_CHANGED, this);
 
 		lv_group_remove_all_objs(settings_menu_group);
 		lv_group_set_editing(settings_menu_group, false);
@@ -77,6 +86,8 @@ struct PatchViewSettingsMenu {
 		lv_group_add_obj(settings_menu_group, graphics_update_rate_slider);
 
 		lv_group_add_obj(settings_menu_group, show_samplerate_check);
+		lv_group_add_obj(settings_menu_group, float_audioload_check);
+		lv_group_add_obj(settings_menu_group, show_knobset_name_check);
 
 		lv_group_add_obj(settings_menu_group, ui_PVShowControlMapsCheck);
 		lv_group_add_obj(settings_menu_group, ui_PVControlMapTranspSlider);
@@ -115,6 +126,8 @@ struct PatchViewSettingsMenu {
 		lv_check(graphics_show_check, settings.show_graphic_screens);
 
 		lv_check(show_samplerate_check, settings.show_samplerate);
+		lv_check(float_audioload_check, settings.float_loadmeter);
+		lv_check(show_knobset_name_check, settings.show_knobset_name);
 
 		update_interactive_states();
 
@@ -364,11 +377,9 @@ private:
 
 		auto page = static_cast<PatchViewSettingsMenu *>(event->user_data);
 
-		auto show_samplerate = lv_obj_has_state(page->show_samplerate_check, LV_STATE_CHECKED);
-		page->settings.show_samplerate = show_samplerate;
-
-		// auto show_knobset_name = lv_obj_has_state(page->show_knobset_name_check, LV_STATE_CHECKED);
-		// page->settings.show_knobset_name = show_knobset_name;
+		page->settings.show_samplerate = lv_obj_has_state(page->show_samplerate_check, LV_STATE_CHECKED);
+		page->settings.float_loadmeter = lv_obj_has_state(page->float_audioload_check, LV_STATE_CHECKED);
+		page->settings.show_knobset_name = lv_obj_has_state(page->show_knobset_name_check, LV_STATE_CHECKED);
 
 		page->settings.changed = true;
 		page->changed_while_visible = true;
@@ -382,7 +393,8 @@ private:
 	lv_obj_t *graphics_update_rate_slider;
 
 	lv_obj_t *show_samplerate_check;
-	// lv_obj_t *show_knobset_name_check;
+	lv_obj_t *float_audioload_check;
+	lv_obj_t *show_knobset_name_check;
 
 	bool visible = false;
 	bool changed_while_visible = false;

--- a/firmware/src/gui/pages/patch_view_settings_menu.hh
+++ b/firmware/src/gui/pages/patch_view_settings_menu.hh
@@ -114,6 +114,8 @@ struct PatchViewSettingsMenu {
 
 		lv_check(graphics_show_check, settings.show_graphic_screens);
 
+		lv_check(show_samplerate_check, settings.show_samplerate);
+
 		update_interactive_states();
 
 		// 0..100 => 0..255

--- a/firmware/src/gui/pages/patch_view_settings_menu.hh
+++ b/firmware/src/gui/pages/patch_view_settings_menu.hh
@@ -16,7 +16,7 @@ struct PatchViewSettingsMenu {
 		, settings{settings}
 		, gui_state{gui_state} {
 
-		auto title = create_settings_menu_title(ui_PVSettingsMenu, "GRAPHICS");
+		auto graphics_title = create_settings_menu_title(ui_PVSettingsMenu, "GRAPHICS");
 
 		auto graphics_settings = create_settings_menu_switch(ui_PVSettingsMenu, "Draw Screens");
 		graphics_show_check = lv_obj_get_child(graphics_settings, 1);
@@ -32,21 +32,26 @@ struct PatchViewSettingsMenu {
 		lv_slider_set_value(
 			graphics_update_rate_slider, ModuleDisplaySettings::ThrottleAmounts.size() - 2, LV_ANIM_OFF);
 
-		lv_obj_move_to_index(title, 1);
+		lv_obj_move_to_index(graphics_title, 1);
 		lv_obj_move_to_index(graphics_settings, 2);
 		lv_obj_move_to_index(graphics_update_rate_label, 3);
 
+		auto bar_title = create_settings_menu_title(ui_PVSettingsMenu, "STATUS BAR");
+
 		auto show_samplerate_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Show Audio Settings");
 		show_samplerate_check = lv_obj_get_child(show_samplerate_cont, 1);
-		lv_obj_move_to_index(show_samplerate_cont, 4);
 
 		auto float_samplerate_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Keep Status on top");
+		lv_obj_set_style_border_width(float_samplerate_cont, 0, 0);
 		float_audioload_check = lv_obj_get_child(float_samplerate_cont, 1);
-		lv_obj_move_to_index(float_samplerate_cont, 5);
 
 		auto show_knobset_cont = create_settings_menu_switch(ui_PVSettingsMenu, "Show KnobSet Name");
 		show_knobset_name_check = lv_obj_get_child(show_knobset_cont, 1);
-		lv_obj_move_to_index(show_knobset_cont, 6);
+
+		lv_obj_move_to_index(bar_title, 4);
+		lv_obj_move_to_index(show_samplerate_cont, 5);
+		lv_obj_move_to_index(float_samplerate_cont, 6);
+		lv_obj_move_to_index(show_knobset_cont, 7);
 
 		lv_obj_set_parent(ui_PVSettingsMenu, lv_layer_top());
 		lv_obj_add_event_cb(ui_SettingsButton, settings_button_cb, LV_EVENT_CLICKED, this);

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -324,7 +324,7 @@ private:
 		if (catchup.mode != catchupmode || catchup.allow_jump_outofrange != catchup_exclude_buttons) {
 			catchup.mode = catchupmode;
 			catchup.allow_jump_outofrange = catchup_exclude_buttons;
-			patch_playloader.set_all_param_catchup_mode(catchup.mode, catchup.allow_jump_outofrange);
+			patch_playloader.update_param_catchup_mode();
 			gui_state.do_write_settings = true;
 		}
 

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -28,9 +28,9 @@ struct PrefsTab : SystemMenuTab {
 		init_SystemPrefsMidiPane(ui_SystemMenuPrefsTab);
 		init_SystemPrefsPatchSuggestedAudioPane(ui_SystemMenuPrefsTab);
 
-		auto sr_idx = lv_obj_get_child_id(ui_SystemPrefsAudioSamplerateCont);
+		auto sr_idx = lv_obj_get_index(ui_SystemPrefsAudioSamplerateCont);
 		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestSampleRateCont, sr_idx + 1);
-		auto bs_idx = lv_obj_get_child_id(ui_SystemPrefsAudioBlocksizeCont);
+		auto bs_idx = lv_obj_get_index(ui_SystemPrefsAudioBlocksizeCont);
 		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestBlocksizeCont, bs_idx + 1);
 
 		lv_obj_add_event_cb(ui_SystemPrefsSaveButton, save_cb, LV_EVENT_CLICKED, this);
@@ -127,6 +127,7 @@ struct PrefsTab : SystemMenuTab {
 
 		lv_group_add_obj(group, ui_SystemPrefsAudioSampleRateDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsPatchSuggestSampleRateCheck);
+		// TODO: clear overrides button
 		lv_group_add_obj(group, ui_SystemPrefsAudioBlocksizeDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsPatchSuggestBlocksizeCheck);
 		lv_group_add_obj(group, ui_SystemPrefsAudioOverrunRetriesDropdown);
@@ -215,6 +216,23 @@ private:
 
 		lv_disable(ui_SystemPrefsSaveButton);
 		lv_disable(ui_SystemPrefsRevertButton);
+
+		auto [cur_sr, cur_bs, _] = patch_playloader.get_audio_settings();
+		if (cur_sr >= 0 && cur_sr != settings.audio.sample_rate) {
+			std::string msg = "Allow patch to override:\n";
+			std::string current = "Current: " + std::to_string(cur_sr);
+			msg += Gui::orange_text(current);
+			lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, msg.c_str());
+		} else
+			lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, "Allow patch to override:");
+
+		if (cur_bs > 0 && cur_bs != settings.audio.block_size) {
+			std::string msg = "Allow patch to override:\n";
+			std::string current = "Current: " + std::to_string(cur_bs);
+			msg += Gui::orange_text(current);
+			lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, msg.c_str());
+		} else
+			lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, "Allow patch to override:");
 	}
 
 	uint32_t read_samplerate_dropdown() {

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -28,6 +28,11 @@ struct PrefsTab : SystemMenuTab {
 		init_SystemPrefsMidiPane(ui_SystemMenuPrefsTab);
 		init_SystemPrefsPatchSuggestedAudioPane(ui_SystemMenuPrefsTab);
 
+		auto sr_idx = lv_obj_get_child_id(ui_SystemPrefsAudioSamplerateCont);
+		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestSampleRateCont, sr_idx + 1);
+		auto bs_idx = lv_obj_get_child_id(ui_SystemPrefsAudioBlocksizeCont);
+		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestBlocksizeCont, bs_idx + 1);
+
 		lv_obj_add_event_cb(ui_SystemPrefsSaveButton, save_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_SystemPrefsRevertButton, revert_cb, LV_EVENT_CLICKED, this);
 
@@ -105,7 +110,9 @@ struct PrefsTab : SystemMenuTab {
 		this->group = group;
 
 		lv_group_remove_obj(ui_SystemPrefsAudioSampleRateDropdown);
+		lv_group_remove_obj(ui_SystemPrefsPatchSuggestSampleRateCheck);
 		lv_group_remove_obj(ui_SystemPrefsAudioBlocksizeDropdown);
+		lv_group_remove_obj(ui_SystemPrefsPatchSuggestBlocksizeCheck);
 		lv_group_remove_obj(ui_SystemPrefsAudioOverrunRetriesDropdown);
 		lv_group_remove_obj(ui_SystemPrefsScreensaverTimeDropdown);
 		lv_group_remove_obj(ui_SystemPrefsScreensaverKnobsCheck);
@@ -114,14 +121,14 @@ struct PrefsTab : SystemMenuTab {
 		lv_group_remove_obj(ui_SystemPrefsFSStartupPatchCheck);
 		lv_group_remove_obj(ui_SystemPrefsFSMaxPatchesDropdown);
 		lv_group_remove_obj(ui_SystemPrefsMidiFeedbackCheck);
-		lv_group_remove_obj(ui_SystemPrefsPatchSuggestSampleRateCheck);
-		lv_group_remove_obj(ui_SystemPrefsPatchSuggestBlocksizeCheck);
 
 		lv_group_remove_obj(ui_SystemPrefsRevertButton);
 		lv_group_remove_obj(ui_SystemPrefsSaveButton);
 
 		lv_group_add_obj(group, ui_SystemPrefsAudioSampleRateDropdown);
+		lv_group_add_obj(group, ui_SystemPrefsPatchSuggestSampleRateCheck);
 		lv_group_add_obj(group, ui_SystemPrefsAudioBlocksizeDropdown);
+		lv_group_add_obj(group, ui_SystemPrefsPatchSuggestBlocksizeCheck);
 		lv_group_add_obj(group, ui_SystemPrefsAudioOverrunRetriesDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsScreensaverTimeDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsScreensaverKnobsCheck);
@@ -130,8 +137,6 @@ struct PrefsTab : SystemMenuTab {
 		lv_group_add_obj(group, ui_SystemPrefsFSStartupPatchCheck);
 		lv_group_add_obj(group, ui_SystemPrefsFSMaxPatchesDropdown);
 		lv_group_add_obj(group, ui_SystemPrefsMidiFeedbackCheck);
-		lv_group_add_obj(group, ui_SystemPrefsPatchSuggestSampleRateCheck);
-		lv_group_add_obj(group, ui_SystemPrefsPatchSuggestBlocksizeCheck);
 
 		lv_group_add_obj(group, ui_SystemPrefsRevertButton);
 		lv_group_add_obj(group, ui_SystemPrefsSaveButton);
@@ -349,7 +354,6 @@ private:
 		{
 			settings.patch_suggested_audio.apply_samplerate = apply_sr;
 			settings.patch_suggested_audio.apply_blocksize = apply_bs;
-			patch_playloader.set_apply_suggested_audio(apply_sr, apply_bs);
 			gui_state.do_write_settings = true;
 		}
 
@@ -464,7 +468,7 @@ private:
 		auto target = event->target;
 
 		// scroll to bottom if we select last items
-		if (target == ui_SystemPrefsPatchSuggestSampleRateCheck || target == ui_SystemPrefsPatchSuggestBlocksizeCheck) {
+		if (target == ui_SystemPrefsMidiFeedbackCheck) {
 			lv_obj_scroll_to_view_recursive(ui_SystemPrefsSaveButton, LV_ANIM_ON);
 
 			// scroll to top if we select first items

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -32,11 +32,13 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestSROverrideCont, sr_idx + 1);
 		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestSampleRateCont, sr_idx + 2);
 		lv_hide(ui_SystemPrefsPatchSuggestSROverrideCont);
+		lv_obj_set_style_text_color(ui_SystemPrefsPatchSuggestSROverrideCont, Gui::orange_highlight, 0);
 
 		auto bs_idx = lv_obj_get_index(ui_SystemPrefsAudioBlocksizeCont);
 		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestBSOverrideCont, bs_idx + 1);
 		lv_obj_move_to_index(ui_SystemPrefsPatchSuggestBlocksizeCont, bs_idx + 2);
 		lv_hide(ui_SystemPrefsPatchSuggestBSOverrideCont);
+		lv_obj_set_style_text_color(ui_SystemPrefsPatchSuggestBSOverrideCont, Gui::orange_highlight, 0);
 
 		lv_obj_add_event_cb(ui_SystemPrefsSaveButton, save_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_SystemPrefsRevertButton, revert_cb, LV_EVENT_CLICKED, this);

--- a/firmware/src/gui/slsexport/CMakeLists.txt
+++ b/firmware/src/gui/slsexport/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(ui_lvgl PRIVATE
   prefs_pane_catchup.cc
   prefs_pane_fs.cc
   prefs_pane_midi.cc
+  prefs_pane_patch_suggested_audio.cc
 
   filebrowser/ui.c
   filebrowser/screens/ui_FileBrowserPage.c
@@ -17,5 +18,6 @@ set_source_files_properties(
   prefs_pane_catchup.cc
   prefs_pane_fs.cc
   prefs_pane_midi.cc
+  prefs_pane_patch_suggested_audio.cc
   PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-enum-enum-conversion;-Wno-deprecated-anon-enum-enum-conversion;"
 )

--- a/firmware/src/gui/slsexport/meta5/screens/ui_MainMenu.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_MainMenu.c
@@ -304,7 +304,7 @@ lv_obj_set_style_pad_top(ui_MenuLabelSettings, 12, LV_PART_MAIN| LV_STATE_DEFAUL
 lv_obj_set_style_pad_bottom(ui_MenuLabelSettings, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 
 ui_MainMenuLoadMeter = lv_label_create(ui_MainMenu);
-lv_obj_set_width( ui_MainMenuLoadMeter, 89);
+lv_obj_set_width( ui_MainMenuLoadMeter, LV_SIZE_CONTENT);
 lv_obj_set_height( ui_MainMenuLoadMeter, 20);
 lv_obj_set_x( ui_MainMenuLoadMeter, -4 );
 lv_obj_set_y( ui_MainMenuLoadMeter, 217 );

--- a/firmware/src/gui/slsexport/meta5/screens/ui_MainMenu.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_MainMenu.c
@@ -325,5 +325,6 @@ lv_obj_set_style_pad_left(ui_MainMenuLoadMeter, 1, LV_PART_MAIN| LV_STATE_DEFAUL
 lv_obj_set_style_pad_right(ui_MainMenuLoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_top(ui_MainMenuLoadMeter, 2, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_bottom(ui_MainMenuLoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_label_set_recolor(ui_MainMenuLoadMeter, 1);
 
 }

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchSelectorPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchSelectorPage.c
@@ -125,6 +125,7 @@ lv_obj_set_style_pad_left(ui_LoadMeter, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_right(ui_LoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_top(ui_LoadMeter, 2, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_bottom(ui_LoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_label_set_recolor(ui_LoadMeter, 1);
 
 ui_DrivesPanel = lv_obj_create(ui_PatchSelectorPage);
 lv_obj_set_width( ui_DrivesPanel, 103);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchSelectorPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchSelectorPage.c
@@ -102,7 +102,7 @@ lv_obj_set_style_pad_top(ui_NowPlayingName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_bottom(ui_NowPlayingName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 
 ui_LoadMeter = lv_label_create(ui_PatchSelectorTitlePanel);
-lv_obj_set_width( ui_LoadMeter, 38);
+lv_obj_set_width( ui_LoadMeter, LV_SIZE_CONTENT);
 lv_obj_set_height( ui_LoadMeter, 20);
 lv_obj_set_x( ui_LoadMeter, 0 );
 lv_obj_set_y( ui_LoadMeter, 2 );
@@ -120,7 +120,7 @@ lv_obj_set_style_text_align(ui_LoadMeter, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN| LV
 lv_obj_set_style_text_font(ui_LoadMeter, &ui_font_MuseoSansRounded50014, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_radius(ui_LoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_bg_color(ui_LoadMeter, lv_color_hex(0x202328), LV_PART_MAIN | LV_STATE_DEFAULT );
-lv_obj_set_style_bg_opa(ui_LoadMeter, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_bg_opa(ui_LoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_left(ui_LoadMeter, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_right(ui_LoadMeter, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_top(ui_LoadMeter, 2, LV_PART_MAIN| LV_STATE_DEFAULT);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
@@ -125,6 +125,7 @@ lv_obj_set_style_pad_left(ui_LoadMeter2, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_right(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_top(ui_LoadMeter2, 2, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_bottom(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_label_set_recolor(ui_LoadMeter2, 1);
 
 ui_ButtonsContainer = lv_obj_create(ui_PatchViewPage);
 lv_obj_set_height( ui_ButtonsContainer, 50);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
@@ -56,7 +56,7 @@ lv_obj_set_style_pad_row(ui_PatchViewPage, 0, LV_PART_SCROLLBAR| LV_STATE_FOCUS_
 lv_obj_set_style_pad_column(ui_PatchViewPage, 0, LV_PART_SCROLLBAR| LV_STATE_FOCUS_KEY);
 
 ui_PatchName = lv_label_create(ui_PatchViewPage);
-lv_obj_set_width( ui_PatchName, 260);
+lv_obj_set_flex_grow(ui_PatchName, 1);
 lv_obj_set_height( ui_PatchName, 20);
 lv_obj_set_x( ui_PatchName, 0 );
 lv_obj_set_y( ui_PatchName, 60 );
@@ -80,25 +80,22 @@ lv_obj_set_style_pad_row(ui_PatchName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_column(ui_PatchName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 
 ui_LoadMeter2 = lv_label_create(ui_PatchViewPage);
-lv_obj_set_width( ui_LoadMeter2, 40);
+lv_obj_set_width( ui_LoadMeter2, LV_SIZE_CONTENT);
 lv_obj_set_height( ui_LoadMeter2, 20);
 lv_obj_set_x( ui_LoadMeter2, 0 );
 lv_obj_set_y( ui_LoadMeter2, 2 );
 lv_obj_set_align( ui_LoadMeter2, LV_ALIGN_TOP_RIGHT );
-// lv_obj_set_flex_flow(ui_LoadMeter2,LV_FLEX_FLOW_ROW);
-// lv_obj_set_flex_align(ui_LoadMeter2, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY);
-// lv_label_set_text(ui_LoadMeter2,"100%");
 lv_obj_clear_flag( ui_LoadMeter2, LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN );    /// Flags
 lv_obj_set_scrollbar_mode(ui_LoadMeter2, LV_SCROLLBAR_MODE_OFF);
 lv_obj_set_style_text_color(ui_LoadMeter2, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_DEFAULT );
 lv_obj_set_style_text_opa(ui_LoadMeter2, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_letter_space(ui_LoadMeter2, -2, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_letter_space(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_line_space(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_align(ui_LoadMeter2, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_font(ui_LoadMeter2, &ui_font_MuseoSansRounded50014, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_radius(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_bg_color(ui_LoadMeter2, lv_color_hex(0x202328), LV_PART_MAIN | LV_STATE_DEFAULT );
-lv_obj_set_style_bg_opa(ui_LoadMeter2, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_bg_opa(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_left(ui_LoadMeter2, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_right(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_top(ui_LoadMeter2, 2, LV_PART_MAIN| LV_STATE_DEFAULT);
@@ -1531,6 +1528,8 @@ lv_obj_set_width( ui_DescriptionCont, lv_pct(100));
 lv_obj_set_height( ui_DescriptionCont, LV_SIZE_CONTENT);
 lv_obj_set_style_pad_ver(ui_DescriptionCont, 4, LV_STATE_DEFAULT);
 lv_obj_set_style_pad_hor(ui_DescriptionCont, 4, LV_STATE_DEFAULT);
+lv_obj_set_style_border_color(ui_DescriptionCont, lv_color_hex(0x888888), LV_STATE_DEFAULT);
+lv_obj_set_style_border_width(ui_DescriptionCont, 1, LV_STATE_DEFAULT);
 
 ui_Description = lv_label_create(ui_DescriptionCont);
 lv_obj_set_width( ui_Description, lv_pct(100));

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
@@ -85,14 +85,14 @@ lv_obj_set_height( ui_LoadMeter2, 20);
 lv_obj_set_x( ui_LoadMeter2, 0 );
 lv_obj_set_y( ui_LoadMeter2, 2 );
 lv_obj_set_align( ui_LoadMeter2, LV_ALIGN_TOP_RIGHT );
-lv_obj_set_flex_flow(ui_LoadMeter2,LV_FLEX_FLOW_ROW);
-lv_obj_set_flex_align(ui_LoadMeter2, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY);
-lv_label_set_text(ui_LoadMeter2,"100%");
+// lv_obj_set_flex_flow(ui_LoadMeter2,LV_FLEX_FLOW_ROW);
+// lv_obj_set_flex_align(ui_LoadMeter2, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY);
+// lv_label_set_text(ui_LoadMeter2,"100%");
 lv_obj_clear_flag( ui_LoadMeter2, LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN );    /// Flags
 lv_obj_set_scrollbar_mode(ui_LoadMeter2, LV_SCROLLBAR_MODE_OFF);
 lv_obj_set_style_text_color(ui_LoadMeter2, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_DEFAULT );
 lv_obj_set_style_text_opa(ui_LoadMeter2, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_letter_space(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_letter_space(ui_LoadMeter2, -2, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_line_space(ui_LoadMeter2, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_align(ui_LoadMeter2, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_font(ui_LoadMeter2, &ui_font_MuseoSansRounded50014, LV_PART_MAIN| LV_STATE_DEFAULT);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
@@ -79,6 +79,31 @@ lv_obj_set_style_pad_bottom(ui_PatchName, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_row(ui_PatchName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_column(ui_PatchName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 
+ui_KnobSetName = lv_label_create(ui_PatchViewPage);
+lv_obj_set_flex_grow(ui_KnobSetName, 1);
+lv_obj_set_height( ui_KnobSetName, 20);
+lv_obj_set_x( ui_KnobSetName, 0 );
+lv_obj_set_y( ui_KnobSetName, 60 );
+lv_obj_set_align( ui_KnobSetName, LV_ALIGN_CENTER );
+lv_label_set_long_mode(ui_KnobSetName,LV_LABEL_LONG_SCROLL);
+lv_label_set_text(ui_KnobSetName,"Patch Name Here");
+lv_obj_clear_flag( ui_KnobSetName, LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM );    /// Flags
+lv_obj_set_scroll_dir(ui_KnobSetName, LV_DIR_HOR);
+lv_obj_set_style_text_color(ui_KnobSetName, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
+lv_obj_set_style_text_opa(ui_KnobSetName, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_letter_space(ui_KnobSetName, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_line_space(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_align(ui_KnobSetName, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_decor(ui_KnobSetName, LV_TEXT_DECOR_NONE, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_font(ui_KnobSetName, &ui_font_MuseoSansRounded70016, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_left(ui_KnobSetName, 6, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_right(ui_KnobSetName, 6, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_top(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_bottom(ui_KnobSetName, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_row(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_column(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_add_flag(ui_KnobSetName, LV_OBJ_FLAG_HIDDEN);
+
 ui_LoadMeter2 = lv_label_create(ui_PatchViewPage);
 lv_obj_set_width( ui_LoadMeter2, LV_SIZE_CONTENT);
 lv_obj_set_height( ui_LoadMeter2, 20);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
@@ -1467,7 +1467,7 @@ lv_obj_set_style_outline_opa(ui_DescriptionPanel, 255, LV_PART_MAIN| LV_STATE_DE
 lv_obj_set_style_outline_width(ui_DescriptionPanel, 3, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_outline_pad(ui_DescriptionPanel, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_left(ui_DescriptionPanel, 10, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_pad_right(ui_DescriptionPanel, 10, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_right(ui_DescriptionPanel, 20, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_top(ui_DescriptionPanel, 8, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_bottom(ui_DescriptionPanel, 8, LV_PART_MAIN| LV_STATE_DEFAULT);
 
@@ -1525,12 +1525,17 @@ lv_obj_set_style_text_color(ui_DescPanelFileName, lv_color_hex(0xFFFFFF), LV_PAR
 lv_obj_set_style_text_opa(ui_DescPanelFileName, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_align(ui_DescPanelFileName, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN| LV_STATE_DEFAULT);
 
-ui_Description = lv_label_create(ui_DescriptionPanel);
+lv_obj_t *ui_DescriptionCont = lv_btn_create(ui_DescriptionPanel);
+lv_obj_remove_style_all(ui_DescriptionCont);
+lv_obj_set_width( ui_DescriptionCont, lv_pct(100));
+lv_obj_set_height( ui_DescriptionCont, LV_SIZE_CONTENT);
+lv_obj_set_style_pad_ver(ui_DescriptionCont, 4, LV_STATE_DEFAULT);
+lv_obj_set_style_pad_hor(ui_DescriptionCont, 4, LV_STATE_DEFAULT);
+
+ui_Description = lv_label_create(ui_DescriptionCont);
 lv_obj_set_width( ui_Description, lv_pct(100));
-lv_obj_set_height( ui_Description, LV_SIZE_CONTENT);   /// 1
-lv_obj_set_x( ui_Description, -8 );
-lv_obj_set_y( ui_Description, -16 );
-lv_obj_set_align( ui_Description, LV_ALIGN_TOP_MID );
+lv_obj_set_height( ui_Description, LV_SIZE_CONTENT);
+lv_obj_set_align( ui_Description, LV_ALIGN_CENTER );
 lv_label_set_text(ui_Description,"Patch Description: This patch has a description that can go on and on and on....");
 lv_obj_add_flag( ui_Description, LV_OBJ_FLAG_CLICKABLE );   /// Flags
 lv_obj_clear_flag( ui_Description, LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM );    /// Flags
@@ -2054,7 +2059,7 @@ ui_SaveDialogFileNameLabel = lv_label_create(ui_SaveDialogRightCont);
 lv_obj_set_width( ui_SaveDialogFileNameLabel, lv_pct(100));
 lv_obj_set_height( ui_SaveDialogFileNameLabel, LV_SIZE_CONTENT);   /// 1
 lv_obj_set_align( ui_SaveDialogFileNameLabel, LV_ALIGN_CENTER );
-lv_label_set_text(ui_SaveDialogFileNameLabel,"Save file as:");
+lv_label_set_text(ui_SaveDialogFileNameLabel,"File:");
 lv_obj_set_style_text_color(ui_SaveDialogFileNameLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
 lv_obj_set_style_text_opa(ui_SaveDialogFileNameLabel, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_font(ui_SaveDialogFileNameLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN| LV_STATE_DEFAULT);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_PatchViewPage.c
@@ -67,7 +67,7 @@ lv_obj_clear_flag( ui_PatchName, LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCU
 lv_obj_set_scroll_dir(ui_PatchName, LV_DIR_HOR);
 lv_obj_set_style_text_color(ui_PatchName, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
 lv_obj_set_style_text_opa(ui_PatchName, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_letter_space(ui_PatchName, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_letter_space(ui_PatchName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_line_space(ui_PatchName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_align(ui_PatchName, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_decor(ui_PatchName, LV_TEXT_DECOR_NONE, LV_PART_MAIN| LV_STATE_DEFAULT);
@@ -91,14 +91,14 @@ lv_obj_clear_flag( ui_KnobSetName, LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FO
 lv_obj_set_scroll_dir(ui_KnobSetName, LV_DIR_HOR);
 lv_obj_set_style_text_color(ui_KnobSetName, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
 lv_obj_set_style_text_opa(ui_KnobSetName, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_letter_space(ui_KnobSetName, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_letter_space(ui_KnobSetName, -1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_line_space(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_align(ui_KnobSetName, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_decor(ui_KnobSetName, LV_TEXT_DECOR_NONE, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_font(ui_KnobSetName, &ui_font_MuseoSansRounded70016, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_text_font(ui_KnobSetName, &ui_font_MuseoSansRounded50014, LV_STATE_DEFAULT);
 lv_obj_set_style_pad_left(ui_KnobSetName, 6, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_right(ui_KnobSetName, 6, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_pad_top(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_obj_set_style_pad_top(ui_KnobSetName, 2, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_bottom(ui_KnobSetName, 1, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_row(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_pad_column(ui_KnobSetName, 0, LV_PART_MAIN| LV_STATE_DEFAULT);

--- a/firmware/src/gui/slsexport/meta5/screens/ui_SystemMenu.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_SystemMenu.c
@@ -602,9 +602,10 @@ lv_obj_set_height( ui_SystemPrefsAudioSampleRateLabel, LV_SIZE_CONTENT);   /// 1
 lv_obj_set_align( ui_SystemPrefsAudioSampleRateLabel, LV_ALIGN_CENTER );
 lv_label_set_text(ui_SystemPrefsAudioSampleRateLabel,"Sample Rate:");
 lv_obj_set_style_text_font(ui_SystemPrefsAudioSampleRateLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_label_set_recolor(ui_SystemPrefsAudioSampleRateLabel, 1);
 
 ui_SystemPrefsAudioSampleRateDropdown = lv_dropdown_create(ui_SystemPrefsAudioSamplerateCont);
-lv_dropdown_set_options( ui_SystemPrefsAudioSampleRateDropdown, "24kHz\n48kHz\n96kHz" );
+lv_dropdown_set_options( ui_SystemPrefsAudioSampleRateDropdown, "24kHz\n32kHz\n48kHz\n96kHz" );
 lv_obj_set_width( ui_SystemPrefsAudioSampleRateDropdown, 90);
 lv_obj_set_height( ui_SystemPrefsAudioSampleRateDropdown, LV_SIZE_CONTENT);   /// 1
 lv_obj_set_align( ui_SystemPrefsAudioSampleRateDropdown, LV_ALIGN_CENTER );
@@ -652,6 +653,7 @@ lv_obj_set_height( ui_SystemPrefsAudioBlocksizeLabel, LV_SIZE_CONTENT);   /// 1
 lv_obj_set_align( ui_SystemPrefsAudioBlocksizeLabel, LV_ALIGN_CENTER );
 lv_label_set_text(ui_SystemPrefsAudioBlocksizeLabel,"Block Size:");
 lv_obj_set_style_text_font(ui_SystemPrefsAudioBlocksizeLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN| LV_STATE_DEFAULT);
+lv_label_set_recolor(ui_SystemPrefsAudioBlocksizeLabel, 1);
 
 ui_SystemPrefsAudioBlocksizeDropdown = lv_dropdown_create(ui_SystemPrefsAudioBlocksizeCont);
 lv_dropdown_set_options( ui_SystemPrefsAudioBlocksizeDropdown, "32\n64\n128\n256\n512" );

--- a/firmware/src/gui/slsexport/meta5/ui.c
+++ b/firmware/src/gui/slsexport/meta5/ui.c
@@ -69,6 +69,7 @@ lv_obj_t *ui_waitspinner;
 void ui_PatchViewPage_screen_init(void);
 lv_obj_t *ui_PatchViewPage;
 lv_obj_t *ui_PatchName;
+lv_obj_t *ui_KnobSetName;
 lv_obj_t *ui_LoadMeter2;
 lv_obj_t *ui_ButtonsContainer;
 lv_obj_t *ui_PlayButton;

--- a/firmware/src/gui/slsexport/meta5/ui.h
+++ b/firmware/src/gui/slsexport/meta5/ui.h
@@ -73,6 +73,7 @@ extern lv_obj_t *ui_waitspinner;
 void ui_PatchViewPage_screen_init(void);
 extern lv_obj_t *ui_PatchViewPage;
 extern lv_obj_t *ui_PatchName;
+extern lv_obj_t *ui_KnobSetName;
 extern lv_obj_t *ui_LoadMeter2;
 extern lv_obj_t *ui_ButtonsContainer;
 extern lv_obj_t *ui_PlayButton;

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
@@ -1,0 +1,90 @@
+
+#include "lvgl.h"
+#include "meta5/ui.h"
+#include "ui_local.h"
+
+namespace MetaModule
+{
+
+lv_obj_t *ui_SystemPrefsPatchSuggestTitle;
+lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCont;
+lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateLabel;
+lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCheck;
+
+lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCont;
+lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeLabel;
+lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCheck;
+
+void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
+	// Title
+	ui_SystemPrefsPatchSuggestTitle = lv_label_create(parentTab);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestTitle, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestTitle, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestTitle, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestTitle, "Patch Audio Suggestions");
+	lv_obj_set_style_text_color(ui_SystemPrefsPatchSuggestTitle, lv_color_hex(0xFD8B18), LV_PART_MAIN);
+	lv_obj_set_style_text_opa(ui_SystemPrefsPatchSuggestTitle, 255, LV_PART_MAIN);
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestTitle, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+	lv_obj_set_style_border_color(ui_SystemPrefsPatchSuggestTitle, lv_color_hex(0x888888), LV_PART_MAIN);
+	lv_obj_set_style_border_opa(ui_SystemPrefsPatchSuggestTitle, 255, LV_PART_MAIN);
+	lv_obj_set_style_border_width(ui_SystemPrefsPatchSuggestTitle, 2, LV_PART_MAIN);
+	lv_obj_set_style_border_side(ui_SystemPrefsPatchSuggestTitle, LV_BORDER_SIDE_BOTTOM, LV_PART_MAIN);
+	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestTitle, 0, LV_PART_MAIN);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestTitle, 0, LV_PART_MAIN);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestTitle, 6, LV_PART_MAIN);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestTitle, 2, LV_PART_MAIN);
+
+	// Samplerate row
+	ui_SystemPrefsPatchSuggestSampleRateCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsPatchSuggestSampleRateCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestSampleRateCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestSampleRateCont, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestSampleRateCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsPatchSuggestSampleRateCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(ui_SystemPrefsPatchSuggestSampleRateCont,
+						  LV_FLEX_ALIGN_SPACE_BETWEEN,
+						  LV_FLEX_ALIGN_CENTER,
+						  LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsPatchSuggestSampleRateCont, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestSampleRateCont, 2, LV_PART_MAIN);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestSampleRateCont, 4, LV_PART_MAIN);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestSampleRateCont, 4, LV_PART_MAIN);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestSampleRateCont, 4, LV_PART_MAIN);
+
+	ui_SystemPrefsPatchSuggestSampleRateLabel = lv_label_create(ui_SystemPrefsPatchSuggestSampleRateCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_SIZE_CONTENT);
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, "Apply samplerate:");
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestSampleRateLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+
+	ui_SystemPrefsPatchSuggestSampleRateCheck = create_prefs_check(ui_SystemPrefsPatchSuggestSampleRateCont);
+
+	// Blocksize row
+	ui_SystemPrefsPatchSuggestBlocksizeCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsPatchSuggestBlocksizeCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestBlocksizeCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestBlocksizeCont, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestBlocksizeCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsPatchSuggestBlocksizeCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(ui_SystemPrefsPatchSuggestBlocksizeCont,
+						  LV_FLEX_ALIGN_SPACE_BETWEEN,
+						  LV_FLEX_ALIGN_CENTER,
+						  LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsPatchSuggestBlocksizeCont, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestBlocksizeCont, 2, LV_PART_MAIN);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestBlocksizeCont, 4, LV_PART_MAIN);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestBlocksizeCont, 4, LV_PART_MAIN);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestBlocksizeCont, 4, LV_PART_MAIN);
+
+	ui_SystemPrefsPatchSuggestBlocksizeLabel = lv_label_create(ui_SystemPrefsPatchSuggestBlocksizeCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_SIZE_CONTENT);
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_SIZE_CONTENT);
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, "Apply blocksize:");
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestBlocksizeLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+
+	ui_SystemPrefsPatchSuggestBlocksizeCheck = create_prefs_check(ui_SystemPrefsPatchSuggestBlocksizeCont);
+}
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
@@ -63,8 +63,8 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
 	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestSROverrideCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
 	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestSROverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestSROverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestSROverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestSROverrideCont, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestSROverrideCont, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
 	auto sr_title = lv_label_create(ui_SystemPrefsPatchSuggestSROverrideCont);
 	lv_obj_set_width(sr_title, LV_SIZE_CONTENT);  /// 1
@@ -125,8 +125,8 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
 	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestBSOverrideCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
 	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestBSOverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestBSOverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestBSOverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestBSOverrideCont, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestBSOverrideCont, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
 	auto bs_title = lv_label_create(ui_SystemPrefsPatchSuggestBSOverrideCont);
 	lv_obj_set_width(bs_title, LV_SIZE_CONTENT);  /// 1

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
@@ -38,6 +38,7 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_align(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_ALIGN_CENTER);
 	lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, "Allow patch to override:");
 	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestSampleRateLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
+	lv_label_set_recolor(ui_SystemPrefsPatchSuggestSampleRateLabel, 1);
 
 	ui_SystemPrefsPatchSuggestSampleRateCheck = create_prefs_check(ui_SystemPrefsPatchSuggestSampleRateCont);
 
@@ -64,6 +65,7 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_align(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_ALIGN_CENTER);
 	lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, "Allow patch to override:");
 	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestBlocksizeLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
+	lv_label_set_recolor(ui_SystemPrefsPatchSuggestBlocksizeLabel, 1);
 
 	ui_SystemPrefsPatchSuggestBlocksizeCheck = create_prefs_check(ui_SystemPrefsPatchSuggestBlocksizeCont);
 }

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
@@ -6,7 +6,6 @@
 namespace MetaModule
 {
 
-lv_obj_t *ui_SystemPrefsPatchSuggestTitle;
 lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCont;
 lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateLabel;
 lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCheck;
@@ -16,24 +15,6 @@ lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeLabel;
 lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCheck;
 
 void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
-	// Title
-	ui_SystemPrefsPatchSuggestTitle = lv_label_create(parentTab);
-	lv_obj_set_width(ui_SystemPrefsPatchSuggestTitle, lv_pct(100));
-	lv_obj_set_height(ui_SystemPrefsPatchSuggestTitle, LV_SIZE_CONTENT);
-	lv_obj_set_align(ui_SystemPrefsPatchSuggestTitle, LV_ALIGN_CENTER);
-	lv_label_set_text(ui_SystemPrefsPatchSuggestTitle, "Patch Audio Suggestions");
-	lv_obj_set_style_text_color(ui_SystemPrefsPatchSuggestTitle, lv_color_hex(0xFD8B18), LV_PART_MAIN);
-	lv_obj_set_style_text_opa(ui_SystemPrefsPatchSuggestTitle, 255, LV_PART_MAIN);
-	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestTitle, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
-	lv_obj_set_style_border_color(ui_SystemPrefsPatchSuggestTitle, lv_color_hex(0x888888), LV_PART_MAIN);
-	lv_obj_set_style_border_opa(ui_SystemPrefsPatchSuggestTitle, 255, LV_PART_MAIN);
-	lv_obj_set_style_border_width(ui_SystemPrefsPatchSuggestTitle, 2, LV_PART_MAIN);
-	lv_obj_set_style_border_side(ui_SystemPrefsPatchSuggestTitle, LV_BORDER_SIDE_BOTTOM, LV_PART_MAIN);
-	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestTitle, 0, LV_PART_MAIN);
-	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestTitle, 0, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestTitle, 6, LV_PART_MAIN);
-	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestTitle, 2, LV_PART_MAIN);
-
 	// Samplerate row
 	ui_SystemPrefsPatchSuggestSampleRateCont = lv_obj_create(parentTab);
 	lv_obj_remove_style_all(ui_SystemPrefsPatchSuggestSampleRateCont);
@@ -55,8 +36,8 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_width(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_SIZE_CONTENT);
 	lv_obj_set_height(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_SIZE_CONTENT);
 	lv_obj_set_align(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_ALIGN_CENTER);
-	lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, "Apply samplerate:");
-	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestSampleRateLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, "Allow patch to override:");
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestSampleRateLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
 
 	ui_SystemPrefsPatchSuggestSampleRateCheck = create_prefs_check(ui_SystemPrefsPatchSuggestSampleRateCont);
 
@@ -81,8 +62,8 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_width(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_SIZE_CONTENT);
 	lv_obj_set_height(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_SIZE_CONTENT);
 	lv_obj_set_align(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_ALIGN_CENTER);
-	lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, "Apply blocksize:");
-	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestBlocksizeLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, "Allow patch to override:");
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestBlocksizeLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
 
 	ui_SystemPrefsPatchSuggestBlocksizeCheck = create_prefs_check(ui_SystemPrefsPatchSuggestBlocksizeCont);
 }

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.cc
@@ -9,10 +9,14 @@ namespace MetaModule
 lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCont;
 lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateLabel;
 lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCheck;
+lv_obj_t *ui_SystemPrefsPatchSuggestSROverrideCont;
+lv_obj_t *ui_SystemPrefsPatchSuggestSROverrideLabel;
 
 lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCont;
 lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeLabel;
 lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCheck;
+lv_obj_t *ui_SystemPrefsPatchSuggestBSOverrideCont;
+lv_obj_t *ui_SystemPrefsPatchSuggestBSOverrideLabel;
 
 void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	// Samplerate row
@@ -31,6 +35,9 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestSampleRateCont, 4, LV_PART_MAIN);
 	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestSampleRateCont, 4, LV_PART_MAIN);
 	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestSampleRateCont, 4, LV_PART_MAIN);
+	lv_obj_set_style_border_width(ui_SystemPrefsPatchSuggestSampleRateCont, 1, LV_PART_MAIN);
+	lv_obj_set_style_border_color(ui_SystemPrefsPatchSuggestSampleRateCont, lv_color_hex(0x888888), LV_PART_MAIN);
+	lv_obj_set_style_border_side(ui_SystemPrefsPatchSuggestSampleRateCont, LV_BORDER_SIDE_BOTTOM, LV_PART_MAIN);
 
 	ui_SystemPrefsPatchSuggestSampleRateLabel = lv_label_create(ui_SystemPrefsPatchSuggestSampleRateCont);
 	lv_obj_set_width(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_SIZE_CONTENT);
@@ -38,9 +45,41 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_align(ui_SystemPrefsPatchSuggestSampleRateLabel, LV_ALIGN_CENTER);
 	lv_label_set_text(ui_SystemPrefsPatchSuggestSampleRateLabel, "Allow patch to override:");
 	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestSampleRateLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
-	lv_label_set_recolor(ui_SystemPrefsPatchSuggestSampleRateLabel, 1);
 
 	ui_SystemPrefsPatchSuggestSampleRateCheck = create_prefs_check(ui_SystemPrefsPatchSuggestSampleRateCont);
+
+	// Patch Samplerate Override row:
+	ui_SystemPrefsPatchSuggestSROverrideCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsPatchSuggestSROverrideCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestSROverrideCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestSROverrideCont, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestSROverrideCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsPatchSuggestSROverrideCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(ui_SystemPrefsPatchSuggestSROverrideCont,
+						  LV_FLEX_ALIGN_SPACE_BETWEEN,
+						  LV_FLEX_ALIGN_CENTER,
+						  LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsPatchSuggestSROverrideCont,
+					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
+	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestSROverrideCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestSROverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestSROverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestSROverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	auto sr_title = lv_label_create(ui_SystemPrefsPatchSuggestSROverrideCont);
+	lv_obj_set_width(sr_title, LV_SIZE_CONTENT);  /// 1
+	lv_obj_set_height(sr_title, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(sr_title, LV_ALIGN_CENTER);
+	lv_label_set_text(sr_title, "Patch override:");
+	lv_obj_set_style_text_font(sr_title, &ui_font_MuseoSansRounded70016, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_SystemPrefsPatchSuggestSROverrideLabel = lv_label_create(ui_SystemPrefsPatchSuggestSROverrideCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestSROverrideLabel, LV_SIZE_CONTENT);  /// 1
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestSROverrideLabel, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestSROverrideLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestSROverrideLabel, "32kHz");
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestSROverrideLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestSROverrideLabel, 14, LV_PART_MAIN | LV_STATE_DEFAULT);
 
 	// Blocksize row
 	ui_SystemPrefsPatchSuggestBlocksizeCont = lv_obj_create(parentTab);
@@ -58,6 +97,9 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestBlocksizeCont, 4, LV_PART_MAIN);
 	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestBlocksizeCont, 4, LV_PART_MAIN);
 	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestBlocksizeCont, 4, LV_PART_MAIN);
+	lv_obj_set_style_border_width(ui_SystemPrefsPatchSuggestBlocksizeCont, 1, LV_PART_MAIN);
+	lv_obj_set_style_border_color(ui_SystemPrefsPatchSuggestBlocksizeCont, lv_color_hex(0x888888), LV_PART_MAIN);
+	lv_obj_set_style_border_side(ui_SystemPrefsPatchSuggestBlocksizeCont, LV_BORDER_SIDE_BOTTOM, LV_PART_MAIN);
 
 	ui_SystemPrefsPatchSuggestBlocksizeLabel = lv_label_create(ui_SystemPrefsPatchSuggestBlocksizeCont);
 	lv_obj_set_width(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_SIZE_CONTENT);
@@ -65,9 +107,41 @@ void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab) {
 	lv_obj_set_align(ui_SystemPrefsPatchSuggestBlocksizeLabel, LV_ALIGN_CENTER);
 	lv_label_set_text(ui_SystemPrefsPatchSuggestBlocksizeLabel, "Allow patch to override:");
 	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestBlocksizeLabel, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
-	lv_label_set_recolor(ui_SystemPrefsPatchSuggestBlocksizeLabel, 1);
 
 	ui_SystemPrefsPatchSuggestBlocksizeCheck = create_prefs_check(ui_SystemPrefsPatchSuggestBlocksizeCont);
+
+	// Patch Blocksize Override row:
+	ui_SystemPrefsPatchSuggestBSOverrideCont = lv_obj_create(parentTab);
+	lv_obj_remove_style_all(ui_SystemPrefsPatchSuggestBSOverrideCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestBSOverrideCont, lv_pct(100));
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestBSOverrideCont, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestBSOverrideCont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(ui_SystemPrefsPatchSuggestBSOverrideCont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(ui_SystemPrefsPatchSuggestBSOverrideCont,
+						  LV_FLEX_ALIGN_SPACE_BETWEEN,
+						  LV_FLEX_ALIGN_CENTER,
+						  LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(ui_SystemPrefsPatchSuggestBSOverrideCont,
+					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
+	lv_obj_set_style_pad_left(ui_SystemPrefsPatchSuggestBSOverrideCont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestBSOverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(ui_SystemPrefsPatchSuggestBSOverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(ui_SystemPrefsPatchSuggestBSOverrideCont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	auto bs_title = lv_label_create(ui_SystemPrefsPatchSuggestBSOverrideCont);
+	lv_obj_set_width(bs_title, LV_SIZE_CONTENT);  /// 1
+	lv_obj_set_height(bs_title, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(bs_title, LV_ALIGN_CENTER);
+	lv_label_set_text(bs_title, "Patch override:");
+	lv_obj_set_style_text_font(bs_title, &ui_font_MuseoSansRounded70016, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_SystemPrefsPatchSuggestBSOverrideLabel = lv_label_create(ui_SystemPrefsPatchSuggestBSOverrideCont);
+	lv_obj_set_width(ui_SystemPrefsPatchSuggestBSOverrideLabel, LV_SIZE_CONTENT);  /// 1
+	lv_obj_set_height(ui_SystemPrefsPatchSuggestBSOverrideLabel, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(ui_SystemPrefsPatchSuggestBSOverrideLabel, LV_ALIGN_CENTER);
+	lv_label_set_text(ui_SystemPrefsPatchSuggestBSOverrideLabel, "256");
+	lv_obj_set_style_text_font(ui_SystemPrefsPatchSuggestBSOverrideLabel, &ui_font_MuseoSansRounded70016, LV_PART_MAIN);
+	lv_obj_set_style_pad_right(ui_SystemPrefsPatchSuggestBSOverrideLabel, 14, LV_PART_MAIN | LV_STATE_DEFAULT);
 }
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.hh
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.hh
@@ -1,0 +1,18 @@
+#include "lvgl.h"
+
+namespace MetaModule
+{
+
+extern lv_obj_t *ui_SystemPrefsPatchSuggestTitle;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCont;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateLabel;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCheck;
+
+extern lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCont;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeLabel;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCheck;
+
+void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab);
+
+} // namespace MetaModule
+

--- a/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.hh
+++ b/firmware/src/gui/slsexport/prefs_pane_patch_suggested_audio.hh
@@ -7,12 +7,15 @@ extern lv_obj_t *ui_SystemPrefsPatchSuggestTitle;
 extern lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCont;
 extern lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateLabel;
 extern lv_obj_t *ui_SystemPrefsPatchSuggestSampleRateCheck;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestSROverrideCont;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestSROverrideLabel;
 
 extern lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCont;
 extern lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeLabel;
 extern lv_obj_t *ui_SystemPrefsPatchSuggestBlocksizeCheck;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestBSOverrideCont;
+extern lv_obj_t *ui_SystemPrefsPatchSuggestBSOverrideLabel;
 
 void init_SystemPrefsPatchSuggestedAudioPane(lv_obj_t *parentTab);
 
 } // namespace MetaModule
-

--- a/firmware/src/gui/slsexport/ui_local.cc
+++ b/firmware/src/gui/slsexport/ui_local.cc
@@ -956,4 +956,66 @@ lv_obj_t *create_button_expander_pane(lv_obj_t *parent) {
 	return obj;
 }
 
+// Returns a container where child 0 is the label and child 1 is the dropdown
+lv_obj_t *create_labeled_dropdown(lv_obj_t *parent) {
+	auto cont = lv_obj_create(parent);
+	lv_obj_remove_style_all(cont);
+	lv_obj_set_width(cont, lv_pct(100));
+	lv_obj_set_height(cont, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(cont, LV_ALIGN_CENTER);
+	lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_ROW);
+	lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+	lv_obj_clear_flag(cont, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
+	lv_obj_set_style_pad_left(cont, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(cont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(cont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(cont, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	auto label = lv_label_create(cont);
+	lv_obj_set_width(label, LV_SIZE_CONTENT);  /// 1
+	lv_obj_set_height(label, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(label, LV_ALIGN_CENTER);
+	lv_label_set_text(label, "");
+	lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded70016, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_label_set_recolor(label, 1);
+
+	auto dropdown = lv_dropdown_create(cont);
+	lv_dropdown_set_options(dropdown, "");
+	lv_obj_set_width(dropdown, 60);
+	lv_obj_set_height(dropdown, LV_SIZE_CONTENT); /// 1
+	lv_obj_set_align(dropdown, LV_ALIGN_CENTER);
+	lv_obj_clear_flag(dropdown,
+					  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE |
+						  LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM |
+						  LV_OBJ_FLAG_SCROLL_CHAIN); /// Flags
+	lv_obj_set_style_text_font(dropdown, &ui_font_MuseoSansRounded70014, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(dropdown, lv_color_hex(0x666666), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(dropdown, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_outline_color(dropdown, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_EDITED);
+	lv_obj_set_style_outline_opa(dropdown, 0, LV_PART_MAIN | LV_STATE_EDITED);
+	lv_obj_set_style_outline_color(dropdown, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_opa(dropdown, 255, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_width(dropdown, 2, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_pad(dropdown, 1, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_color(dropdown, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_opa(dropdown, 255, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+
+	lv_obj_set_style_text_font(dropdown, &lv_font_montserrat_14, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+
+	lv_obj_set_style_text_letter_space(lv_dropdown_get_list(dropdown), 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_line_space(lv_dropdown_get_list(dropdown), 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_radius(lv_dropdown_get_list(dropdown), 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(lv_dropdown_get_list(dropdown), lv_color_hex(0x666666), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(lv_dropdown_get_list(dropdown), 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	lv_obj_set_style_bg_color(
+		lv_dropdown_get_list(dropdown), lv_color_hex(0xFD8B18), LV_PART_SELECTED | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(lv_dropdown_get_list(dropdown), 255, LV_PART_SELECTED | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(
+		lv_dropdown_get_list(dropdown), lv_color_hex(0xFD8B18), LV_PART_SELECTED | LV_STATE_CHECKED);
+	lv_obj_set_style_bg_opa(lv_dropdown_get_list(dropdown), 255, LV_PART_SELECTED | LV_STATE_CHECKED);
+
+	return cont;
+}
+
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/ui_local.cc
+++ b/firmware/src/gui/slsexport/ui_local.cc
@@ -690,42 +690,37 @@ lv_obj_t *create_settings_menu_slider(lv_obj_t *parent, std::string const &slide
 	return slider_label;
 }
 
-lv_obj_t *create_midi_map_check(lv_obj_t *parent) {
+lv_obj_t *create_prefs_check(lv_obj_t *parent) {
 	auto check = lv_switch_create(parent);
-	lv_obj_set_width(check, 19);
-	lv_obj_set_height(check, 18);
-	lv_obj_set_align(check, LV_ALIGN_CENTER);
-	lv_obj_add_flag(check, LV_OBJ_FLAG_FLEX_IN_NEW_TRACK); /// Flags
+
+	lv_obj_set_width(check, 35);
+	lv_obj_set_height(check, 20);
+	lv_obj_set_align(check, LV_ALIGN_TOP_RIGHT);
+	lv_obj_add_flag(check, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+	lv_obj_clear_flag(check,
+					  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE |
+						  LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE);
 	lv_obj_set_style_radius(check, 20, LV_PART_MAIN | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_color(check, lv_color_hex(0x888888), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(check, lv_color_hex(0x202328), LV_PART_MAIN | LV_STATE_DEFAULT);
 	lv_obj_set_style_bg_opa(check, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_outline_color(check, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_opa(check, 255, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_width(check, 2, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_pad(check, 1, LV_PART_MAIN | LV_STATE_FOCUSED);
+	lv_obj_set_style_outline_color(check, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_opa(check, 255, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_width(check, 2, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+	lv_obj_set_style_outline_pad(check, 1, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
 
-	lv_obj_set_style_bg_color(check, lv_color_hex(0xDDDDDD), LV_PART_INDICATOR | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_opa(check, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
-	lv_obj_set_style_outline_color(check, lv_color_hex(0x333333), LV_PART_INDICATOR | LV_STATE_DEFAULT);
-	lv_obj_set_style_outline_opa(check, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
-	lv_obj_set_style_outline_width(check, 2, LV_PART_INDICATOR | LV_STATE_DEFAULT);
-	lv_obj_set_style_outline_pad(check, 1, LV_PART_INDICATOR | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_color(check, lv_color_hex(0xDDDDDD), LV_PART_INDICATOR | LV_STATE_CHECKED);
+	lv_obj_set_style_bg_color(check, lv_color_hex(0x4067D3), LV_PART_INDICATOR | LV_STATE_CHECKED);
 	lv_obj_set_style_bg_opa(check, 255, LV_PART_INDICATOR | LV_STATE_CHECKED);
-	lv_obj_set_style_outline_color(check, lv_color_hex(0xFD8B18), LV_PART_INDICATOR | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_opa(check, 255, LV_PART_INDICATOR | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_width(check, 2, LV_PART_INDICATOR | LV_STATE_FOCUS_KEY);
-	lv_obj_set_style_outline_pad(check, 2, LV_PART_INDICATOR | LV_STATE_FOCUS_KEY);
 
-	lv_obj_set_style_radius(check, 20, LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_color(check, lv_color_hex(0x333333), LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(check, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
 	lv_obj_set_style_bg_opa(check, 255, LV_PART_KNOB | LV_STATE_DEFAULT);
-	lv_obj_set_style_bg_color(check, lv_color_hex(0xFD8B18), LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_bg_opa(check, 255, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_outline_width(check, 0, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_outline_pad(check, 0, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_shadow_color(check, lv_color_hex(0xFD8B18), LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_shadow_opa(check, 255, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_shadow_width(check, 1, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_shadow_spread(check, 1, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_shadow_ofs_x(check, -1, LV_PART_KNOB | LV_STATE_CHECKED);
-	lv_obj_set_style_shadow_ofs_y(check, 0, LV_PART_KNOB | LV_STATE_CHECKED);
+	lv_obj_set_style_pad_left(check, -4, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_right(check, -6, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_top(check, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_bottom(check, -5, LV_PART_KNOB | LV_STATE_DEFAULT);
 
 	return check;
 }

--- a/firmware/src/gui/slsexport/ui_local.h
+++ b/firmware/src/gui/slsexport/ui_local.h
@@ -40,4 +40,6 @@ lv_obj_t *create_midi_map_dropdown(lv_obj_t *parent, std::string const &options)
 lv_obj_t *create_button_expander_item(lv_obj_t *parent);
 lv_obj_t *create_button_expander_pane(lv_obj_t *parent);
 
+lv_obj_t *create_labeled_dropdown(lv_obj_t *parent);
+
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/ui_local.h
+++ b/firmware/src/gui/slsexport/ui_local.h
@@ -32,7 +32,8 @@ lv_obj_t *create_settings_menu_title(lv_obj_t *parent, std::string const &title_
 
 lv_obj_t *create_file_menu_item(lv_obj_t *parent, std::string_view text);
 
-lv_obj_t *create_midi_map_check(lv_obj_t *parent);
+lv_obj_t *create_prefs_check(lv_obj_t *parent);
+
 lv_obj_t *create_midi_map_label(lv_obj_t *parent, std::string const &title);
 lv_obj_t *create_midi_map_dropdown(lv_obj_t *parent, std::string const &options);
 

--- a/firmware/src/gui/styles.hh
+++ b/firmware/src/gui/styles.hh
@@ -60,6 +60,8 @@ struct Gui {
 	// General outline for focused objects (FOCUS and FOCUS_KEY)
 	static inline lv_style_t focus_style;
 
+	static inline lv_style_t debug_border;
+
 	// COLORS
 	static inline std::string color_text(std::string_view txt, std::string_view color) {
 		return std::string{color} + std::string{txt} + LV_TXT_COLOR_CMD + " ";
@@ -293,6 +295,13 @@ struct Gui {
 			auto hsv = lv_color_to_hsv(color);
 			color = lv_color_hsv_to_rgb(hsv.h, hsv.s / 2, hsv.v / 2);
 		}
+
+		// debug border
+		lv_style_init(&debug_border);
+		lv_style_set_radius(&debug_border, 0);
+		lv_style_set_border_color(&debug_border, lv_color_hex(0xff0000));
+		lv_style_set_border_opa(&debug_border, LV_OPA_70);
+		lv_style_set_border_width(&debug_border, 1);
 
 		// invisible_style
 		lv_style_init(&invisible_style);

--- a/firmware/src/gui/styles.hh
+++ b/firmware/src/gui/styles.hh
@@ -99,7 +99,9 @@ struct Gui {
 		return color_text(txt, "^cccccc ");
 	}
 
-	static inline const char *brown_highlight_html = "^A26E3E ";
+	static inline std::string_view grey_color_html = "^aaaaaa ";
+	static inline std::string_view brown_highlight_html = "^A26E3E ";
+	static inline std::string_view orange_highlight_html = "^fd8b18 ";
 
 	static inline lv_theme_t *theme;
 	static inline lv_disp_t *display;

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -68,11 +68,12 @@ public:
 			}
 		}
 
+		patch_playloader.connect_user_settings(&settings);
+
 		patch_playloader.request_new_audio_settings(
 			settings.audio.sample_rate, settings.audio.block_size, settings.audio.max_overrun_retries);
-		patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.allow_jump_outofrange);
-		patch_playloader.set_apply_suggested_audio(settings.patch_suggested_audio.apply_samplerate,
-													    settings.patch_suggested_audio.apply_blocksize);
+
+		patch_playloader.update_param_catchup_mode();
 
 		ModuleFactory::setModuleDisplayName("HubMedium", "Panel");
 

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -69,6 +69,7 @@ public:
 		}
 
 		patch_playloader.connect_user_settings(&settings);
+		patch_playloader.connect_notification_queue(&notify_queue);
 
 		patch_playloader.request_new_audio_settings(
 			settings.audio.sample_rate, settings.audio.block_size, settings.audio.max_overrun_retries);

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -71,6 +71,8 @@ public:
 		patch_playloader.request_new_audio_settings(
 			settings.audio.sample_rate, settings.audio.block_size, settings.audio.max_overrun_retries);
 		patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.allow_jump_outofrange);
+		patch_playloader.set_apply_suggested_audio(settings.patch_suggested_audio.apply_samplerate,
+													    settings.patch_suggested_audio.apply_blocksize);
 
 		ModuleFactory::setModuleDisplayName("HubMedium", "Panel");
 

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -458,21 +458,21 @@ private:
 		bool change_sr = settings->patch_suggested_audio.apply_samplerate && (sugg_sr > 0 && sugg_sr != cur_sr);
 		bool change_bs = settings->patch_suggested_audio.apply_blocksize && (sugg_bs > 0 && sugg_bs != cur_bs);
 
-			if (change_sr || change_bs) {
-				uint32_t new_sr = change_sr ? sugg_sr : cur_sr;
-				uint16_t new_bs = change_bs ? sugg_bs : cur_bs;
+		if (change_sr || change_bs) {
+			uint32_t new_sr = change_sr ? sugg_sr : cur_sr;
+			uint16_t new_bs = change_bs ? sugg_bs : cur_bs;
 
-				if (notify_queue) {
-					std::string message{};
-					if (change_sr)
-						message += "Sample-rate changed to " + std::to_string(new_sr);
-					if (change_sr && change_bs)
-						message += "\n";
-					if (change_bs)
-						message += "Block-size changed to " + std::to_string(new_bs);
-					notify_queue->put({message, Notification::Priority::Info, 2000});
-				}
-				request_new_audio_settings(new_sr, new_bs, max_retries);
+			// if (notify_queue) {
+			// 	std::string message{};
+			// 	if (change_sr)
+			// 		message += "Sample-rate: " + std::to_string(new_sr);
+			// 	if (change_sr && change_bs)
+			// 		message += "\n";
+			// 	if (change_bs)
+			// 		message += "Block-size: " + std::to_string(new_bs);
+			// 	notify_queue->put({message, Notification::Priority::Info, change_bs * 1000 + change_sr * 1000});
+			// }
+			request_new_audio_settings(new_sr, new_bs, max_retries);
 		}
 	}
 

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -299,6 +299,8 @@ struct PatchPlayLoader {
 
 	void connect_user_settings(UserSettings *settings) {
 		this->settings = settings;
+		request_new_audio_settings(
+			settings->audio.sample_rate, settings->audio.block_size, settings->audio.max_overrun_retries);
 	}
 
 	void connect_notification_queue(NotificationQueue *notification_queue) {
@@ -461,9 +463,6 @@ private:
 					notify_queue->put({message, Notification::Priority::Info, 2000});
 				}
 				request_new_audio_settings(new_sr, new_bs, max_retries);
-
-				settings->audio.block_size = new_bs;
-				settings->audio.sample_rate = new_sr;
 			}
 		} else {
 			pr_err("Patch Play Loader not initialized with user settings\n");

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -440,13 +440,23 @@ private:
 	}
 
 	void apply_suggested_audio_settings() {
-		if (settings) {
-			auto sugg_sr = next_patch->suggested_samplerate;
-			auto sugg_bs = next_patch->suggested_blocksize;
-			auto [cur_sr, cur_bs, max_retries] = get_audio_settings();
+		if (!settings) {
+			pr_err("Error: PatchPlayLoader not initialized with user settings\n");
+			return;
+		}
 
-			bool change_sr = settings->patch_suggested_audio.apply_samplerate && (sugg_sr > 0 && sugg_sr != cur_sr);
-			bool change_bs = settings->patch_suggested_audio.apply_blocksize && (sugg_bs > 0 && sugg_bs != cur_bs);
+		auto [cur_sr, cur_bs, max_retries] = get_audio_settings();
+
+		auto sugg_sr = next_patch->suggested_samplerate;
+		if (!sugg_sr)
+			sugg_sr = settings->audio.sample_rate;
+
+		auto sugg_bs = next_patch->suggested_blocksize;
+		if (!sugg_bs)
+			sugg_bs = settings->audio.block_size;
+
+		bool change_sr = settings->patch_suggested_audio.apply_samplerate && (sugg_sr > 0 && sugg_sr != cur_sr);
+		bool change_bs = settings->patch_suggested_audio.apply_blocksize && (sugg_bs > 0 && sugg_bs != cur_bs);
 
 			if (change_sr || change_bs) {
 				uint32_t new_sr = change_sr ? sugg_sr : cur_sr;
@@ -463,9 +473,6 @@ private:
 					notify_queue->put({message, Notification::Priority::Info, 2000});
 				}
 				request_new_audio_settings(new_sr, new_bs, max_retries);
-			}
-		} else {
-			pr_err("Patch Play Loader not initialized with user settings\n");
 		}
 	}
 

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -439,8 +439,18 @@ private:
 			delay_ms(20); //let Async threads run
 			pr_info("Heap: %u\n", get_heap_size());
 
+			auto sugg_sr = next_patch->suggested_samplerate;
+			auto sugg_bs = next_patch->suggested_blocksize;
+			auto [cur_sr, cur_bs, _] = get_audio_settings();
+			pr_dbg("Patch file: %u/%u, current: %u/%u\n", sugg_sr, sugg_bs, cur_sr, cur_bs);
+			if ((sugg_sr > 0 && sugg_sr != cur_sr) || (sugg_bs > 0 && sugg_sr != cur_sr)) {
+				pr_dbg("Request new audio settings %u/%u\n", sugg_sr ? sugg_sr : cur_sr, sugg_bs ? sugg_bs : cur_bs);
+				request_new_audio_settings(sugg_sr ? sugg_sr : cur_sr, sugg_bs ? sugg_bs : cur_bs, 1);
+			}
+
 			if (start_audio_immediately)
 				start_audio();
+
 		} else {
 			patches_.close_playing_patch();
 		}

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -331,35 +331,6 @@ struct PatchPlayLoader {
 	}
 
 private:
-	PatchPlayer &player_;
-	FileStorageProxy &storage_;
-	OpenPatchManager &patches_;
-
-	PatchData *next_patch = nullptr;
-	CalibrationPatch calibration;
-
-	std::atomic<bool> loading_new_patch_ = false;
-	std::atomic<bool> audio_is_muted_ = false;
-	std::atomic<bool> stopping_audio_ = false;
-	std::atomic<bool> starting_audio_ = false;
-	std::atomic<bool> saving_patch_ = false;
-	std::atomic<bool> should_save_patch_ = false;
-	std::atomic<bool> audio_overrun_ = false;
-	bool stopped_because_of_overrun_ = false;
-	bool should_play_when_loaded_ = true;
-
-	UserSettings *settings = nullptr;
-	std::atomic<AudioSRBlock> new_audio_settings_ = {};
-	unsigned max_audio_retries = 0;
-
-	NotificationQueue *notify_queue = nullptr;
-
-	PatchLocation new_loc{};
-	PatchLocation old_loc{};
-	enum class RenameState { Idle, RequestSaveNew, SavingNew, RequestDeleteOld, DeletingOld };
-	RenameState rename_state_{RenameState::Idle};
-	uint32_t attempts = 0;
-
 	Result save_patch(PatchLocation const &loc) {
 		auto view_patch = patches_.get_view_patch();
 
@@ -542,5 +513,34 @@ private:
 
 		return {true, ""};
 	}
+
+	PatchPlayer &player_;
+	FileStorageProxy &storage_;
+	OpenPatchManager &patches_;
+
+	PatchData *next_patch = nullptr;
+	CalibrationPatch calibration;
+
+	std::atomic<bool> loading_new_patch_ = false;
+	std::atomic<bool> audio_is_muted_ = false;
+	std::atomic<bool> stopping_audio_ = false;
+	std::atomic<bool> starting_audio_ = false;
+	std::atomic<bool> saving_patch_ = false;
+	std::atomic<bool> should_save_patch_ = false;
+	std::atomic<bool> audio_overrun_ = false;
+	bool stopped_because_of_overrun_ = false;
+	bool should_play_when_loaded_ = true;
+
+	UserSettings *settings = nullptr;
+	std::atomic<AudioSRBlock> new_audio_settings_ = {};
+	unsigned max_audio_retries = 0;
+
+	NotificationQueue *notify_queue = nullptr;
+
+	PatchLocation new_loc{};
+	PatchLocation old_loc{};
+	enum class RenameState { Idle, RequestSaveNew, SavingNew, RequestDeleteOld, DeletingOld };
+	RenameState rename_state_{RenameState::Idle};
+	uint32_t attempts = 0;
 };
 } // namespace MetaModule

--- a/firmware/src/user_settings/patch_suggested_audio_settings.hh
+++ b/firmware/src/user_settings/patch_suggested_audio_settings.hh
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstdint>
+
+namespace MetaModule
+{
+
+// Controls whether to apply suggested audio params from patch files
+struct PatchSuggestedAudioSettings {
+    bool apply_samplerate{true};
+    bool apply_blocksize{true};
+
+    void make_valid() {
+        // Booleans are inherently valid; keep for symmetry/forward-compat
+    }
+};
+
+} // namespace MetaModule
+

--- a/firmware/src/user_settings/settings.hh
+++ b/firmware/src/user_settings/settings.hh
@@ -4,6 +4,7 @@
 #include "fs/volumes.hh"
 #include "user_settings/fs_settings.hh"
 #include "user_settings/midi_settings.hh"
+#include "user_settings/patch_suggested_audio_settings.hh"
 #include "user_settings/plugin_preload_settings.hh"
 #include "user_settings/screensaver_settings.hh"
 #include "user_settings/view_settings.hh"
@@ -26,6 +27,7 @@ struct UserSettings {
 	CatchupSettings catchup{};
 	FilesystemSettings filesystem{};
 	MidiSettings midi{};
+	PatchSuggestedAudioSettings patch_suggested_audio{};
 };
 
 } // namespace MetaModule

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -82,6 +82,7 @@ static bool read(ryml::ConstNodeRef const &node, ModuleDisplaySettings *s) {
 	read_or_default(node, "show_graphic_screens", s, &ModuleDisplaySettings::show_graphic_screens);
 	read_or_default(node, "graphic_screen_throttle", s, &ModuleDisplaySettings::graphic_screen_throttle);
 	read_or_default(node, "show_samplerate", s, &ModuleDisplaySettings::show_samplerate);
+	read_or_default(node, "float_loadmeter", s, &ModuleDisplaySettings::float_loadmeter);
 	read_or_default(node, "show_knobset_name", s, &ModuleDisplaySettings::show_knobset_name);
 
 	return true;

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -146,6 +146,17 @@ static bool read(ryml::ConstNodeRef const &node, FilesystemSettings *settings) {
 	return true;
 }
 
+static bool read(ryml::ConstNodeRef const &node, PatchSuggestedAudioSettings *settings) {
+	if (!node.is_map())
+		return false;
+
+	read_or_default(node, "apply_samplerate", settings, &PatchSuggestedAudioSettings::apply_samplerate);
+	read_or_default(node, "apply_blocksize", settings, &PatchSuggestedAudioSettings::apply_blocksize);
+	settings->make_valid();
+
+	return true;
+}
+
 namespace Settings
 {
 
@@ -172,6 +183,7 @@ bool parse(std::span<char> yaml, UserSettings *settings) {
 	read_or_default(node, "catchup", settings, &UserSettings::catchup);
 	read_or_default(node, "filesystem", settings, &UserSettings::filesystem);
 	read_or_default(node, "midi", settings, &UserSettings::midi);
+	read_or_default(node, "patch_suggested_audio", settings, &UserSettings::patch_suggested_audio);
 
 	read_or_default(node, "last_patch_opened", settings, &UserSettings::initial_patch_name);
 	// TODO: cleaner way to parse an enum and reject out of range?

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -81,6 +81,8 @@ static bool read(ryml::ConstNodeRef const &node, ModuleDisplaySettings *s) {
 	read_or_default(node, "cable_style", s, &ModuleDisplaySettings::cable_style);
 	read_or_default(node, "show_graphic_screens", s, &ModuleDisplaySettings::show_graphic_screens);
 	read_or_default(node, "graphic_screen_throttle", s, &ModuleDisplaySettings::graphic_screen_throttle);
+	read_or_default(node, "show_samplerate", s, &ModuleDisplaySettings::show_samplerate);
+	read_or_default(node, "show_knobset_name", s, &ModuleDisplaySettings::show_knobset_name);
 
 	return true;
 }

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -81,6 +81,13 @@ static void write(ryml::NodeRef *n, FilesystemSettings const &s) {
 	n->append_child() << ryml::key("midi_feedback") << std::to_underlying(s.midi_feedback);
 }
 
+static void write(ryml::NodeRef *n, PatchSuggestedAudioSettings const &s) {
+	*n |= ryml::MAP;
+
+	n->append_child() << ryml::key("apply_samplerate") << s.apply_samplerate;
+	n->append_child() << ryml::key("apply_blocksize") << s.apply_blocksize;
+}
+
 namespace Settings
 {
 
@@ -105,6 +112,7 @@ uint32_t serialize(UserSettings const &settings, std::span<char> buffer) {
 	data["catchup"] << settings.catchup;
 	data["filesystem"] << settings.filesystem;
 	data["midi"] << settings.midi;
+	data["patch_suggested_audio"] << settings.patch_suggested_audio;
 
 	auto res = ryml::emit_yaml(tree, c4::substr(buffer.data(), buffer.size()));
 	return res.size();

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -32,6 +32,8 @@ static void write(ryml::NodeRef *n, ModuleDisplaySettings const &s) {
 	n->append_child() << ryml::key("cable_style") << s.cable_style;
 	n->append_child() << ryml::key("show_graphic_screens") << s.show_graphic_screens;
 	n->append_child() << ryml::key("graphic_screen_throttle") << s.graphic_screen_throttle;
+	n->append_child() << ryml::key("show_samplerate") << s.show_samplerate;
+	n->append_child() << ryml::key("show_knobset_name") << s.show_knobset_name;
 }
 
 static void write(ryml::NodeRef *n, AudioSettings const &s) {

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -33,6 +33,7 @@ static void write(ryml::NodeRef *n, ModuleDisplaySettings const &s) {
 	n->append_child() << ryml::key("show_graphic_screens") << s.show_graphic_screens;
 	n->append_child() << ryml::key("graphic_screen_throttle") << s.graphic_screen_throttle;
 	n->append_child() << ryml::key("show_samplerate") << s.show_samplerate;
+	n->append_child() << ryml::key("float_loadmeter") << s.float_loadmeter;
 	n->append_child() << ryml::key("show_knobset_name") << s.show_knobset_name;
 }
 

--- a/firmware/src/user_settings/view_settings.hh
+++ b/firmware/src/user_settings/view_settings.hh
@@ -26,6 +26,7 @@ struct ModuleDisplaySettings {
 	bool changed = true; //???unused but keep for backward compat
 	bool show_graphic_screens = true;
 	bool show_samplerate = true;
+	bool float_loadmeter = false;
 	bool show_knobset_name = false;
 
 	constexpr static std::array<unsigned, 6> ThrottleAmounts = {32, 16, 8, 4, 2, 1};

--- a/firmware/src/user_settings/view_settings.hh
+++ b/firmware/src/user_settings/view_settings.hh
@@ -25,6 +25,8 @@ struct ModuleDisplaySettings {
 	unsigned view_height_px = 180;
 	bool changed = true; //???unused but keep for backward compat
 	bool show_graphic_screens = true;
+	bool show_samplerate = true;
+	bool show_knobset_name = false;
 
 	constexpr static std::array<unsigned, 6> ThrottleAmounts = {32, 16, 8, 4, 2, 1};
 	unsigned graphic_screen_throttle = 1;

--- a/firmware/tests/patch_player_tests.cc
+++ b/firmware/tests/patch_player_tests.cc
@@ -781,6 +781,8 @@ PatchData:
   midi_pitchwheel_range: 1
   mapped_lights: []
   vcvModuleStates: []
+  suggested_samplerate: 0
+  suggested_blocksize: 0
 )"
 		  // clang-format off
 		 );
@@ -1070,6 +1072,8 @@ PatchData:
   midi_pitchwheel_range: 1
   mapped_lights: []
   vcvModuleStates: []
+  suggested_samplerate: 0
+  suggested_blocksize: 0
 )");
 	// clang-format on
 }

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -323,6 +323,8 @@ TEST_CASE("Serialize settings") {
       opa: 100
     show_graphic_screens: 1
     graphic_screen_throttle: 1
+    show_samplerate: 1
+    show_knobset_name: 0
   module_view:
     map_ring_flash_active: 0
     scroll_to_active_param: 1
@@ -338,6 +340,8 @@ TEST_CASE("Serialize settings") {
       opa: 0
     show_graphic_screens: 1
     graphic_screen_throttle: 1
+    show_samplerate: 1
+    show_knobset_name: 0
   audio:
     sample_rate: 24000
     block_size: 512

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -62,6 +62,9 @@ TEST_CASE("Parse settings file") {
 
   midi:
     midi_feedback: 1
+  patch_suggested_audio:
+    apply_samplerate: 0
+    apply_blocksize: 1
 )";
 	// clang-format on
 
@@ -112,6 +115,9 @@ TEST_CASE("Parse settings file") {
 	CHECK(settings.filesystem.max_open_patches == 7);
 
 	CHECK(settings.midi.midi_feedback == MetaModule::MidiSettings::MidiFeedback::Enabled);
+
+	CHECK(settings.patch_suggested_audio.apply_samplerate == false);
+	CHECK(settings.patch_suggested_audio.apply_blocksize == true);
 }
 
 TEST_CASE("Get default settings if file is missing fields") {
@@ -245,6 +251,9 @@ TEST_CASE("Get default settings if file is missing fields") {
 	CHECK(settings.filesystem.max_open_patches == 15);
 
 	CHECK(settings.midi.midi_feedback == MetaModule::MidiSettings::MidiFeedback::Enabled);
+
+	CHECK(settings.patch_suggested_audio.apply_samplerate == true);
+	CHECK(settings.patch_suggested_audio.apply_blocksize == true);
 }
 
 TEST_CASE("Serialize settings") {
@@ -293,6 +302,9 @@ TEST_CASE("Serialize settings") {
 	settings.filesystem.auto_reload_patch_file = false;
 
 	settings.midi.midi_feedback = MetaModule::MidiSettings::MidiFeedback::Disabled;
+
+	settings.patch_suggested_audio.apply_samplerate = false;
+	settings.patch_suggested_audio.apply_blocksize = true;
 
 	// clang format-off
 	std::string expected = R"(Settings:
@@ -347,6 +359,9 @@ TEST_CASE("Serialize settings") {
     max_open_patches: 8
   midi:
     midi_feedback: 0
+  patch_suggested_audio:
+    apply_samplerate: 0
+    apply_blocksize: 1
 )";
 	// clang format-on
 

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -21,6 +21,9 @@ TEST_CASE("Parse settings file") {
       mode: ShowAll
       opa: 100
     view_height_px: 180
+    show_knobset_name: 1
+    show_samplerate: 0
+    float_loadmeter: 1
 
   module_view:
     map_ring_flash_active: false
@@ -35,6 +38,8 @@ TEST_CASE("Parse settings file") {
       mode: HideAlways
       opa: 0
     view_height_px: 240
+    show_samplerate: 1
+    float_loadmeter: 0
 
   audio:
     sample_rate: 96000
@@ -118,6 +123,14 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.patch_suggested_audio.apply_samplerate == false);
 	CHECK(settings.patch_suggested_audio.apply_blocksize == true);
+
+	CHECK(settings.patch_view.show_samplerate == false);
+	CHECK(settings.patch_view.float_loadmeter == true);
+	CHECK(settings.patch_view.show_knobset_name == true);
+
+	CHECK(settings.module_view.show_samplerate == true);
+	CHECK(settings.module_view.float_loadmeter == false);
+	CHECK(settings.module_view.show_knobset_name == false);
 }
 
 TEST_CASE("Get default settings if file is missing fields") {
@@ -324,6 +337,7 @@ TEST_CASE("Serialize settings") {
     show_graphic_screens: 1
     graphic_screen_throttle: 1
     show_samplerate: 1
+    float_loadmeter: 0
     show_knobset_name: 0
   module_view:
     map_ring_flash_active: 0
@@ -341,6 +355,7 @@ TEST_CASE("Serialize settings") {
     show_graphic_screens: 1
     graphic_screen_throttle: 1
     show_samplerate: 1
+    float_loadmeter: 0
     show_knobset_name: 0
   audio:
     sample_rate: 24000

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -58,6 +58,9 @@ Ui::Ui(std::string_view sdcard_path, std::string_view flash_path, std::string_vi
 
 	preload_plugins();
 
+	patch_playloader.connect_user_settings(&settings);
+	patch_playloader.update_param_catchup_mode();
+
 	patch_playloader.notify_audio_is_muted();
 	std::cout << "UI: buffers have # frames: in: " << in_buffer.size() << ", out: " << out_buffer.size() << "\n";
 
@@ -67,8 +70,6 @@ Ui::Ui(std::string_view sdcard_path, std::string_view flash_path, std::string_vi
 
 	params.set_output_plugged(cur_outchan_left, true);
 	params.set_output_plugged(cur_outchan_right, true);
-
-	patch_playloader.set_all_param_catchup_mode(settings.catchup.mode, settings.catchup.allow_jump_outofrange);
 
 	plugin_interface.register_interface();
 }

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -59,6 +59,7 @@ Ui::Ui(std::string_view sdcard_path, std::string_view flash_path, std::string_vi
 	preload_plugins();
 
 	patch_playloader.connect_user_settings(&settings);
+	patch_playloader.connect_notification_queue(&notify_queue);
 	patch_playloader.update_param_catchup_mode();
 
 	patch_playloader.notify_audio_is_muted();


### PR DESCRIPTION
This PR adds two fields to the patch file format:
- `suggested_samplerate`
- `suggested_blocksize`

These can be set to any valid sample rate or block size, or to 0.

When a patch file is loaded, the audio settings will be automatically changed to those found in the patch file. If the field is 0 or missing, the audio setting won't be changed.

Since the sample rate and block size can now change dynamically without the user explicitly going the Prefs page, it's handy to display the current SR/BS at the top of the screen. Two new display options are added:
- `Show audio settings`: displays the current samplerate and blocksize next to the cpu load (`68% 48k/128`)
- `Keep load meter on top`: Puts the cpu load meter on top of the patch as you scroll through modules

This also adds two user settings in the Prefs panel that allow the user to enable/disable this feature for sample rate and block size separately.

The user can also view and edit the suggested audio settings for a patch in the Patch Info window (the circle-I icon in the patch view button bar). That window has been re-done a bit to make room and to make the patch description a little easier to edit. Changing the settings here in this window will mark the patch as modified.

Having the sample rate and block size in the Patch Info window has the added benefit of making it easier to change the audio settings without needing to go all the way to the main Settings > Prefs page. 

The 4ms VCV plugin has a companion feature that  lets the user assign a suggested audio sample rate and block size to a patch, and save those fields in the patch yml file.