### PR TITLE
Add module bypass toggle with visual feedback and persistence

### DIFF
--- a/firmware/src/gui/pages/module_view/action_menu.hh
+++ b/firmware/src/gui/pages/module_view/action_menu.hh
@@ -76,9 +76,8 @@ public:
 		lv_group_set_wrap(group, false);
 	}
 
-	void prepare_focus(lv_group_t *parent_group, unsigned module_idx, lv_obj_t *canvas = nullptr) {
+	void prepare_focus(lv_group_t *parent_group, unsigned module_idx) {
 		this->module_idx = module_idx;
-		this->module_canvas = canvas;
 		base_group = parent_group;
 		confirm_popup.init(lv_layer_top(), group);
 
@@ -123,7 +122,6 @@ public:
 		preset_popup.init(lv_layer_sys(), group);
 
 		update_midi_map_text();
-		update_bypass_text();
 	}
 
 	void back() {
@@ -155,6 +153,7 @@ public:
 	}
 
 	void show() {
+		update_bypass_text();
 		lv_group_focus_obj(ui_ModuleViewActionAutopatchBut);
 
 		if (!visible) {
@@ -338,13 +337,10 @@ private:
 		auto *pd = page->patches.get_view_patch();
 		bool new_state = !pd->is_module_bypassed(page->module_idx);
 
-		pd->set_module_bypassed(page->module_idx, new_state);
 		page->patch_mod_queue.put(
 			SetModuleBypass{.module_id = static_cast<uint16_t>(page->module_idx), .bypassed = new_state});
 		page->patches.mark_view_patch_modified();
-		page->update_bypass_text();
-		if (page->module_canvas)
-			lv_obj_set_style_opa(page->module_canvas, new_state ? LV_OPA_50 : LV_OPA_COVER, LV_PART_MAIN);
+		page->hide();
 	}
 
 	FatFileIO &ramdisk;
@@ -362,7 +358,6 @@ private:
 	ResetParams reset_params_;
 
 	unsigned module_idx = 0;
-	lv_obj_t *module_canvas = nullptr;
 	lv_group_t *group;
 	lv_group_t *base_group = nullptr;
 	bool visible = false;

--- a/firmware/src/gui/pages/module_view/action_menu.hh
+++ b/firmware/src/gui/pages/module_view/action_menu.hh
@@ -170,6 +170,10 @@ public:
 		return visible;
 	}
 
+	void reactivate_group() {
+		lv_group_activate(group);
+	}
+
 	void update() {
 		process_delete_module();
 		auto_map.update();
@@ -340,7 +344,11 @@ private:
 		page->patch_mod_queue.put(
 			SetModuleBypass{.module_id = static_cast<uint16_t>(page->module_idx), .bypassed = new_state});
 		page->patches.mark_view_patch_modified();
-		page->hide();
+
+		// Use new_state directly since the patch data hasn't been updated yet
+		auto *label = lv_obj_get_child(page->moduleViewActionBypassBut, 0);
+		if (label)
+			lv_label_set_text(label, new_state ? "Bypass: On" : "Bypass: Off");
 	}
 
 	FatFileIO &ramdisk;

--- a/firmware/src/gui/pages/module_view/draw_module.cc
+++ b/firmware/src/gui/pages/module_view/draw_module.cc
@@ -43,6 +43,9 @@ void ModuleViewPage::redraw_module() {
 	auto [faceplate, width] = module_drawer.read_faceplate(slug);
 	canvas = module_drawer.draw_faceplate(faceplate, width, buffer);
 
+	if (patch->is_module_bypassed(this_module_id))
+		lv_obj_set_style_opa(canvas, LV_OPA_50, LV_PART_MAIN);
+
 	active_knobset = page_list.get_active_knobset();
 
 	module_drawer.draw_mapped_elements(

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -149,7 +149,7 @@ struct ModuleViewPage : PageBase {
 			lv_obj_set_flex_align(
 				ui_ElementRollerButtonCont, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 			settings_menu.prepare_focus(group);
-			action_menu.prepare_focus(group, this_module_id, canvas);
+			action_menu.prepare_focus(group, this_module_id);
 		}
 
 		quick_control_mode = false;
@@ -336,6 +336,10 @@ struct ModuleViewPage : PageBase {
 						   },
 						   [&, this](RemoveMapping &mod) {
 							   patch->remove_mapping(mod.set_id, mod.map);
+							   refresh = true;
+						   },
+						   [&, this](SetModuleBypass &mod) {
+							   patch->set_module_bypassed(mod.module_id, mod.bypassed);
 							   refresh = true;
 						   },
 						   [&](auto &m) { refresh = false; },

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -272,6 +272,11 @@ struct ModuleViewPage : PageBase {
 		if (handle_patch_mods()) {
 			redraw_module();
 			mapping_pane.refresh();
+
+			if (action_menu.is_visible()) {
+				focus_button_bar();
+				action_menu.reactivate_group();
+			}
 		}
 
 		// Draw the on-screen elements (knobs, lights, etc)

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -149,7 +149,7 @@ struct ModuleViewPage : PageBase {
 			lv_obj_set_flex_align(
 				ui_ElementRollerButtonCont, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 			settings_menu.prepare_focus(group);
-			action_menu.prepare_focus(group, this_module_id);
+			action_menu.prepare_focus(group, this_module_id, canvas);
 		}
 
 		quick_control_mode = false;

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -246,6 +246,8 @@ struct PatchViewPage : PageBase {
 
 			module_canvases.push_back(canvas);
 			style_module(canvas);
+			if (patch->is_module_bypassed(module_idx))
+				lv_obj_set_style_opa(canvas, LV_OPA_50, LV_PART_MAIN);
 
 			// Give the callback access to the module_idx:
 			lv_obj_set_user_data(canvas, (void *)(&module_ids[module_ids.size() - 1]));

--- a/firmware/src/patch_play/patch_mod_queue.hh
+++ b/firmware/src/patch_play/patch_mod_queue.hh
@@ -78,6 +78,11 @@ struct LoadModuleState {
 	std::string data;
 };
 
+struct SetModuleBypass {
+	uint16_t module_id;
+	bool bypassed;
+};
+
 using PatchModRequest = std::variant<SetStaticParam,
 									 AddMapping,
 									 ModifyMapping,
@@ -91,7 +96,8 @@ using PatchModRequest = std::variant<SetStaticParam,
 									 CalibrationOnOff,
 									 SetChanCalibration,
 									 SetMidiPolyNum,
-									 LoadModuleState>;
+									 LoadModuleState,
+									 SetModuleBypass>;
 
 using PatchModQueue = LockFreeFifoSpsc<PatchModRequest, 128>;
 

--- a/firmware/src/patch_play/patch_mods.hh
+++ b/firmware/src/patch_play/patch_mods.hh
@@ -51,6 +51,7 @@ inline void handle_patch_mods(PatchModQueue &patch_mod_queue,
 
 					   [&new_cal_state](CalibrationOnOff &mod) { new_cal_state = mod.enable; },
 					   [&player](LoadModuleState &mod) { player.reset_module(mod.module_id, mod.data); },
+					   [&player](SetModuleBypass &mod) { player.set_module_bypass(mod.module_id, mod.bypassed); },
 				   },
 				   patch_mod);
 	}

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -213,6 +213,12 @@ public:
 		for (auto const &k : pd.static_knobs)
 			modules[k.module_id]->set_param(k.param_id, k.value);
 
+		// Apply bypass state
+		for (auto id : pd.bypassed_modules) {
+			if (id < num_modules)
+				modules[id]->bypassed = true;
+		}
+
 		calc_multiple_module_indicies();
 
 		active_knob_set = 0;
@@ -358,6 +364,7 @@ public:
 		pd.module_slugs.clear();
 		pd.mapped_lights.clear();
 		pd.module_states.clear();
+		pd.bypassed_modules.clear();
 		pd.midi_maps.set.clear();
 		pd.midi_maps.name = "";
 
@@ -784,6 +791,11 @@ public:
 	void reset_module(uint16_t module_id, std::string_view data = "") {
 		if (module_id < num_modules)
 			modules[module_id]->load_state(data);
+	}
+
+	void set_module_bypass(uint16_t module_id, bool bypassed) {
+		if (module_id < num_modules)
+			modules[module_id]->bypassed = bypassed;
 	}
 
 	void add_module(BrandModuleSlug slug) {

--- a/firmware/tests/patch_player_tests.cc
+++ b/firmware/tests/patch_player_tests.cc
@@ -783,6 +783,7 @@ PatchData:
   vcvModuleStates: []
   suggested_samplerate: 0
   suggested_blocksize: 0
+  bypassed_modules: []
 )"
 		  // clang-format off
 		 );
@@ -1074,6 +1075,7 @@ PatchData:
   vcvModuleStates: []
   suggested_samplerate: 0
   suggested_blocksize: 0
+  bypassed_modules: []
 )");
 	// clang-format on
 }


### PR DESCRIPTION
Hey Dan! I had a go at implementing the changes necessary to allow users to bypass modules on the MetaModule. Obviously the work on `CoreProcessor::bypassed` has already been done, so this was just adding it to the interface and patch storage. 

I should say that I used Claude Code to do this, so this code is not entirely handmade. I've tested it on the simulator and on the device and it seems to work very nicely. 

This is one of three PRs for this feature; it's the central one. The others teach metamodule-patch-serial and the VCV MetaModule Hub about the bypass feature so that modules' bypass status is saved in patch files. 

I hope this is helpful and not just a bunch of extra work for you. I'm enjoying being able to bypass high-CPU effects modules on the Meta! 

## Summary

Implements module bypass for the MetaModule (issue #375):

- **UI toggle**: Add "Bypass: On/Off" button to the ModuleView action menu. Sends a message through the patch mod queue to set the `CoreProcessor::bypassed` flag on the audio thread, and updates the GUI's PatchData for persistence.
- **Visual indicator**: Bypassed modules are dimmed to 50% opacity in both PatchView and ModuleView.
- **Persistence**: Bypass state is saved/restored via the `bypassed_modules` field in patch YAML (requires 4ms/metamodule-patch-serial#1).

Closes #375

## Test plan

- [ ] Toggle bypass from the ModuleView action menu — audio output should change depending on module's bypass settings
- [ ] Bypassed modules appear dimmed in PatchView and ModuleView
- [ ] Menu label reflects current state ("Bypass: On" or "Bypass: Off") when reopening the action menu
- [ ] Save a patch with bypassed modules, reload — bypass states are restored
- [ ] Old patches without bypass data load normally
- [ ] firmware tests pass (`make all`)