### PR TITLE
Midi CC control of knobset

### DIFF
--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -166,7 +166,7 @@ public:
 					auto &cc = info.params.midi_ccs[info.settings.midi.knobset_cc & 127];
 
 					auto midi_chan =
-						info.settings.midi.knobset_channel + 1; //User sees channels 1-16, but internally is 0-15
+						info.settings.midi.knobset_channel - 1; //User sees channels 1-16, but internally is 0-15
 					if (cc.changed && cc.val == midi_chan) {
 						auto next = std::clamp<unsigned>(cc.value, 0, num_knobsets - 1);
 						if (next != info.page_list.get_active_knobset())

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -154,16 +154,36 @@ public:
 	}
 
 	void handle_knobset_change() {
-		if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
-			if (auto patch = info.open_patch_manager.get_playing_patch(); patch != nullptr) {
 
-				if (int num_knobsets = patch->knob_sets.size(); num_knobsets > 0) {
+		// Patch must be valid, playing, and have at least one knobset
+		if (auto patch = info.open_patch_manager.get_playing_patch(); patch != nullptr) {
+			if (int num_knobsets = patch->knob_sets.size(); num_knobsets > 0) {
+
+				std::optional<int> next_knobset = std::nullopt;
+
+				// Change knobset via MIDI CC
+				if (info.settings.midi.knobset_control == MidiSettings::KnobsetControl::Enabled) {
+					auto &cc = info.params.midi_ccs[info.settings.midi.knobset_cc & 127];
+
+					auto midi_chan =
+						info.settings.midi.knobset_channel + 1; //User sees channels 1-16, but internally is 0-15
+					if (cc.changed && cc.val == midi_chan) {
+						auto next = std::clamp<unsigned>(cc.value, 0, num_knobsets - 1);
+						if (next != info.page_list.get_active_knobset())
+							next_knobset = next;
+					}
+				}
+
+				// Change knobset via Button+Encoder
+				if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
 					int cur_knobset = info.page_list.get_active_knobset();
-					int next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
+					next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
+				}
 
-					info.patch_mod_queue.put(ChangeKnobSet{.knobset_num = (unsigned)next_knobset});
-					info.page_list.set_active_knobset(next_knobset);
-					std::string ks_name = patch->valid_knob_set_name(next_knobset);
+				if (next_knobset.has_value()) {
+					info.patch_mod_queue.put(ChangeKnobSet{.knobset_num = (unsigned)*next_knobset});
+					info.page_list.set_active_knobset(*next_knobset);
+					std::string ks_name = patch->valid_knob_set_name(*next_knobset);
 
 					bool patchview_knobset_visible = cur_page == page_list.page(PageId::PatchView) &&
 													 info.settings.patch_view.show_knobset_name &&
@@ -175,7 +195,7 @@ public:
 							{"Using Knob Set \"" + ks_name + "\"", Notification::Priority::Status, 600});
 					}
 
-					button_light.display_knobset(next_knobset);
+					button_light.display_knobset(*next_knobset);
 				}
 			}
 		}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -160,23 +160,23 @@ public:
 			if (int num_knobsets = patch->knob_sets.size(); num_knobsets > 0) {
 
 				std::optional<int> next_knobset = std::nullopt;
+				int cur_knobset = info.page_list.get_active_knobset();
 
 				// Change knobset via MIDI CC
 				if (info.settings.midi.knobset_control == MidiSettings::KnobsetControl::Enabled) {
 					auto &cc = info.params.midi_ccs[info.settings.midi.knobset_cc & 127];
 
-					auto midi_chan =
-						info.settings.midi.knobset_channel - 1; //User sees channels 1-16, but internally is 0-15
+					auto midi_chan = info.settings.midi.knobset_channel - 1;
 					if (cc.changed && cc.val == midi_chan) {
-						auto next = std::clamp<unsigned>(cc.value, 0, num_knobsets - 1);
-						if (next != info.page_list.get_active_knobset())
-							next_knobset = next;
+						if (cc.value != cur_knobset && cc.value < num_knobsets) {
+							next_knobset = cc.value;
+							cc.changed = false;
+						}
 					}
 				}
 
 				// Change knobset via Button+Encoder
 				if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
-					int cur_knobset = info.page_list.get_active_knobset();
 					next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
 				}
 

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -370,6 +370,11 @@ struct PatchSelectorPage : PageBase {
 
 					if (result.success) {
 						patches.start_viewing(selected_patch);
+
+						// Clear cc events so we don't change knobsets with stale events
+						for (auto &cc : params.midi_ccs)
+							cc.changed = false;
+
 						missing_plugins.start(
 							patches.get_view_patch(), group, [this](bool) { exit_to_patch_view_page(); });
 						state = State::Closing;

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -61,6 +61,9 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(fs_section.startup_patch_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(fs_section.max_patches_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(midi_section.feedback_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(midi_section.knobset_control_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(midi_section.knobset_cc_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(midi_section.knobset_channel_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(audio_section.sr_override_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(audio_section.bs_override_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(missingplugins_section.dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
@@ -75,6 +78,9 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(fs_section.startup_patch_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(fs_section.max_patches_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(midi_section.feedback_check, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(midi_section.knobset_control_check, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(midi_section.knobset_cc_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(midi_section.knobset_channel_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.sr_override_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.bs_override_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(missingplugins_section.dropdown, focus_cb, LV_EVENT_FOCUSED, this);
@@ -204,6 +210,9 @@ private:
 		lv_show(catchup_section.allowjump_cont, catchup.mode == CatchupParam::Mode::ResumeOnEqual);
 
 		lv_check(midi_section.feedback_check, midi.midi_feedback == MidiSettings::MidiFeedback::Enabled);
+		lv_check(midi_section.knobset_control_check, midi.knobset_control == MidiSettings::KnobsetControl::Enabled);
+		lv_dropdown_set_selected(midi_section.knobset_cc_dropdown, midi.knobset_cc);
+		lv_dropdown_set_selected(midi_section.knobset_channel_dropdown, midi.knobset_channel - 1);
 
 		// Patch suggested audio toggles
 		lv_check(audio_section.sr_override_check, settings.patch_suggested_audio.apply_samplerate);
@@ -330,6 +339,20 @@ private:
 																				 MidiSettings::MidiFeedback::Disabled;
 	}
 
+	auto read_knobset_control_check() {
+		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED)
+				 ? MidiSettings::KnobsetControl::Enabled
+				 : MidiSettings::KnobsetControl::Disabled;
+	}
+
+	uint32_t read_knobset_cc_dropdown() {
+		return lv_dropdown_get_selected(midi_section.knobset_cc_dropdown);
+	}
+
+	uint32_t read_knobset_channel_dropdown() {
+		return lv_dropdown_get_selected(midi_section.knobset_channel_dropdown) + 1;
+	}
+
 	MissingPluginSettings::Autoload read_missing_plugins_dropdown() {
 		auto item = lv_dropdown_get_selected(missingplugins_section.dropdown);
 		if (item == 1)
@@ -396,6 +419,18 @@ private:
 		auto midi_feedback = read_midi_feedback_check();
 		if (midi.midi_feedback != midi_feedback) {
 			midi.midi_feedback = midi_feedback;
+			gui_state.do_write_settings = true;
+		}
+
+		auto knobset_control = read_knobset_control_check();
+		auto knobset_cc = read_knobset_cc_dropdown();
+		auto knobset_channel = read_knobset_channel_dropdown();
+		if (midi.knobset_control != knobset_control || midi.knobset_cc != knobset_cc ||
+			midi.knobset_channel != knobset_channel)
+		{
+			midi.knobset_control = knobset_control;
+			midi.knobset_cc = knobset_cc;
+			midi.knobset_channel = knobset_channel;
 			gui_state.do_write_settings = true;
 		}
 
@@ -482,6 +517,18 @@ private:
 			lv_group_set_editing(group, false);
 			return true;
 
+		} else if (lv_dropdown_is_open(midi_section.knobset_cc_dropdown)) {
+			lv_dropdown_close(midi_section.knobset_cc_dropdown);
+			lv_group_focus_obj(midi_section.knobset_cc_dropdown);
+			lv_group_set_editing(group, false);
+			return true;
+
+		} else if (lv_dropdown_is_open(midi_section.knobset_channel_dropdown)) {
+			lv_dropdown_close(midi_section.knobset_channel_dropdown);
+			lv_group_focus_obj(midi_section.knobset_channel_dropdown);
+			lv_group_set_editing(group, false);
+			return true;
+
 		} else if (lv_dropdown_is_open(missingplugins_section.dropdown)) {
 			lv_dropdown_close(missingplugins_section.dropdown);
 			lv_group_focus_obj(missingplugins_section.dropdown);
@@ -530,6 +577,9 @@ private:
 		auto catchup_exclude_buttons = read_catchup_exclude_check();
 		auto fs_max_patches = read_fs_max_open_patches();
 		auto midi_feedback = read_midi_feedback_check();
+		auto knobset_control = read_knobset_control_check();
+		auto knobset_cc = read_knobset_cc_dropdown();
+		auto knobset_channel = read_knobset_channel_dropdown();
 		auto apply_sr = read_patch_suggest_samplerate_check();
 		auto apply_bs = read_patch_suggest_blocksize_check();
 		auto load_initial_patch = lv_obj_has_state(fs_section.startup_patch_check, LV_STATE_CHECKED);
@@ -542,7 +592,9 @@ private:
 			knobwake == screensaver.knobs_can_wake && catchupmode == catchup.mode &&
 			catchup_exclude_buttons == catchup.allow_jump_outofrange &&
 			load_initial_patch == settings.load_initial_patch && fs_max_patches == fs.max_open_patches &&
-			midi_feedback == midi.midi_feedback && mp_mode == missing_plugins.autoload &&
+			midi_feedback == midi.midi_feedback && knobset_control == midi.knobset_control &&
+			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
+			mp_mode == missing_plugins.autoload &&
 			apply_sr == settings.patch_suggested_audio.apply_samplerate &&
 			apply_bs == settings.patch_suggested_audio.apply_blocksize)
 		{

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -213,6 +213,7 @@ private:
 		lv_check(midi_section.knobset_control_check, midi.knobset_control == MidiSettings::KnobsetControl::Enabled);
 		lv_dropdown_set_selected(midi_section.knobset_cc_dropdown, midi.knobset_cc);
 		lv_dropdown_set_selected(midi_section.knobset_channel_dropdown, midi.knobset_channel - 1);
+		update_knobset_control_items(midi.knobset_control == MidiSettings::KnobsetControl::Enabled);
 
 		// Patch suggested audio toggles
 		lv_check(audio_section.sr_override_check, settings.patch_suggested_audio.apply_samplerate);
@@ -343,6 +344,14 @@ private:
 		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED)
 				 ? MidiSettings::KnobsetControl::Enabled
 				 : MidiSettings::KnobsetControl::Disabled;
+	}
+
+	void update_knobset_control_items(bool enabled) {
+		lv_enable(midi_section.knobset_cc_dropdown, enabled);
+		lv_enable(midi_section.knobset_channel_dropdown, enabled);
+		auto opa = enabled ? LV_OPA_100 : LV_OPA_50;
+		lv_obj_set_style_opa(lv_obj_get_parent(midi_section.knobset_cc_dropdown), opa, LV_PART_MAIN);
+		lv_obj_set_style_opa(lv_obj_get_parent(midi_section.knobset_channel_dropdown), opa, LV_PART_MAIN);
 	}
 
 	uint32_t read_knobset_cc_dropdown() {
@@ -586,6 +595,7 @@ private:
 		auto mp_mode = read_missing_plugins_dropdown();
 
 		lv_show(catchup_section.allowjump_cont, catchupmode == CatchupParam::Mode::ResumeOnEqual);
+		update_knobset_control_items(knobset_control == MidiSettings::KnobsetControl::Enabled);
 
 		if (block_size == audio_settings.block_size && sample_rate == audio_settings.sample_rate &&
 			overrun_retries == audio_settings.max_overrun_retries && timeout == screensaver.timeout_ms &&

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -15,7 +15,9 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	create_prefs_note(midi_cont, "Sends MIDI to controller\nwhen MIDI-mapped params\nchange");
 
 	// Knob Set Control
-	auto knobset_cont = create_prefs_labeled_check(parent, "Knob Set Control:");
+	create_prefs_section_title(parent, "MIDI Knob Set Select");
+
+	auto knobset_cont = create_prefs_labeled_check(parent, "Enable:");
 	knobset_control_check = lv_obj_get_child(knobset_cont, 1);
 
 	create_prefs_note(knobset_cont, "MIDI CC values 0-7\nselect Knob Set");

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -1,5 +1,6 @@
 #include "prefs_section_midi.hh"
 #include "ui_local.h"
+#include <string>
 
 namespace MetaModule
 {
@@ -12,6 +13,32 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	feedback_check = lv_obj_get_child(midi_cont, 1);
 
 	create_prefs_note(midi_cont, "Sends MIDI to controller\nwhen MIDI-mapped params\nchange");
+
+	// Knob Set Control
+	auto knobset_cont = create_prefs_labeled_check(parent, "Knob Set Control:");
+	knobset_control_check = lv_obj_get_child(knobset_cont, 1);
+
+	create_prefs_note(knobset_cont, "Change knobsets via MIDI CC");
+
+	// MIDI CC number (0-127)
+	std::string cc_opts;
+	for (int i = 0; i <= 127; i++) {
+		cc_opts += std::to_string(i) + "\n";
+	}
+	cc_opts.pop_back();
+	auto cc_cont = create_prefs_labeled_dropdown(parent, "MIDI CC:", cc_opts);
+	knobset_cc_dropdown = lv_obj_get_child(cc_cont, 1);
+	lv_obj_set_width(knobset_cc_dropdown, 60);
+
+	// MIDI Channel (1-16)
+	std::string ch_opts;
+	for (int i = 1; i <= 16; i++) {
+		ch_opts += std::to_string(i) + "\n";
+	}
+	ch_opts.pop_back();
+	auto ch_cont = create_prefs_labeled_dropdown(parent, "MIDI Channel:", ch_opts);
+	knobset_channel_dropdown = lv_obj_get_child(ch_cont, 1);
+	lv_obj_set_width(knobset_channel_dropdown, 50);
 }
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -18,7 +18,7 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	auto knobset_cont = create_prefs_labeled_check(parent, "Knob Set Control:");
 	knobset_control_check = lv_obj_get_child(knobset_cont, 1);
 
-	create_prefs_note(knobset_cont, "Change knobsets via MIDI CC");
+	create_prefs_note(knobset_cont, "MIDI CC values 0-7\nselect Knob Set");
 
 	// MIDI CC number (0-127)
 	std::string cc_opts;

--- a/firmware/src/gui/slsexport/prefs_section_midi.hh
+++ b/firmware/src/gui/slsexport/prefs_section_midi.hh
@@ -5,6 +5,9 @@ namespace MetaModule
 
 struct PrefsSectionMidi {
 	lv_obj_t *feedback_check;
+	lv_obj_t *knobset_control_check;
+	lv_obj_t *knobset_cc_dropdown;
+	lv_obj_t *knobset_channel_dropdown;
 
 	void create(lv_obj_t *parent);
 };

--- a/firmware/src/params/params_state.hh
+++ b/firmware/src/params/params_state.hh
@@ -121,6 +121,7 @@ struct ParamsMidiState : ParamsState {
 	struct MidiChangedVal {
 		uint8_t changed : 1;
 		uint8_t val : 7;
+		uint8_t value;
 	};
 	std::array<MidiChangedVal, NumMidiCCs> midi_ccs;
 	MidiChangedVal last_midi_note;

--- a/firmware/src/params/sync_params.hh
+++ b/firmware/src/params/sync_params.hh
@@ -54,6 +54,7 @@ public:
 				if (e.type == Midi::Event::Type::CC && e.note < NumMidiCCs) {
 					params.midi_ccs[e.note].changed = 1;
 					params.midi_ccs[e.note].val = e.midi_chan;
+					params.midi_ccs[e.note].value = e.val;
 				}
 				if (e.type == Midi::Event::Type::NoteOn && e.note < NumMidiNotes) {
 					params.last_midi_note.changed = 1;

--- a/firmware/src/user_settings/midi_settings.hh
+++ b/firmware/src/user_settings/midi_settings.hh
@@ -7,12 +7,25 @@ namespace MetaModule
 
 struct MidiSettings {
 	enum class MidiFeedback : uint32_t { Disabled = 0, Enabled = 1 };
+	enum class KnobsetControl : uint32_t { Disabled = 0, Enabled = 1 };
 
 	MidiFeedback midi_feedback{MidiFeedback::Enabled};
+	KnobsetControl knobset_control{KnobsetControl::Disabled};
+	uint32_t knobset_cc{0};
+	uint32_t knobset_channel{16};
 
 	void make_valid() {
 		if (std::to_underlying(midi_feedback) > 1) {
 			midi_feedback = MidiFeedback::Disabled;
+		}
+		if (std::to_underlying(knobset_control) > 1) {
+			knobset_control = KnobsetControl::Disabled;
+		}
+		if (knobset_cc > 127) {
+			knobset_cc = 0;
+		}
+		if (knobset_channel < 1 || knobset_channel > 16) {
+			knobset_channel = 1;
 		}
 	}
 };

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -146,6 +146,16 @@ static bool read(ryml::ConstNodeRef const &node, FilesystemSettings *settings) {
 		settings->midi_feedback = MidiSettings{}.midi_feedback;
 	}
 
+	if (node.has_child("knobset_control")) {
+		settings->knobset_control = node["knobset_control"].val() == "1" ? MidiSettings::KnobsetControl::Enabled :
+																		   MidiSettings::KnobsetControl::Disabled;
+	} else {
+		settings->knobset_control = MidiSettings{}.knobset_control;
+	}
+
+	read_or_default(node, "knobset_cc", settings, &MidiSettings::knobset_cc);
+	read_or_default(node, "knobset_channel", settings, &MidiSettings::knobset_channel);
+
 	settings->make_valid();
 
 	return true;

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -84,6 +84,9 @@ static void write(ryml::NodeRef *n, FilesystemSettings const &s) {
 	*n |= ryml::MAP;
 
 	n->append_child() << ryml::key("midi_feedback") << std::to_underlying(s.midi_feedback);
+	n->append_child() << ryml::key("knobset_control") << std::to_underlying(s.knobset_control);
+	n->append_child() << ryml::key("knobset_cc") << s.knobset_cc;
+	n->append_child() << ryml::key("knobset_channel") << s.knobset_channel;
 }
 
 static void write(ryml::NodeRef *n, PatchSuggestedAudioSettings const &s) {

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -397,6 +397,9 @@ TEST_CASE("Serialize settings") {
     max_open_patches: 8
   midi:
     midi_feedback: 0
+    knobset_control: 0
+    knobset_cc: 0
+    knobset_channel: 16
   patch_suggested_audio:
     apply_samplerate: 0
     apply_blocksize: 1


### PR DESCRIPTION
Adds preferences/settings to enable this, and choose the MIDI CC number and channel.
Values 0-7 select Knob Set 1-8 if present.

The MIDI CC values are not filtered, so they can be used for mappings too.