### PR TITLE
MetaButton Expander can select knobset

### DIFF
--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -210,8 +210,8 @@ void AudioStream::process(CombinedAudioBlock &audio_block, ParamBlock &param_blo
 
 	param_block.metaparams.midi_poly_chans = player.get_midi_poly_num();
 
-	// Button Expander
-	if (param_block.metaparams.button_exp_connected != 0) {
+	// Button Expander: block events if Back button is held down
+	if (param_block.metaparams.button_exp_connected != 0 && !param_block.metaparams.meta_buttons[0].is_pressed()) {
 		handle_button_events(param_block.metaparams.ext_buttons_high_events, 1.f);
 		handle_button_events(param_block.metaparams.ext_buttons_low_events, 0.f);
 	}

--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -464,6 +464,8 @@ ParamBlock &AudioStream::cache_params(unsigned block) {
 	local_params.metaparams.button_exp_connected = param_blocks[block].metaparams.button_exp_connected;
 	local_params.metaparams.ext_buttons_high_events = param_blocks[block].metaparams.ext_buttons_high_events;
 	local_params.metaparams.ext_buttons_low_events = param_blocks[block].metaparams.ext_buttons_low_events;
+	local_params.metaparams.meta_buttons[0].set_state_no_events(
+		param_blocks[block].metaparams.meta_buttons[0].is_pressed());
 
 	for (auto i = 0u; i < block_size_; i++)
 		local_params.params[i] = param_blocks[block].params[i]; // 45us/49us alt

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -207,7 +207,9 @@ public:
 						auto firstbit = std::countr_zero(events) % 8;
 						if (firstbit < num_knobsets) {
 							next_knobset = firstbit;
-							metaparams.ignore_metabutton_release = true;
+							if (info.settings.button_exp_knobset.require_back) {
+								metaparams.ignore_metabutton_release = true;
+							}
 						}
 					}
 				}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -158,11 +158,12 @@ public:
 		// Patch must be valid, playing, and have at least one knobset
 		if (auto patch = info.open_patch_manager.get_playing_patch(); patch != nullptr) {
 			if (int num_knobsets = patch->knob_sets.size(); num_knobsets > 0) {
+				auto &metaparams = info.metaparams;
 
 				std::optional<int> next_knobset = std::nullopt;
 				int cur_knobset = info.page_list.get_active_knobset();
 
-				// Change knobset via MIDI CC
+				// Detecrt MIDI CC
 				if (info.settings.midi.knobset_control == MidiSettings::KnobsetControl::Enabled) {
 					auto &cc = info.params.midi_ccs[info.settings.midi.knobset_cc & 127];
 
@@ -175,23 +176,40 @@ public:
 					}
 				}
 
-				// Change knobset via Back Button + Encoder
-				if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
+				// Detect Back Button + Encoder
+				if (auto knobset_change = metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
 					next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
 				}
 
-				// TODO: change via Back button + Button expander
-				if (info.metaparams.meta_buttons[0].is_pressed() && info.metaparams.button_exp_connected > 0) {
-					auto mask = info.metaparams.ext_buttons_high_events;
-					int i = 0;
-					while (mask) {
-						if (mask & 0b1) {
-							if (i < num_knobsets)
-								next_knobset = i;
-							// TODO: Disable Back button release event
+				// Detect Back button + Button expander
+				// Filter out disconnected button expanders and ones for which this feature is not enabled
+				if (auto exp = (info.settings.button_exp_knobset.button_expander & metaparams.button_exp_connected)) {
+					bool back_pressed = true;
+
+					if (info.settings.button_exp_knobset.require_back) {
+						back_pressed = metaparams.meta_buttons[0].is_pressed();
+
+						if (metaparams.meta_buttons[0].is_just_pressed()) {
+							// Clear all events when pressing Back
+							metaparams.ext_buttons_high_events = 0;
 						}
-						mask >>= 1;
-						i++;
+					}
+
+					if (back_pressed && metaparams.ext_buttons_high_events) {
+						// turn bit mask 0bwxyz into 0xWWXXYYZZ
+						auto mask = ((exp & 0b0001) ? 0x000000FFu : 0) | ((exp & 0b0010) ? 0x0000FF00u : 0) |
+									((exp & 0b0100) ? 0x00FF0000u : 0) | ((exp & 0b1000) ? 0xFF000000u : 0);
+
+						// Get and clear events on the enabled expander(s)
+						auto events = metaparams.ext_buttons_high_events;
+						metaparams.ext_buttons_high_events &= ~mask;
+
+						auto firstbit = std::countr_zero(events);
+						pr_dbg("Back + exp %d (max %d)\n", firstbit, num_knobsets);
+						if (firstbit < num_knobsets) {
+							next_knobset = firstbit;
+							metaparams.ignore_metabutton_release = true;
+						}
 					}
 				}
 

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -181,7 +181,19 @@ public:
 				}
 
 				// TODO: change via Back button + Button expander
-				{}
+				if (info.metaparams.meta_buttons[0].is_pressed() && info.metaparams.button_exp_connected > 0) {
+					auto mask = info.metaparams.ext_buttons_high_events;
+					unsigned i = 0;
+					while (mask) {
+						if (mask & 0b1) {
+							if (i < next_knobset)
+								next_knobset = i;
+							// TODO: Disable Back button release event
+						}
+						mask >>= 1;
+						i++;
+					}
+				}
 
 				// Perform the knob set change:
 				if (next_knobset.has_value()) {

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -183,10 +183,10 @@ public:
 				// TODO: change via Back button + Button expander
 				if (info.metaparams.meta_buttons[0].is_pressed() && info.metaparams.button_exp_connected > 0) {
 					auto mask = info.metaparams.ext_buttons_high_events;
-					unsigned i = 0;
+					int i = 0;
 					while (mask) {
 						if (mask & 0b1) {
-							if (i < next_knobset)
+							if (i < num_knobsets)
 								next_knobset = i;
 							// TODO: Disable Back button release event
 						}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -195,17 +195,16 @@ public:
 						}
 					}
 
-					if (back_pressed && metaparams.ext_buttons_high_events) {
-						// turn bit mask 0bwxyz into 0xWWXXYYZZ
-						auto mask = ((exp & 0b0001) ? 0x000000FFu : 0) | ((exp & 0b0010) ? 0x0000FF00u : 0) |
-									((exp & 0b0100) ? 0x00FF0000u : 0) | ((exp & 0b1000) ? 0xFF000000u : 0);
+					// turn bit mask 0bwxyz into 0xWWXXYYZZ
+					auto mask = ((exp & 0b0001) ? 0x000000FFu : 0) | ((exp & 0b0010) ? 0x0000FF00u : 0) |
+								((exp & 0b0100) ? 0x00FF0000u : 0) | ((exp & 0b1000) ? 0xFF000000u : 0);
 
+					if (back_pressed && (metaparams.ext_buttons_high_events & mask)) {
 						// Get and clear events on the enabled expander(s)
-						auto events = metaparams.ext_buttons_high_events;
+						auto events = metaparams.ext_buttons_high_events & mask;
 						metaparams.ext_buttons_high_events &= ~mask;
 
-						auto firstbit = std::countr_zero(events);
-						pr_dbg("Back + exp %d (max %d)\n", firstbit, num_knobsets);
+						auto firstbit = std::countr_zero(events) % 8;
 						if (firstbit < num_knobsets) {
 							next_knobset = firstbit;
 							metaparams.ignore_metabutton_release = true;

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -175,11 +175,15 @@ public:
 					}
 				}
 
-				// Change knobset via Button+Encoder
+				// Change knobset via Back Button + Encoder
 				if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
 					next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
 				}
 
+				// TODO: change via Back button + Button expander
+				{}
+
+				// Perform the knob set change:
 				if (next_knobset.has_value()) {
 					info.patch_mod_queue.put(ChangeKnobSet{.knobset_num = (unsigned)*next_knobset});
 					info.page_list.set_active_knobset(*next_knobset);

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -5,6 +5,7 @@
 #include "gui/pages/system_menu_tab_base.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/slsexport/prefs_section_audio.hh"
+#include "gui/slsexport/prefs_section_button_exp_knobset.hh"
 #include "gui/slsexport/prefs_section_catchup.hh"
 #include "gui/slsexport/prefs_section_fs.hh"
 #include "gui/slsexport/prefs_section_midi.hh"
@@ -29,6 +30,7 @@ struct PrefsTab : SystemMenuTab {
 		, fs{settings.filesystem}
 		, midi{settings.midi}
 		, missing_plugins{settings.missing_plugins}
+		, button_exp_knobset{settings.button_exp_knobset}
 		, settings{settings} {
 
 		audio_section.create(ui_SystemMenuPrefsTab);
@@ -37,6 +39,7 @@ struct PrefsTab : SystemMenuTab {
 		fs_section.create(ui_SystemMenuPrefsTab);
 		midi_section.create(ui_SystemMenuPrefsTab);
 		missingplugins_section.create(ui_SystemMenuPrefsTab);
+		buttonexpknobset_section.create(ui_SystemMenuPrefsTab);
 
 		auto btns = create_save_revert_buttons(ui_SystemMenuPrefsTab);
 		save_button = lv_obj_get_child(btns, 1);
@@ -67,6 +70,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(audio_section.sr_override_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(audio_section.bs_override_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(missingplugins_section.dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.expander_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.require_back_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 
 		lv_obj_add_event_cb(audio_section.blocksize_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.overrun_retries, focus_cb, LV_EVENT_FOCUSED, this);
@@ -84,6 +89,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(audio_section.sr_override_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.bs_override_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(missingplugins_section.dropdown, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.expander_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.require_back_check, focus_cb, LV_EVENT_FOCUSED, this);
 
 		std::string opts;
 		for (auto item : AudioSettings::ValidBlockSizes) {
@@ -226,6 +233,11 @@ private:
 																									 2;
 			lv_dropdown_set_selected(missingplugins_section.dropdown, idx);
 		}
+
+		// Button expander knob set
+		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, button_exp_knobset.button_expander);
+		lv_check(buttonexpknobset_section.require_back_check, button_exp_knobset.require_back);
+		update_require_back_enabled(button_exp_knobset.button_expander != 0);
 
 		gui_state.do_write_settings = false;
 
@@ -371,6 +383,20 @@ private:
 		return MissingPluginSettings::Autoload::Ask;
 	}
 
+	uint32_t read_button_exp_knobset_dropdown() {
+		return lv_dropdown_get_selected(buttonexpknobset_section.expander_dropdown);
+	}
+
+	bool read_require_back_check() {
+		return lv_obj_has_state(buttonexpknobset_section.require_back_check, LV_STATE_CHECKED);
+	}
+
+	void update_require_back_enabled(bool expander_enabled) {
+		lv_enable(buttonexpknobset_section.require_back_check, expander_enabled);
+		auto opa = expander_enabled ? LV_OPA_100 : LV_OPA_50;
+		lv_obj_set_style_opa(buttonexpknobset_section.require_back_cont, opa, LV_PART_MAIN);
+	}
+
 	// Update the settings structure from the dropdown and checkbox selections
 	// This is called when the user clicks "Apply" or exits the prefs page
 	void update_settings_from_dropdown() {
@@ -484,6 +510,15 @@ private:
 			gui_state.do_write_settings = true;
 		}
 
+		// Button expander knob set
+		auto bexp = read_button_exp_knobset_dropdown();
+		auto bexp_back = read_require_back_check();
+		if (button_exp_knobset.button_expander != bexp || button_exp_knobset.require_back != bexp_back) {
+			button_exp_knobset.button_expander = bexp;
+			button_exp_knobset.require_back = bexp_back;
+			gui_state.do_write_settings = true;
+		}
+
 		lv_disable(save_button);
 		lv_disable(revert_button);
 	}
@@ -544,6 +579,12 @@ private:
 			lv_group_set_editing(group, false);
 			return true;
 
+		} else if (lv_dropdown_is_open(buttonexpknobset_section.expander_dropdown)) {
+			lv_dropdown_close(buttonexpknobset_section.expander_dropdown);
+			lv_group_focus_obj(buttonexpknobset_section.expander_dropdown);
+			lv_group_set_editing(group, false);
+			return true;
+
 		} else {
 			update_settings_from_dropdown();
 			return false;
@@ -593,9 +634,12 @@ private:
 		auto apply_bs = read_patch_suggest_blocksize_check();
 		auto load_initial_patch = lv_obj_has_state(fs_section.startup_patch_check, LV_STATE_CHECKED);
 		auto mp_mode = read_missing_plugins_dropdown();
+		auto bexp = read_button_exp_knobset_dropdown();
+		auto bexp_back = read_require_back_check();
 
 		lv_show(catchup_section.allowjump_cont, catchupmode == CatchupParam::Mode::ResumeOnEqual);
 		update_knobset_control_items(knobset_control == MidiSettings::KnobsetControl::Enabled);
+		update_require_back_enabled(bexp != 0);
 
 		if (block_size == audio_settings.block_size && sample_rate == audio_settings.sample_rate &&
 			overrun_retries == audio_settings.max_overrun_retries && timeout == screensaver.timeout_ms &&
@@ -606,7 +650,9 @@ private:
 			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
 			mp_mode == missing_plugins.autoload &&
 			apply_sr == settings.patch_suggested_audio.apply_samplerate &&
-			apply_bs == settings.patch_suggested_audio.apply_blocksize)
+			apply_bs == settings.patch_suggested_audio.apply_blocksize &&
+			bexp == button_exp_knobset.button_expander &&
+			bexp_back == button_exp_knobset.require_back)
 		{
 			lv_disable(save_button);
 			lv_disable(revert_button);
@@ -625,7 +671,10 @@ private:
 		auto target = event->target;
 
 		// scroll to bottom if we select last items
-		if (target == page->missingplugins_section.dropdown) {
+		if (target == page->buttonexpknobset_section.expander_dropdown ||
+			target == page->buttonexpknobset_section.require_back_check ||
+			target == page->missingplugins_section.dropdown)
+		{
 			lv_obj_scroll_to_view_recursive(page->save_button, LV_ANIM_ON);
 
 			// scroll to top if we select first items
@@ -644,6 +693,7 @@ private:
 	FilesystemSettings &fs;
 	MidiSettings &midi;
 	MissingPluginSettings &missing_plugins;
+	ButtonExpKnobSetSettings &button_exp_knobset;
 	UserSettings &settings;
 
 	lv_group_t *group = nullptr;
@@ -654,6 +704,7 @@ private:
 	PrefsSectionFilesystem fs_section;
 	PrefsSectionMidi midi_section;
 	PrefsSectionMissingPlugins missingplugins_section;
+	PrefsSectionButtonExpKnobSet buttonexpknobset_section;
 
 	lv_obj_t *save_button;
 	lv_obj_t *revert_button;

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -38,8 +38,8 @@ struct PrefsTab : SystemMenuTab {
 		catchup_section.create(ui_SystemMenuPrefsTab);
 		fs_section.create(ui_SystemMenuPrefsTab);
 		midi_section.create(ui_SystemMenuPrefsTab);
-		missingplugins_section.create(ui_SystemMenuPrefsTab);
 		buttonexpknobset_section.create(ui_SystemMenuPrefsTab);
+		missingplugins_section.create(ui_SystemMenuPrefsTab);
 
 		auto btns = create_save_revert_buttons(ui_SystemMenuPrefsTab);
 		save_button = lv_obj_get_child(btns, 1);
@@ -131,6 +131,7 @@ struct PrefsTab : SystemMenuTab {
 
 		set_options(ScreensaverSettings::ValidOptions, catchup_section.mode_dropdown);
 		set_options(CatchupSettings::ValidOptions, catchup_section.mode_dropdown);
+		set_options(ButtonExpKnobSetSettings::ValidOptions, buttonexpknobset_section.expander_dropdown);
 	}
 
 	void prepare_focus(lv_group_t *group) override {
@@ -235,7 +236,9 @@ private:
 		}
 
 		// Button expander knob set
-		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, button_exp_knobset.button_expander);
+		auto bexp_item = get_index(ButtonExpKnobSetSettings::ValidOptions,
+								   [this](auto t) { return t.value == button_exp_knobset.button_expander; });
+		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, bexp_item >= 0 ? bexp_item : 0);
 		lv_check(buttonexpknobset_section.require_back_check, button_exp_knobset.require_back);
 		update_require_back_enabled(button_exp_knobset.button_expander != 0);
 
@@ -353,9 +356,9 @@ private:
 	}
 
 	auto read_knobset_control_check() {
-		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED)
-				 ? MidiSettings::KnobsetControl::Enabled
-				 : MidiSettings::KnobsetControl::Disabled;
+		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED) ?
+				   MidiSettings::KnobsetControl::Enabled :
+				   MidiSettings::KnobsetControl::Disabled;
 	}
 
 	void update_knobset_control_items(bool enabled) {
@@ -384,7 +387,11 @@ private:
 	}
 
 	uint32_t read_button_exp_knobset_dropdown() {
-		return lv_dropdown_get_selected(buttonexpknobset_section.expander_dropdown);
+		auto item = lv_dropdown_get_selected(buttonexpknobset_section.expander_dropdown);
+		if (item >= 0 && item < ButtonExpKnobSetSettings::ValidOptions.size())
+			return ButtonExpKnobSetSettings::ValidOptions[item].value;
+		else
+			return ButtonExpKnobSetSettings::DefaultButtonExpander;
 	}
 
 	bool read_require_back_check() {
@@ -648,10 +655,8 @@ private:
 			load_initial_patch == settings.load_initial_patch && fs_max_patches == fs.max_open_patches &&
 			midi_feedback == midi.midi_feedback && knobset_control == midi.knobset_control &&
 			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
-			mp_mode == missing_plugins.autoload &&
-			apply_sr == settings.patch_suggested_audio.apply_samplerate &&
-			apply_bs == settings.patch_suggested_audio.apply_blocksize &&
-			bexp == button_exp_knobset.button_expander &&
+			mp_mode == missing_plugins.autoload && apply_sr == settings.patch_suggested_audio.apply_samplerate &&
+			apply_bs == settings.patch_suggested_audio.apply_blocksize && bexp == button_exp_knobset.button_expander &&
 			bexp_back == button_exp_knobset.require_back)
 		{
 			lv_disable(save_button);
@@ -671,10 +676,7 @@ private:
 		auto target = event->target;
 
 		// scroll to bottom if we select last items
-		if (target == page->buttonexpknobset_section.expander_dropdown ||
-			target == page->buttonexpknobset_section.require_back_check ||
-			target == page->missingplugins_section.dropdown)
-		{
+		if (target == page->missingplugins_section.dropdown) {
 			lv_obj_scroll_to_view_recursive(page->save_button, LV_ANIM_ON);
 
 			// scroll to top if we select first items

--- a/firmware/src/gui/slsexport/CMakeLists.txt
+++ b/firmware/src/gui/slsexport/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
           prefs_section_fs.cc
           prefs_section_midi.cc
           prefs_section_missing_plugins.cc
+          prefs_section_button_exp_knobset.cc
           filebrowser/ui.c
           filebrowser/screens/ui_FileBrowserPage.c
 )
@@ -23,5 +24,6 @@ set_source_files_properties(
   prefs_section_fs.cc
   prefs_section_midi.cc
   prefs_section_missing_plugins.cc
+  prefs_section_button_exp_knobset.cc
   PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-enum-enum-conversion;-Wno-deprecated-anon-enum-enum-conversion;"
 )

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -14,7 +14,7 @@ void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 	lv_obj_set_width(expander_dropdown, 80);
 
 	require_back_cont = create_prefs_labeled_check(parent, "Back + Button");
-	require_back_note = create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
+	create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
 
 	require_back_check = lv_obj_get_child(require_back_cont, 1);
 }

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -7,11 +7,11 @@ namespace MetaModule
 
 void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 
-	create_prefs_section_title(parent, "BUTTON EXP. KNOB SET SELECT");
+	create_prefs_section_title(parent, "METABUTTON KNOB SET SELECT");
 
-	auto cont = create_prefs_labeled_dropdown(parent, "Button Expander #:", "Disabled\n1\n2\n3\n4");
+	auto cont = create_prefs_labeled_dropdown(parent, "MetaButton #:");
 	expander_dropdown = lv_obj_get_child(cont, 1);
-	lv_obj_set_width(expander_dropdown, 110);
+	lv_obj_set_width(expander_dropdown, 80);
 
 	require_back_cont = create_prefs_labeled_check(parent, "With Back button\npressed:");
 	require_back_check = lv_obj_get_child(require_back_cont, 1);

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -13,7 +13,9 @@ void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 	expander_dropdown = lv_obj_get_child(cont, 1);
 	lv_obj_set_width(expander_dropdown, 80);
 
-	require_back_cont = create_prefs_labeled_check(parent, "With Back button\npressed:");
+	require_back_cont = create_prefs_labeled_check(parent, "Back + Button");
+	require_back_note = create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
+
 	require_back_check = lv_obj_get_child(require_back_cont, 1);
 }
 

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -1,0 +1,20 @@
+#include "prefs_section_button_exp_knobset.hh"
+#include "lvgl.h"
+#include "ui_local.h"
+
+namespace MetaModule
+{
+
+void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
+
+	create_prefs_section_title(parent, "BUTTON EXP. KNOB SET SELECT");
+
+	auto cont = create_prefs_labeled_dropdown(parent, "Button Expander #:", "Disabled\n1\n2\n3\n4");
+	expander_dropdown = lv_obj_get_child(cont, 1);
+	lv_obj_set_width(expander_dropdown, 110);
+
+	require_back_cont = create_prefs_labeled_check(parent, "With Back button\npressed:");
+	require_back_check = lv_obj_get_child(require_back_cont, 1);
+}
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.hh
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.hh
@@ -1,0 +1,14 @@
+#include "lvgl.h"
+
+namespace MetaModule
+{
+
+struct PrefsSectionButtonExpKnobSet {
+	lv_obj_t *expander_dropdown;
+	lv_obj_t *require_back_cont;
+	lv_obj_t *require_back_check;
+
+	void create(lv_obj_t *parent);
+};
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_fs.cc
+++ b/firmware/src/gui/slsexport/prefs_section_fs.cc
@@ -7,7 +7,7 @@ namespace MetaModule
 void PrefsSectionFilesystem::create(lv_obj_t *parent) {
 
 	// Title
-	create_prefs_section_title(parent, "Patch Files");
+	create_prefs_section_title(parent, "PATCH FILES");
 
 	// Startup Patch
 	auto startup_cont = create_prefs_labeled_check(parent, "Startup Patch:");

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -15,7 +15,7 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	create_prefs_note(midi_cont, "Sends MIDI to controller\nwhen MIDI-mapped params\nchange");
 
 	// Knob Set Control
-	create_prefs_section_title(parent, "MIDI Knob Set Select");
+	create_prefs_section_title(parent, "MIDI KNOB SET SELECT");
 
 	auto knobset_cont = create_prefs_labeled_check(parent, "Enable:");
 	knobset_control_check = lv_obj_get_child(knobset_cont, 1);

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -20,7 +20,7 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	auto knobset_cont = create_prefs_labeled_check(parent, "Enable:");
 	knobset_control_check = lv_obj_get_child(knobset_cont, 1);
 
-	create_prefs_note(knobset_cont, "MIDI CC values 0-7\nselect Knob Set");
+	create_prefs_note(knobset_cont, "MIDI CC values 0-7       \nselect Knob Set       ");
 
 	// MIDI CC number (0-127)
 	std::string cc_opts;

--- a/firmware/src/params/catchup_manager.hh
+++ b/firmware/src/params/catchup_manager.hh
@@ -1,8 +1,5 @@
 #pragma once
-#include "CoreModules/CoreProcessor.hh"
-#include "CoreModules/hub/button_expander_defs.hh"
 #include "catchup_param.hh"
-#include "conf/panel_conf.hh"
 #include "patch-serial/patch/patch.hh"
 #include "toggle_param.hh"
 #include <vector>
@@ -134,6 +131,9 @@ public:
 		for (unsigned i = 0u; auto &knob : active_knob_maps) {
 
 			for (auto &knob_map : knob) {
+				if (knob_map.map.is_button())
+					continue;
+
 				auto module_val = modules[knob_map.map.module_id]->get_param(knob_map.map.param_id);
 				float scaled_phys_val = knob_map.map.get_mapped_val(panel_knobs[i]);
 

--- a/firmware/src/user_settings/button_exp_knobset_settings.hh
+++ b/firmware/src/user_settings/button_exp_knobset_settings.hh
@@ -7,7 +7,7 @@ namespace MetaModule
 {
 
 struct ButtonExpKnobSetSettings {
-	// Bitfield: each expander N (1-4) is represented by (1 << N)
+	// Bitfield: expander #N (1-4) is represented by bit (N-1)
 	static constexpr uint32_t Disabled = 0;
 	static constexpr uint32_t Any = 0b1111;
 	static constexpr uint32_t Exp1 = (1 << 0);

--- a/firmware/src/user_settings/button_exp_knobset_settings.hh
+++ b/firmware/src/user_settings/button_exp_knobset_settings.hh
@@ -1,18 +1,43 @@
 #pragma once
+#include <array>
 #include <cstdint>
+#include <string_view>
 
 namespace MetaModule
 {
 
 struct ButtonExpKnobSetSettings {
-	static constexpr uint32_t DefaultButtonExpander = 0;
-	static constexpr bool DefaultRequireBack = true;
+	// Bitfield: each expander N (1-4) is represented by (1 << N)
+	static constexpr uint32_t Disabled = 0;
+	static constexpr uint32_t Any = 0b1111;
+	static constexpr uint32_t Exp1 = (1 << 0);
+	static constexpr uint32_t Exp2 = (1 << 1);
+	static constexpr uint32_t Exp3 = (1 << 2);
+	static constexpr uint32_t Exp4 = (1 << 3);
 
-	uint32_t button_expander = DefaultButtonExpander; // 0=disabled, 1-4
+	struct Option {
+		uint32_t value;
+		std::string_view label;
+	};
+	static constexpr std::array ValidOptions = {
+		Option{Disabled, "Off"},
+		Option{Any, "Any"},
+		Option{Exp1, "#1"},
+		Option{Exp2, "#2"},
+		Option{Exp3, "#3"},
+		Option{Exp4, "#4"},
+	};
+
+	static constexpr uint32_t DefaultButtonExpander = Disabled;
+	static constexpr bool DefaultRequireBack = true;
+	static constexpr uint32_t ValidMask = Any | Exp1 | Exp2 | Exp3 | Exp4;
+
+	uint32_t button_expander = DefaultButtonExpander;
 	bool require_back = DefaultRequireBack;
 
 	void make_valid() {
-		if (button_expander > 4)
+		// Check that only valid bits are set
+		if (button_expander & ~ValidMask)
 			button_expander = DefaultButtonExpander;
 
 		if (*reinterpret_cast<uint8_t *>(&require_back) != 0)

--- a/firmware/src/user_settings/button_exp_knobset_settings.hh
+++ b/firmware/src/user_settings/button_exp_knobset_settings.hh
@@ -1,0 +1,25 @@
+#pragma once
+#include <cstdint>
+
+namespace MetaModule
+{
+
+struct ButtonExpKnobSetSettings {
+	static constexpr uint32_t DefaultButtonExpander = 0;
+	static constexpr bool DefaultRequireBack = true;
+
+	uint32_t button_expander = DefaultButtonExpander; // 0=disabled, 1-4
+	bool require_back = DefaultRequireBack;
+
+	void make_valid() {
+		if (button_expander > 4)
+			button_expander = DefaultButtonExpander;
+
+		if (*reinterpret_cast<uint8_t *>(&require_back) != 0)
+			require_back = true;
+		else
+			require_back = false;
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/user_settings/settings.hh
+++ b/firmware/src/user_settings/settings.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "audio_settings.hh"
+#include "button_exp_knobset_settings.hh"
 #include "catchup_settings.hh"
 #include "fs/volumes.hh"
 #include "user_settings/fs_settings.hh"
@@ -30,6 +31,7 @@ struct UserSettings {
 	FilesystemSettings filesystem{};
 	MidiSettings midi{};
 	PatchSuggestedAudioSettings patch_suggested_audio{};
+	ButtonExpKnobSetSettings button_exp_knobset{};
 };
 
 } // namespace MetaModule

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -172,6 +172,17 @@ static bool read(ryml::ConstNodeRef const &node, PatchSuggestedAudioSettings *se
 	return true;
 }
 
+static bool read(ryml::ConstNodeRef const &node, ButtonExpKnobSetSettings *settings) {
+	if (!node.is_map())
+		return false;
+
+	read_or_default(node, "button_expander", settings, &ButtonExpKnobSetSettings::button_expander);
+	read_or_default(node, "require_back", settings, &ButtonExpKnobSetSettings::require_back);
+	settings->make_valid();
+
+	return true;
+}
+
 static bool read(ryml::ConstNodeRef const &node, MissingPluginSettings *settings) {
 	if (!node.is_map())
 		return false;
@@ -216,6 +227,7 @@ bool parse(std::span<char> yaml, UserSettings *settings) {
 	read_or_default(node, "filesystem", settings, &UserSettings::filesystem);
 	read_or_default(node, "midi", settings, &UserSettings::midi);
 	read_or_default(node, "patch_suggested_audio", settings, &UserSettings::patch_suggested_audio);
+	read_or_default(node, "button_exp_knobset", settings, &UserSettings::button_exp_knobset);
 
 	read_or_default(node, "last_patch_opened", settings, &UserSettings::initial_patch_name);
 	// TODO: cleaner way to parse an enum and reject out of range?

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -96,6 +96,13 @@ static void write(ryml::NodeRef *n, PatchSuggestedAudioSettings const &s) {
 	n->append_child() << ryml::key("apply_blocksize") << s.apply_blocksize;
 }
 
+static void write(ryml::NodeRef *n, ButtonExpKnobSetSettings const &s) {
+	*n |= ryml::MAP;
+
+	n->append_child() << ryml::key("button_expander") << s.button_expander;
+	n->append_child() << ryml::key("require_back") << s.require_back;
+}
+
 static void write(ryml::NodeRef *n, MissingPluginSettings const &s) {
 	*n |= ryml::MAP;
 
@@ -131,6 +138,7 @@ uint32_t serialize(UserSettings const &settings, std::span<char> buffer) {
 	data["filesystem"] << settings.filesystem;
 	data["midi"] << settings.midi;
 	data["patch_suggested_audio"] << settings.patch_suggested_audio;
+	data["button_exp_knobset"] << settings.button_exp_knobset;
 
 	auto res = ryml::emit_yaml(tree, c4::substr(buffer.data(), buffer.size()));
 	return res.size();

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -74,7 +74,7 @@ TEST_CASE("Parse settings file") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 2
+    button_expander: 8
     require_back: 0
 )";
 	// clang-format on
@@ -140,7 +140,7 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Never);
 
-	CHECK(settings.button_exp_knobset.button_expander == 2);
+	CHECK(settings.button_exp_knobset.button_expander == 8); // (1<<3) = Expander 3
 	CHECK(settings.button_exp_knobset.require_back == false);
 }
 
@@ -341,7 +341,7 @@ TEST_CASE("Serialize settings") {
 	settings.patch_suggested_audio.apply_samplerate = false;
 	settings.patch_suggested_audio.apply_blocksize = true;
 
-	settings.button_exp_knobset.button_expander = 3;
+	settings.button_exp_knobset.button_expander = 8; // (1<<3) = Expander 3
 	settings.button_exp_knobset.require_back = false;
 
 	// clang format-off
@@ -416,7 +416,7 @@ TEST_CASE("Serialize settings") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 3
+    button_expander: 8
     require_back: 0
 )";
 	// clang format-on

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -74,7 +74,7 @@ TEST_CASE("Parse settings file") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 8
+    button_expander: 4
     require_back: 0
 )";
 	// clang-format on
@@ -140,7 +140,7 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Never);
 
-	CHECK(settings.button_exp_knobset.button_expander == 8); // (1<<3) = Expander 3
+	CHECK(settings.button_exp_knobset.button_expander == 4); // (1<<2) = Expander #3
 	CHECK(settings.button_exp_knobset.require_back == false);
 }
 
@@ -341,7 +341,7 @@ TEST_CASE("Serialize settings") {
 	settings.patch_suggested_audio.apply_samplerate = false;
 	settings.patch_suggested_audio.apply_blocksize = true;
 
-	settings.button_exp_knobset.button_expander = 8; // (1<<3) = Expander 3
+	settings.button_exp_knobset.button_expander = 4; // (1<<2) = Expander #3
 	settings.button_exp_knobset.require_back = false;
 
 	// clang format-off
@@ -416,7 +416,7 @@ TEST_CASE("Serialize settings") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 8
+    button_expander: 4
     require_back: 0
 )";
 	// clang format-on

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -73,6 +73,9 @@ TEST_CASE("Parse settings file") {
   patch_suggested_audio:
     apply_samplerate: 0
     apply_blocksize: 1
+  button_exp_knobset:
+    button_expander: 2
+    require_back: 0
 )";
 	// clang-format on
 
@@ -136,6 +139,9 @@ TEST_CASE("Parse settings file") {
 	CHECK(settings.module_view.show_knobset_name == false);
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Never);
+
+	CHECK(settings.button_exp_knobset.button_expander == 2);
+	CHECK(settings.button_exp_knobset.require_back == false);
 }
 
 TEST_CASE("Get default settings if file is missing fields") {
@@ -280,6 +286,9 @@ TEST_CASE("Get default settings if file is missing fields") {
 	CHECK(settings.patch_suggested_audio.apply_blocksize == true);
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Ask);
+
+	CHECK(settings.button_exp_knobset.button_expander == 0);
+	CHECK(settings.button_exp_knobset.require_back == true);
 }
 
 TEST_CASE("Serialize settings") {
@@ -331,6 +340,9 @@ TEST_CASE("Serialize settings") {
 
 	settings.patch_suggested_audio.apply_samplerate = false;
 	settings.patch_suggested_audio.apply_blocksize = true;
+
+	settings.button_exp_knobset.button_expander = 3;
+	settings.button_exp_knobset.require_back = false;
 
 	// clang format-off
 	std::string expected = R"(Settings:
@@ -403,6 +415,9 @@ TEST_CASE("Serialize settings") {
   patch_suggested_audio:
     apply_samplerate: 0
     apply_blocksize: 1
+  button_exp_knobset:
+    button_expander: 3
+    require_back: 0
 )";
 	// clang format-on
 


### PR DESCRIPTION
This PR adds MetaButtons expander support for changing the knob set.

A new preference controls the behavior:
- Disabled
- Specific expander (1–4) — one designated expander changes knob sets.
- Any/All expanders — any MetaButtons expander can change knob sets.

An optional Back + Expander Button mode requires holding Back while pressing an expander button to switch knob sets, mirroring the existing Back + Encoder turn behavior. Back events are suppressed on button release when this mode is active.

When enabled, Button 1 jumps to knob set 1, Button 2 to knob set 2, etc. If the patch doesn't have the requested knob set, the button acts normally (i.e. it passes the pressed/released events to the module it's mapped to).

Notes:
Regardless of feature state, holding Back now suppresses all MetaButtons events in the Audio Stream (i.e. modules will not see button events while the Back button is held down).

Mapping buttons for both normal use and knob set navigation is not recommended when Back + Expander Button is disabled — button events may fire against either the old or new knob set mappings unpredictably. Enable Back + Expander Button mode to avoid this if you intend to use button mappings AND button knob set navigation in the same patch.
