### PR TITLE
Reduce Notifications

### DIFF
--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -210,8 +210,8 @@ void AudioStream::process(CombinedAudioBlock &audio_block, ParamBlock &param_blo
 
 	param_block.metaparams.midi_poly_chans = player.get_midi_poly_num();
 
-	// Button Expander
-	if (param_block.metaparams.button_exp_connected != 0) {
+	// Button Expander: block events if Back button is held down
+	if (param_block.metaparams.button_exp_connected != 0 && !param_block.metaparams.meta_buttons[0].is_pressed()) {
 		handle_button_events(param_block.metaparams.ext_buttons_high_events, 1.f);
 		handle_button_events(param_block.metaparams.ext_buttons_low_events, 0.f);
 	}

--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -464,6 +464,8 @@ ParamBlock &AudioStream::cache_params(unsigned block) {
 	local_params.metaparams.button_exp_connected = param_blocks[block].metaparams.button_exp_connected;
 	local_params.metaparams.ext_buttons_high_events = param_blocks[block].metaparams.ext_buttons_high_events;
 	local_params.metaparams.ext_buttons_low_events = param_blocks[block].metaparams.ext_buttons_low_events;
+	local_params.metaparams.meta_buttons[0].set_state_no_events(
+		param_blocks[block].metaparams.meta_buttons[0].is_pressed());
 
 	for (auto i = 0u; i < block_size_; i++)
 		local_params.params[i] = param_blocks[block].params[i]; // 45us/49us alt

--- a/firmware/src/gui/notify/display.hh
+++ b/firmware/src/gui/notify/display.hh
@@ -16,13 +16,14 @@ namespace MetaModule
 
 struct DisplayNotification {
 
-	static void show(Notification const &msg) {
+	static void show(Notification const &msg, bool animate) {
 		lv_label_set_text(ui_MessageLabel, msg.message.c_str());
 
-		if (msg.duration_ms > 0) {
-			slide_down_up_animation(ui_MessagePanel, msg.duration_ms);
+		auto duration = (msg.duration_ms > 0) ? msg.duration_ms : 5000;
+		if (animate) {
+			slide_down_up_animation(ui_MessagePanel, duration);
 		} else {
-			slide_down_up_animation(ui_MessagePanel, 10000);
+			disappear_animation(ui_MessagePanel, duration);
 		}
 	}
 
@@ -35,25 +36,38 @@ struct DisplayNotification {
 	}
 
 	static void slide_down_up_animation(lv_obj_t *obj, int hold_time) {
-		ui_anim_user_data_t *user_data = (ui_anim_user_data_t *)lv_mem_alloc(sizeof(ui_anim_user_data_t));
-		user_data->target = obj;
-		user_data->val = -1;
+		lv_obj_refr_size(obj);
+		lv_obj_refr_pos(obj);
+		int offscreen_y = lv_obj_get_height(obj) * 2 + 10;
+
+		lv_anim_t anim;
+		lv_anim_init(&anim);
+		lv_anim_set_time(&anim, 400);
+		lv_anim_set_exec_cb(&anim, (lv_anim_exec_xcb_t)lv_obj_set_y);
+		lv_anim_set_var(&anim, obj);
+		lv_anim_set_values(&anim, -1 * offscreen_y, 0);
+		lv_anim_set_path_cb(&anim, lv_anim_path_ease_in_out);
+		lv_anim_set_delay(&anim, 0);
+		lv_anim_set_playback_time(&anim, 400);
+		lv_anim_set_playback_delay(&anim, hold_time + 400);
+		lv_anim_set_early_apply(&anim, false);
+		lv_anim_start(&anim);
+	}
+
+	static void disappear_animation(lv_obj_t *obj, int hold_time) {
 		lv_obj_refr_size(obj);
 		int startpos = lv_obj_get_height(obj) * 2 + 10;
 
 		lv_anim_t anim;
 		lv_anim_init(&anim);
-		lv_anim_set_time(&anim, 400);
-		lv_anim_set_user_data(&anim, user_data);
-		lv_anim_set_custom_exec_cb(&anim, _ui_anim_callback_set_y);
+		lv_anim_set_time(&anim, 1);
+		lv_anim_set_exec_cb(&anim, (lv_anim_exec_xcb_t)lv_obj_set_y);
+		lv_anim_set_var(&anim, obj);
 		lv_anim_set_values(&anim, -1 * startpos, 0);
-		lv_anim_set_path_cb(&anim, lv_anim_path_ease_in_out);
+		lv_anim_set_path_cb(&anim, lv_anim_path_step);
 		lv_anim_set_delay(&anim, 0);
-		lv_anim_set_deleted_cb(&anim, _ui_anim_callback_free_user_data);
-		lv_anim_set_playback_time(&anim, 400);
-		lv_anim_set_playback_delay(&anim, hold_time + 400);
-		lv_anim_set_repeat_count(&anim, 0);
-		lv_anim_set_repeat_delay(&anim, 0);
+		lv_anim_set_playback_time(&anim, 1);
+		lv_anim_set_playback_delay(&anim, hold_time);
 		lv_anim_set_early_apply(&anim, false);
 		lv_anim_start(&anim);
 	}

--- a/firmware/src/gui/pages/main_menu.hh
+++ b/firmware/src/gui/pages/main_menu.hh
@@ -138,11 +138,10 @@ private:
 			page->load_page(PageId::ModuleList,
 							{.patch_loc_hash = page->patches.get_view_patch_loc_hash(), .view_knobset_id = 0});
 		} else {
-			page->notify_queue.put(
-				{"Too many unsaved patches open! Save or close them to open a new patch, or change this in "
-				 "Settings > Prefs.",
-				 Notification::Priority::Info,
-				 4000});
+			page->notify_queue.put({"Too many unsaved patches open! Save or close some. Tip: set your preference in "
+									"Settings > Prefs.",
+									Notification::Priority::Error,
+									4000});
 		}
 	}
 

--- a/firmware/src/gui/pages/make_cable.hh
+++ b/firmware/src/gui/pages/make_cable.hh
@@ -72,7 +72,7 @@ inline void make_cable(GuiState::CableBeginning &new_cable,
 		if (make_panel_mapping) {
 			jackmapping.type = ElementType::Input;
 			patch_mod_queue.put(jackmapping);
-			notify_queue.put({"Added cable from panel input", Notification::Priority::Info, 1000});
+			notify_queue.put({"Added cable from panel input", Notification::Priority::Status, 1000});
 		}
 	}
 
@@ -92,7 +92,9 @@ inline void make_cable(GuiState::CableBeginning &new_cable,
 					newcable.out = cable->out;
 
 				} else {
-					notify_queue.put({"Error: cannot connect two inputs", Notification::Priority::Error, 2000});
+					notify_queue.put({"Error: cannot connect two inputs with no output connected",
+									  Notification::Priority::Error,
+									  2000});
 				}
 			}
 		} else {
@@ -108,7 +110,7 @@ inline void make_cable(GuiState::CableBeginning &new_cable,
 inline void abort_cable(GuiState &gui_state, NotificationQueue &notify_queue) {
 	if (gui_state.new_cable) {
 		gui_state.new_cable = std::nullopt;
-		notify_queue.put(Notification{"Cancelled making a cable", Notification::Priority::Info, 1000});
+		notify_queue.put(Notification{"Cancelled making a cable", Notification::Priority::Status, 1000});
 	}
 }
 

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -277,7 +277,7 @@ public:
 				if ((info.settings.notifications.amount == All || msg->priority == Error) ||
 					(info.settings.notifications.amount == Fewer && msg->priority == Info))
 				{
-					DisplayNotification::show(*msg);
+					DisplayNotification::show(*msg, info.settings.notifications.animation);
 				}
 
 				pr_info("Notify: %s (%u)\n", msg->message.c_str(), msg->duration_ms);

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -207,7 +207,9 @@ public:
 						auto firstbit = std::countr_zero(events) % 8;
 						if (firstbit < num_knobsets) {
 							next_knobset = firstbit;
-							metaparams.ignore_metabutton_release = true;
+							if (info.settings.button_exp_knobset.require_back) {
+								metaparams.ignore_metabutton_release = true;
+							}
 						}
 					}
 				}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -158,11 +158,12 @@ public:
 		// Patch must be valid, playing, and have at least one knobset
 		if (auto patch = info.open_patch_manager.get_playing_patch(); patch != nullptr) {
 			if (int num_knobsets = patch->knob_sets.size(); num_knobsets > 0) {
+				auto &metaparams = info.metaparams;
 
 				std::optional<int> next_knobset = std::nullopt;
 				int cur_knobset = info.page_list.get_active_knobset();
 
-				// Change knobset via MIDI CC
+				// Detecrt MIDI CC
 				if (info.settings.midi.knobset_control == MidiSettings::KnobsetControl::Enabled) {
 					auto &cc = info.params.midi_ccs[info.settings.midi.knobset_cc & 127];
 
@@ -175,23 +176,40 @@ public:
 					}
 				}
 
-				// Change knobset via Back Button + Encoder
-				if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
+				// Detect Back Button + Encoder
+				if (auto knobset_change = metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
 					next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
 				}
 
-				// TODO: change via Back button + Button expander
-				if (info.metaparams.meta_buttons[0].is_pressed() && info.metaparams.button_exp_connected > 0) {
-					auto mask = info.metaparams.ext_buttons_high_events;
-					int i = 0;
-					while (mask) {
-						if (mask & 0b1) {
-							if (i < num_knobsets)
-								next_knobset = i;
-							// TODO: Disable Back button release event
+				// Detect Back button + Button expander
+				// Filter out disconnected button expanders and ones for which this feature is not enabled
+				if (auto exp = (info.settings.button_exp_knobset.button_expander & metaparams.button_exp_connected)) {
+					bool back_pressed = true;
+
+					if (info.settings.button_exp_knobset.require_back) {
+						back_pressed = metaparams.meta_buttons[0].is_pressed();
+
+						if (metaparams.meta_buttons[0].is_just_pressed()) {
+							// Clear all events when pressing Back
+							metaparams.ext_buttons_high_events = 0;
 						}
-						mask >>= 1;
-						i++;
+					}
+
+					if (back_pressed && metaparams.ext_buttons_high_events) {
+						// turn bit mask 0bwxyz into 0xWWXXYYZZ
+						auto mask = ((exp & 0b0001) ? 0x000000FFu : 0) | ((exp & 0b0010) ? 0x0000FF00u : 0) |
+									((exp & 0b0100) ? 0x00FF0000u : 0) | ((exp & 0b1000) ? 0xFF000000u : 0);
+
+						// Get and clear events on the enabled expander(s)
+						auto events = metaparams.ext_buttons_high_events;
+						metaparams.ext_buttons_high_events &= ~mask;
+
+						auto firstbit = std::countr_zero(events);
+						pr_dbg("Back + exp %d (max %d)\n", firstbit, num_knobsets);
+						if (firstbit < num_knobsets) {
+							next_knobset = firstbit;
+							metaparams.ignore_metabutton_release = true;
+						}
 					}
 				}
 

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -181,7 +181,19 @@ public:
 				}
 
 				// TODO: change via Back button + Button expander
-				{}
+				if (info.metaparams.meta_buttons[0].is_pressed() && info.metaparams.button_exp_connected > 0) {
+					auto mask = info.metaparams.ext_buttons_high_events;
+					unsigned i = 0;
+					while (mask) {
+						if (mask & 0b1) {
+							if (i < next_knobset)
+								next_knobset = i;
+							// TODO: Disable Back button release event
+						}
+						mask >>= 1;
+						i++;
+					}
+				}
 
 				// Perform the knob set change:
 				if (next_knobset.has_value()) {

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -183,10 +183,10 @@ public:
 				// TODO: change via Back button + Button expander
 				if (info.metaparams.meta_buttons[0].is_pressed() && info.metaparams.button_exp_connected > 0) {
 					auto mask = info.metaparams.ext_buttons_high_events;
-					unsigned i = 0;
+					int i = 0;
 					while (mask) {
 						if (mask & 0b1) {
-							if (i < next_knobset)
+							if (i < num_knobsets)
 								next_knobset = i;
 							// TODO: Disable Back button release event
 						}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -195,17 +195,16 @@ public:
 						}
 					}
 
-					if (back_pressed && metaparams.ext_buttons_high_events) {
-						// turn bit mask 0bwxyz into 0xWWXXYYZZ
-						auto mask = ((exp & 0b0001) ? 0x000000FFu : 0) | ((exp & 0b0010) ? 0x0000FF00u : 0) |
-									((exp & 0b0100) ? 0x00FF0000u : 0) | ((exp & 0b1000) ? 0xFF000000u : 0);
+					// turn bit mask 0bwxyz into 0xWWXXYYZZ
+					auto mask = ((exp & 0b0001) ? 0x000000FFu : 0) | ((exp & 0b0010) ? 0x0000FF00u : 0) |
+								((exp & 0b0100) ? 0x00FF0000u : 0) | ((exp & 0b1000) ? 0xFF000000u : 0);
 
+					if (back_pressed && (metaparams.ext_buttons_high_events & mask)) {
 						// Get and clear events on the enabled expander(s)
-						auto events = metaparams.ext_buttons_high_events;
+						auto events = metaparams.ext_buttons_high_events & mask;
 						metaparams.ext_buttons_high_events &= ~mask;
 
-						auto firstbit = std::countr_zero(events);
-						pr_dbg("Back + exp %d (max %d)\n", firstbit, num_knobsets);
+						auto firstbit = std::countr_zero(events) % 8;
 						if (firstbit < num_knobsets) {
 							next_knobset = firstbit;
 							metaparams.ignore_metabutton_release = true;

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -175,11 +175,15 @@ public:
 					}
 				}
 
-				// Change knobset via Button+Encoder
+				// Change knobset via Back Button + Encoder
 				if (auto knobset_change = info.metaparams.rotary_with_metabutton.use_motion(); knobset_change != 0) {
 					next_knobset = MathTools::wrap<int>(knobset_change + cur_knobset, 0, num_knobsets - 1);
 				}
 
+				// TODO: change via Back button + Button expander
+				{}
+
+				// Perform the knob set change:
 				if (next_knobset.has_value()) {
 					info.patch_mod_queue.put(ChangeKnobSet{.knobset_num = (unsigned)*next_knobset});
 					info.page_list.set_active_knobset(*next_knobset);

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -269,8 +269,18 @@ public:
 		if (lv_obj_get_y(ui_MessagePanel) < -30) {
 			if (auto msg = info.notify_queue.get()) {
 				screensaver.wake();
+				using enum NotificationSettings::Amount;
+				using enum Notification::Priority;
+				// All -> Error + Info + Status
+				// Fewer -> Error + Info
+				// Critical -> Error
+				if ((info.settings.notifications.amount == All || msg->priority == Error) ||
+					(info.settings.notifications.amount == Fewer && msg->priority == Info))
+				{
+					DisplayNotification::show(*msg);
+				}
+
 				pr_info("Notify: %s (%u)\n", msg->message.c_str(), msg->duration_ms);
-				DisplayNotification::show(*msg);
 			}
 		}
 

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -5,6 +5,7 @@
 #include "gui/pages/system_menu_tab_base.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/slsexport/prefs_section_audio.hh"
+#include "gui/slsexport/prefs_section_button_exp_knobset.hh"
 #include "gui/slsexport/prefs_section_catchup.hh"
 #include "gui/slsexport/prefs_section_fs.hh"
 #include "gui/slsexport/prefs_section_midi.hh"
@@ -29,6 +30,7 @@ struct PrefsTab : SystemMenuTab {
 		, fs{settings.filesystem}
 		, midi{settings.midi}
 		, missing_plugins{settings.missing_plugins}
+		, button_exp_knobset{settings.button_exp_knobset}
 		, settings{settings} {
 
 		audio_section.create(ui_SystemMenuPrefsTab);
@@ -37,6 +39,7 @@ struct PrefsTab : SystemMenuTab {
 		fs_section.create(ui_SystemMenuPrefsTab);
 		midi_section.create(ui_SystemMenuPrefsTab);
 		missingplugins_section.create(ui_SystemMenuPrefsTab);
+		buttonexpknobset_section.create(ui_SystemMenuPrefsTab);
 
 		auto btns = create_save_revert_buttons(ui_SystemMenuPrefsTab);
 		save_button = lv_obj_get_child(btns, 1);
@@ -67,6 +70,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(audio_section.sr_override_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(audio_section.bs_override_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(missingplugins_section.dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.expander_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.require_back_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 
 		lv_obj_add_event_cb(audio_section.blocksize_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.overrun_retries, focus_cb, LV_EVENT_FOCUSED, this);
@@ -84,6 +89,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(audio_section.sr_override_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.bs_override_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(missingplugins_section.dropdown, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.expander_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(buttonexpknobset_section.require_back_check, focus_cb, LV_EVENT_FOCUSED, this);
 
 		std::string opts;
 		for (auto item : AudioSettings::ValidBlockSizes) {
@@ -226,6 +233,11 @@ private:
 																									 2;
 			lv_dropdown_set_selected(missingplugins_section.dropdown, idx);
 		}
+
+		// Button expander knob set
+		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, button_exp_knobset.button_expander);
+		lv_check(buttonexpknobset_section.require_back_check, button_exp_knobset.require_back);
+		update_require_back_enabled(button_exp_knobset.button_expander != 0);
 
 		gui_state.do_write_settings = false;
 
@@ -371,6 +383,20 @@ private:
 		return MissingPluginSettings::Autoload::Ask;
 	}
 
+	uint32_t read_button_exp_knobset_dropdown() {
+		return lv_dropdown_get_selected(buttonexpknobset_section.expander_dropdown);
+	}
+
+	bool read_require_back_check() {
+		return lv_obj_has_state(buttonexpknobset_section.require_back_check, LV_STATE_CHECKED);
+	}
+
+	void update_require_back_enabled(bool expander_enabled) {
+		lv_enable(buttonexpknobset_section.require_back_check, expander_enabled);
+		auto opa = expander_enabled ? LV_OPA_100 : LV_OPA_50;
+		lv_obj_set_style_opa(buttonexpknobset_section.require_back_cont, opa, LV_PART_MAIN);
+	}
+
 	// Update the settings structure from the dropdown and checkbox selections
 	// This is called when the user clicks "Apply" or exits the prefs page
 	void update_settings_from_dropdown() {
@@ -484,6 +510,15 @@ private:
 			gui_state.do_write_settings = true;
 		}
 
+		// Button expander knob set
+		auto bexp = read_button_exp_knobset_dropdown();
+		auto bexp_back = read_require_back_check();
+		if (button_exp_knobset.button_expander != bexp || button_exp_knobset.require_back != bexp_back) {
+			button_exp_knobset.button_expander = bexp;
+			button_exp_knobset.require_back = bexp_back;
+			gui_state.do_write_settings = true;
+		}
+
 		lv_disable(save_button);
 		lv_disable(revert_button);
 	}
@@ -544,6 +579,12 @@ private:
 			lv_group_set_editing(group, false);
 			return true;
 
+		} else if (lv_dropdown_is_open(buttonexpknobset_section.expander_dropdown)) {
+			lv_dropdown_close(buttonexpknobset_section.expander_dropdown);
+			lv_group_focus_obj(buttonexpknobset_section.expander_dropdown);
+			lv_group_set_editing(group, false);
+			return true;
+
 		} else {
 			update_settings_from_dropdown();
 			return false;
@@ -593,9 +634,12 @@ private:
 		auto apply_bs = read_patch_suggest_blocksize_check();
 		auto load_initial_patch = lv_obj_has_state(fs_section.startup_patch_check, LV_STATE_CHECKED);
 		auto mp_mode = read_missing_plugins_dropdown();
+		auto bexp = read_button_exp_knobset_dropdown();
+		auto bexp_back = read_require_back_check();
 
 		lv_show(catchup_section.allowjump_cont, catchupmode == CatchupParam::Mode::ResumeOnEqual);
 		update_knobset_control_items(knobset_control == MidiSettings::KnobsetControl::Enabled);
+		update_require_back_enabled(bexp != 0);
 
 		if (block_size == audio_settings.block_size && sample_rate == audio_settings.sample_rate &&
 			overrun_retries == audio_settings.max_overrun_retries && timeout == screensaver.timeout_ms &&
@@ -606,7 +650,9 @@ private:
 			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
 			mp_mode == missing_plugins.autoload &&
 			apply_sr == settings.patch_suggested_audio.apply_samplerate &&
-			apply_bs == settings.patch_suggested_audio.apply_blocksize)
+			apply_bs == settings.patch_suggested_audio.apply_blocksize &&
+			bexp == button_exp_knobset.button_expander &&
+			bexp_back == button_exp_knobset.require_back)
 		{
 			lv_disable(save_button);
 			lv_disable(revert_button);
@@ -625,7 +671,10 @@ private:
 		auto target = event->target;
 
 		// scroll to bottom if we select last items
-		if (target == page->missingplugins_section.dropdown) {
+		if (target == page->buttonexpknobset_section.expander_dropdown ||
+			target == page->buttonexpknobset_section.require_back_check ||
+			target == page->missingplugins_section.dropdown)
+		{
 			lv_obj_scroll_to_view_recursive(page->save_button, LV_ANIM_ON);
 
 			// scroll to top if we select first items
@@ -644,6 +693,7 @@ private:
 	FilesystemSettings &fs;
 	MidiSettings &midi;
 	MissingPluginSettings &missing_plugins;
+	ButtonExpKnobSetSettings &button_exp_knobset;
 	UserSettings &settings;
 
 	lv_group_t *group = nullptr;
@@ -654,6 +704,7 @@ private:
 	PrefsSectionFilesystem fs_section;
 	PrefsSectionMidi midi_section;
 	PrefsSectionMissingPlugins missingplugins_section;
+	PrefsSectionButtonExpKnobSet buttonexpknobset_section;
 
 	lv_obj_t *save_button;
 	lv_obj_t *revert_button;

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -38,8 +38,8 @@ struct PrefsTab : SystemMenuTab {
 		catchup_section.create(ui_SystemMenuPrefsTab);
 		fs_section.create(ui_SystemMenuPrefsTab);
 		midi_section.create(ui_SystemMenuPrefsTab);
-		missingplugins_section.create(ui_SystemMenuPrefsTab);
 		buttonexpknobset_section.create(ui_SystemMenuPrefsTab);
+		missingplugins_section.create(ui_SystemMenuPrefsTab);
 
 		auto btns = create_save_revert_buttons(ui_SystemMenuPrefsTab);
 		save_button = lv_obj_get_child(btns, 1);
@@ -131,6 +131,7 @@ struct PrefsTab : SystemMenuTab {
 
 		set_options(ScreensaverSettings::ValidOptions, catchup_section.mode_dropdown);
 		set_options(CatchupSettings::ValidOptions, catchup_section.mode_dropdown);
+		set_options(ButtonExpKnobSetSettings::ValidOptions, buttonexpknobset_section.expander_dropdown);
 	}
 
 	void prepare_focus(lv_group_t *group) override {
@@ -235,7 +236,9 @@ private:
 		}
 
 		// Button expander knob set
-		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, button_exp_knobset.button_expander);
+		auto bexp_item = get_index(ButtonExpKnobSetSettings::ValidOptions,
+								   [this](auto t) { return t.value == button_exp_knobset.button_expander; });
+		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, bexp_item >= 0 ? bexp_item : 0);
 		lv_check(buttonexpknobset_section.require_back_check, button_exp_knobset.require_back);
 		update_require_back_enabled(button_exp_knobset.button_expander != 0);
 
@@ -353,9 +356,9 @@ private:
 	}
 
 	auto read_knobset_control_check() {
-		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED)
-				 ? MidiSettings::KnobsetControl::Enabled
-				 : MidiSettings::KnobsetControl::Disabled;
+		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED) ?
+				   MidiSettings::KnobsetControl::Enabled :
+				   MidiSettings::KnobsetControl::Disabled;
 	}
 
 	void update_knobset_control_items(bool enabled) {
@@ -384,7 +387,11 @@ private:
 	}
 
 	uint32_t read_button_exp_knobset_dropdown() {
-		return lv_dropdown_get_selected(buttonexpknobset_section.expander_dropdown);
+		auto item = lv_dropdown_get_selected(buttonexpknobset_section.expander_dropdown);
+		if (item >= 0 && item < ButtonExpKnobSetSettings::ValidOptions.size())
+			return ButtonExpKnobSetSettings::ValidOptions[item].value;
+		else
+			return ButtonExpKnobSetSettings::DefaultButtonExpander;
 	}
 
 	bool read_require_back_check() {
@@ -648,10 +655,8 @@ private:
 			load_initial_patch == settings.load_initial_patch && fs_max_patches == fs.max_open_patches &&
 			midi_feedback == midi.midi_feedback && knobset_control == midi.knobset_control &&
 			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
-			mp_mode == missing_plugins.autoload &&
-			apply_sr == settings.patch_suggested_audio.apply_samplerate &&
-			apply_bs == settings.patch_suggested_audio.apply_blocksize &&
-			bexp == button_exp_knobset.button_expander &&
+			mp_mode == missing_plugins.autoload && apply_sr == settings.patch_suggested_audio.apply_samplerate &&
+			apply_bs == settings.patch_suggested_audio.apply_blocksize && bexp == button_exp_knobset.button_expander &&
 			bexp_back == button_exp_knobset.require_back)
 		{
 			lv_disable(save_button);
@@ -671,10 +676,7 @@ private:
 		auto target = event->target;
 
 		// scroll to bottom if we select last items
-		if (target == page->buttonexpknobset_section.expander_dropdown ||
-			target == page->buttonexpknobset_section.require_back_check ||
-			target == page->missingplugins_section.dropdown)
-		{
+		if (target == page->missingplugins_section.dropdown) {
 			lv_obj_scroll_to_view_recursive(page->save_button, LV_ANIM_ON);
 
 			// scroll to top if we select first items

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -10,6 +10,7 @@
 #include "gui/slsexport/prefs_section_fs.hh"
 #include "gui/slsexport/prefs_section_midi.hh"
 #include "gui/slsexport/prefs_section_missing_plugins.hh"
+#include "gui/slsexport/prefs_section_notifications.hh"
 #include "gui/slsexport/prefs_section_screensaver.hh"
 #include "gui/slsexport/ui_local.h"
 #include "gui/styles.hh"
@@ -31,6 +32,7 @@ struct PrefsTab : SystemMenuTab {
 		, midi{settings.midi}
 		, missing_plugins{settings.missing_plugins}
 		, button_exp_knobset{settings.button_exp_knobset}
+		, notifications{settings.notifications}
 		, settings{settings} {
 
 		audio_section.create(ui_SystemMenuPrefsTab);
@@ -40,6 +42,7 @@ struct PrefsTab : SystemMenuTab {
 		midi_section.create(ui_SystemMenuPrefsTab);
 		buttonexpknobset_section.create(ui_SystemMenuPrefsTab);
 		missingplugins_section.create(ui_SystemMenuPrefsTab);
+		notifications_section.create(ui_SystemMenuPrefsTab);
 
 		auto btns = create_save_revert_buttons(ui_SystemMenuPrefsTab);
 		save_button = lv_obj_get_child(btns, 1);
@@ -72,6 +75,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(missingplugins_section.dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(buttonexpknobset_section.expander_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(buttonexpknobset_section.require_back_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(notifications_section.amount_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(notifications_section.animation_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 
 		lv_obj_add_event_cb(audio_section.blocksize_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(audio_section.overrun_retries, focus_cb, LV_EVENT_FOCUSED, this);
@@ -91,6 +96,8 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(missingplugins_section.dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(buttonexpknobset_section.expander_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(buttonexpknobset_section.require_back_check, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(notifications_section.amount_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(notifications_section.animation_check, focus_cb, LV_EVENT_FOCUSED, this);
 
 		std::string opts;
 		for (auto item : AudioSettings::ValidBlockSizes) {
@@ -132,6 +139,7 @@ struct PrefsTab : SystemMenuTab {
 		set_options(ScreensaverSettings::ValidOptions, catchup_section.mode_dropdown);
 		set_options(CatchupSettings::ValidOptions, catchup_section.mode_dropdown);
 		set_options(ButtonExpKnobSetSettings::ValidOptions, buttonexpknobset_section.expander_dropdown);
+		set_options(NotificationSettings::ValidAmountOptions, notifications_section.amount_dropdown);
 	}
 
 	void prepare_focus(lv_group_t *group) override {
@@ -241,6 +249,12 @@ private:
 		lv_dropdown_set_selected(buttonexpknobset_section.expander_dropdown, bexp_item >= 0 ? bexp_item : 0);
 		lv_check(buttonexpknobset_section.require_back_check, button_exp_knobset.require_back);
 		update_require_back_enabled(button_exp_knobset.button_expander != 0);
+
+		// Notifications
+		auto notif_item = get_index(NotificationSettings::ValidAmountOptions,
+									[this](auto t) { return t.value == notifications.amount; });
+		lv_dropdown_set_selected(notifications_section.amount_dropdown, notif_item >= 0 ? notif_item : 0);
+		lv_check(notifications_section.animation_check, notifications.animation);
 
 		gui_state.do_write_settings = false;
 
@@ -398,6 +412,18 @@ private:
 		return lv_obj_has_state(buttonexpknobset_section.require_back_check, LV_STATE_CHECKED);
 	}
 
+	NotificationSettings::Amount read_notification_amount_dropdown() {
+		auto item = lv_dropdown_get_selected(notifications_section.amount_dropdown);
+		if (item >= 0 && item < NotificationSettings::ValidAmountOptions.size())
+			return NotificationSettings::ValidAmountOptions[item].value;
+		else
+			return NotificationSettings::DefaultAmount;
+	}
+
+	bool read_notification_animation_check() {
+		return lv_obj_has_state(notifications_section.animation_check, LV_STATE_CHECKED);
+	}
+
 	void update_require_back_enabled(bool expander_enabled) {
 		lv_enable(buttonexpknobset_section.require_back_check, expander_enabled);
 		auto opa = expander_enabled ? LV_OPA_100 : LV_OPA_50;
@@ -526,6 +552,15 @@ private:
 			gui_state.do_write_settings = true;
 		}
 
+		// Notifications
+		auto notif_amount = read_notification_amount_dropdown();
+		auto notif_anim = read_notification_animation_check();
+		if (notifications.amount != notif_amount || notifications.animation != notif_anim) {
+			notifications.amount = notif_amount;
+			notifications.animation = notif_anim;
+			gui_state.do_write_settings = true;
+		}
+
 		lv_disable(save_button);
 		lv_disable(revert_button);
 	}
@@ -592,6 +627,12 @@ private:
 			lv_group_set_editing(group, false);
 			return true;
 
+		} else if (lv_dropdown_is_open(notifications_section.amount_dropdown)) {
+			lv_dropdown_close(notifications_section.amount_dropdown);
+			lv_group_focus_obj(notifications_section.amount_dropdown);
+			lv_group_set_editing(group, false);
+			return true;
+
 		} else {
 			update_settings_from_dropdown();
 			return false;
@@ -643,6 +684,8 @@ private:
 		auto mp_mode = read_missing_plugins_dropdown();
 		auto bexp = read_button_exp_knobset_dropdown();
 		auto bexp_back = read_require_back_check();
+		auto notif_amount = read_notification_amount_dropdown();
+		auto notif_anim = read_notification_animation_check();
 
 		lv_show(catchup_section.allowjump_cont, catchupmode == CatchupParam::Mode::ResumeOnEqual);
 		update_knobset_control_items(knobset_control == MidiSettings::KnobsetControl::Enabled);
@@ -657,7 +700,8 @@ private:
 			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
 			mp_mode == missing_plugins.autoload && apply_sr == settings.patch_suggested_audio.apply_samplerate &&
 			apply_bs == settings.patch_suggested_audio.apply_blocksize && bexp == button_exp_knobset.button_expander &&
-			bexp_back == button_exp_knobset.require_back)
+			bexp_back == button_exp_knobset.require_back && notif_amount == notifications.amount &&
+			notif_anim == notifications.animation)
 		{
 			lv_disable(save_button);
 			lv_disable(revert_button);
@@ -676,7 +720,10 @@ private:
 		auto target = event->target;
 
 		// scroll to bottom if we select last items
-		if (target == page->missingplugins_section.dropdown) {
+		if (target == page->notifications_section.amount_dropdown ||
+			target == page->notifications_section.animation_check ||
+			target == page->missingplugins_section.dropdown)
+		{
 			lv_obj_scroll_to_view_recursive(page->save_button, LV_ANIM_ON);
 
 			// scroll to top if we select first items
@@ -696,6 +743,7 @@ private:
 	MidiSettings &midi;
 	MissingPluginSettings &missing_plugins;
 	ButtonExpKnobSetSettings &button_exp_knobset;
+	NotificationSettings &notifications;
 	UserSettings &settings;
 
 	lv_group_t *group = nullptr;
@@ -707,6 +755,7 @@ private:
 	PrefsSectionMidi midi_section;
 	PrefsSectionMissingPlugins missingplugins_section;
 	PrefsSectionButtonExpKnobSet buttonexpknobset_section;
+	PrefsSectionNotifications notifications_section;
 
 	lv_obj_t *save_button;
 	lv_obj_t *revert_button;

--- a/firmware/src/gui/pages/system_tab.hh
+++ b/firmware/src/gui/pages/system_tab.hh
@@ -252,7 +252,7 @@ private:
 					if (Settings::write_settings(
 							page->storage, page->settings, res == 1 ? Volume::USB : Volume::SDCard))
 						page->notify_queue.put(
-							{"Successfully saved settings.yml file to disk", Notification::Priority::Info, 2000});
+							{"Successfully saved settings.yml file to disk", Notification::Priority::Status, 2000});
 					else
 						page->notify_queue.put(
 							{"Failed to save settings.yml file to disk", Notification::Priority::Error, 2000});
@@ -275,8 +275,9 @@ private:
 					if (Settings::read_settings(page->storage, &tmp, res == 1 ? Volume::USB : Volume::SDCard)) {
 						page->settings = tmp;
 						if (Settings::write_settings(page->storage, tmp, Volume::NorFlash)) {
-							page->notify_queue.put(
-								{"Successfully loaded file and updated settings", Notification::Priority::Info, 2000});
+							page->notify_queue.put({"Successfully loaded file and updated settings",
+													Notification::Priority::Status,
+													2000});
 						} else {
 							page->notify_queue.put(
 								{"Failed to update settings from the file", Notification::Priority::Error, 2000});

--- a/firmware/src/gui/slsexport/CMakeLists.txt
+++ b/firmware/src/gui/slsexport/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
           prefs_section_midi.cc
           prefs_section_missing_plugins.cc
           prefs_section_button_exp_knobset.cc
+          prefs_section_notifications.cc
           filebrowser/ui.c
           filebrowser/screens/ui_FileBrowserPage.c
 )
@@ -25,5 +26,6 @@ set_source_files_properties(
   prefs_section_midi.cc
   prefs_section_missing_plugins.cc
   prefs_section_button_exp_knobset.cc
+  prefs_section_notifications.cc
   PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-enum-enum-conversion;-Wno-deprecated-anon-enum-enum-conversion;"
 )

--- a/firmware/src/gui/slsexport/CMakeLists.txt
+++ b/firmware/src/gui/slsexport/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
           prefs_section_fs.cc
           prefs_section_midi.cc
           prefs_section_missing_plugins.cc
+          prefs_section_button_exp_knobset.cc
           filebrowser/ui.c
           filebrowser/screens/ui_FileBrowserPage.c
 )
@@ -23,5 +24,6 @@ set_source_files_properties(
   prefs_section_fs.cc
   prefs_section_midi.cc
   prefs_section_missing_plugins.cc
+  prefs_section_button_exp_knobset.cc
   PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-enum-enum-conversion;-Wno-deprecated-anon-enum-enum-conversion;"
 )

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -13,7 +13,7 @@ void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 	expander_dropdown = lv_obj_get_child(cont, 1);
 	lv_obj_set_width(expander_dropdown, 80);
 
-	require_back_cont = create_prefs_labeled_check(parent, "Back + Button");
+	require_back_cont = create_prefs_labeled_check(parent, "Back + Button:");
 	create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
 
 	require_back_check = lv_obj_get_child(require_back_cont, 1);

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -14,7 +14,7 @@ void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 	lv_obj_set_width(expander_dropdown, 80);
 
 	require_back_cont = create_prefs_labeled_check(parent, "Back + Button");
-	require_back_note = create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
+	create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
 
 	require_back_check = lv_obj_get_child(require_back_cont, 1);
 }

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -7,11 +7,11 @@ namespace MetaModule
 
 void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 
-	create_prefs_section_title(parent, "BUTTON EXP. KNOB SET SELECT");
+	create_prefs_section_title(parent, "METABUTTON KNOB SET SELECT");
 
-	auto cont = create_prefs_labeled_dropdown(parent, "Button Expander #:", "Disabled\n1\n2\n3\n4");
+	auto cont = create_prefs_labeled_dropdown(parent, "MetaButton #:");
 	expander_dropdown = lv_obj_get_child(cont, 1);
-	lv_obj_set_width(expander_dropdown, 110);
+	lv_obj_set_width(expander_dropdown, 80);
 
 	require_back_cont = create_prefs_labeled_check(parent, "With Back button\npressed:");
 	require_back_check = lv_obj_get_child(require_back_cont, 1);

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -13,7 +13,9 @@ void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
 	expander_dropdown = lv_obj_get_child(cont, 1);
 	lv_obj_set_width(expander_dropdown, 80);
 
-	require_back_cont = create_prefs_labeled_check(parent, "With Back button\npressed:");
+	require_back_cont = create_prefs_labeled_check(parent, "Back + Button");
+	require_back_note = create_prefs_note(require_back_cont, "Hold Back and press a\nButton to change Knob Sets");
+
 	require_back_check = lv_obj_get_child(require_back_cont, 1);
 }
 

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.cc
@@ -1,0 +1,20 @@
+#include "prefs_section_button_exp_knobset.hh"
+#include "lvgl.h"
+#include "ui_local.h"
+
+namespace MetaModule
+{
+
+void PrefsSectionButtonExpKnobSet::create(lv_obj_t *parent) {
+
+	create_prefs_section_title(parent, "BUTTON EXP. KNOB SET SELECT");
+
+	auto cont = create_prefs_labeled_dropdown(parent, "Button Expander #:", "Disabled\n1\n2\n3\n4");
+	expander_dropdown = lv_obj_get_child(cont, 1);
+	lv_obj_set_width(expander_dropdown, 110);
+
+	require_back_cont = create_prefs_labeled_check(parent, "With Back button\npressed:");
+	require_back_check = lv_obj_get_child(require_back_cont, 1);
+}
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.hh
+++ b/firmware/src/gui/slsexport/prefs_section_button_exp_knobset.hh
@@ -1,0 +1,14 @@
+#include "lvgl.h"
+
+namespace MetaModule
+{
+
+struct PrefsSectionButtonExpKnobSet {
+	lv_obj_t *expander_dropdown;
+	lv_obj_t *require_back_cont;
+	lv_obj_t *require_back_check;
+
+	void create(lv_obj_t *parent);
+};
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_fs.cc
+++ b/firmware/src/gui/slsexport/prefs_section_fs.cc
@@ -7,7 +7,7 @@ namespace MetaModule
 void PrefsSectionFilesystem::create(lv_obj_t *parent) {
 
 	// Title
-	create_prefs_section_title(parent, "Patch Files");
+	create_prefs_section_title(parent, "PATCH FILES");
 
 	// Startup Patch
 	auto startup_cont = create_prefs_labeled_check(parent, "Startup Patch:");

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -15,7 +15,7 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	create_prefs_note(midi_cont, "Sends MIDI to controller\nwhen MIDI-mapped params\nchange");
 
 	// Knob Set Control
-	create_prefs_section_title(parent, "MIDI Knob Set Select");
+	create_prefs_section_title(parent, "MIDI KNOB SET SELECT");
 
 	auto knobset_cont = create_prefs_labeled_check(parent, "Enable:");
 	knobset_control_check = lv_obj_get_child(knobset_cont, 1);

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -20,7 +20,7 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	auto knobset_cont = create_prefs_labeled_check(parent, "Enable:");
 	knobset_control_check = lv_obj_get_child(knobset_cont, 1);
 
-	create_prefs_note(knobset_cont, "MIDI CC values 0-7\nselect Knob Set");
+	create_prefs_note(knobset_cont, "MIDI CC values 0-7       \nselect Knob Set       ");
 
 	// MIDI CC number (0-127)
 	std::string cc_opts;

--- a/firmware/src/gui/slsexport/prefs_section_notifications.cc
+++ b/firmware/src/gui/slsexport/prefs_section_notifications.cc
@@ -1,0 +1,19 @@
+#include "prefs_section_notifications.hh"
+#include "ui_local.h"
+
+namespace MetaModule
+{
+
+void PrefsSectionNotifications::create(lv_obj_t *parent) {
+
+	create_prefs_section_title(parent, "NOTIFICATIONS");
+
+	auto amount_cont = create_prefs_labeled_dropdown(parent, "Show:", "All\nFewer\nOnly Critical");
+	amount_dropdown = lv_obj_get_child(amount_cont, 1);
+	lv_obj_set_width(amount_dropdown, 110);
+
+	auto anim_cont = create_prefs_labeled_check(parent, "Animations:");
+	animation_check = lv_obj_get_child(anim_cont, 1);
+}
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_notifications.hh
+++ b/firmware/src/gui/slsexport/prefs_section_notifications.hh
@@ -1,0 +1,13 @@
+#include "lvgl.h"
+
+namespace MetaModule
+{
+
+struct PrefsSectionNotifications {
+	lv_obj_t *amount_dropdown;
+	lv_obj_t *animation_check;
+
+	void create(lv_obj_t *parent);
+};
+
+} // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_screensaver.cc
+++ b/firmware/src/gui/slsexport/prefs_section_screensaver.cc
@@ -14,7 +14,7 @@ void PrefsSectionScreenSaver::create(lv_obj_t *parent) {
 	time_dropdown = lv_obj_get_child(screensaver_cont, 1);
 	lv_obj_set_width(time_dropdown, 90);
 
-	auto ss_knobs_cont = create_prefs_labeled_check(parent, "Wake with knob");
+	auto ss_knobs_cont = create_prefs_labeled_check(parent, "Wake with knob:");
 	knobs_check = lv_obj_get_child(ss_knobs_cont, 1);
 }
 

--- a/firmware/src/gui/ui.hh
+++ b/firmware/src/gui/ui.hh
@@ -189,7 +189,7 @@ private:
 			notify_queue.put({load_status.error_string, Notification::Priority::Error, 1500});
 
 		} else if (load_status.error_string.size()) {
-			notify_queue.put({load_status.error_string, Notification::Priority::Info, 3000});
+			notify_queue.put({load_status.error_string, Notification::Priority::Status, 1500});
 		}
 	}
 

--- a/firmware/src/params/catchup_manager.hh
+++ b/firmware/src/params/catchup_manager.hh
@@ -1,8 +1,5 @@
 #pragma once
-#include "CoreModules/CoreProcessor.hh"
-#include "CoreModules/hub/button_expander_defs.hh"
 #include "catchup_param.hh"
-#include "conf/panel_conf.hh"
 #include "patch-serial/patch/patch.hh"
 #include "toggle_param.hh"
 #include <vector>
@@ -134,6 +131,9 @@ public:
 		for (unsigned i = 0u; auto &knob : active_knob_maps) {
 
 			for (auto &knob_map : knob) {
+				if (knob_map.map.is_button())
+					continue;
+
 				auto module_val = modules[knob_map.map.module_id]->get_param(knob_map.map.param_id);
 				float scaled_phys_val = knob_map.map.get_mapped_val(panel_knobs[i]);
 

--- a/firmware/src/patch_file/change_checker.hh
+++ b/firmware/src/patch_file/change_checker.hh
@@ -53,11 +53,11 @@ struct PatchFileChangeChecker {
 					version_conflict = true;
 					std::string message = "A new version of ";
 					message.append(loc.filename.c_str());
-					message.append(" was just transferred, but you have unsaved changes. Please save, revert, or "
-								   "duplicate the patch");
+					message.append(" was just transferred, but you have unsaved changes. Please duplicate, "
+								   "move/rename, or revert the patch");
 					notify_queue.put({
 						.message = message,
-						.priority = Notification::Priority::Info,
+						.priority = Notification::Priority::Error,
 						.duration_ms = 3000,
 					});
 

--- a/firmware/src/patch_file/reload_patch.cc
+++ b/firmware/src/patch_file/reload_patch.cc
@@ -59,7 +59,7 @@ Result ReloadPatch::reload_patch_file(PatchLocation const &loc, Function<void()>
 	auto max_open_patches = std::max<uint32_t>(fs_settings.max_open_patches, 2u) - 1;
 
 	if (!patches.have_space_to_open_patch(max_open_patches)) {
-		return {false, "Too many unsaved patches open! Save or close them to open a new patch"};
+		return {false, "Too many unsaved patches open! Save or close some."};
 	}
 
 	while (!patch_storage.request_load_patch(loc)) {

--- a/firmware/src/user_settings/button_exp_knobset_settings.hh
+++ b/firmware/src/user_settings/button_exp_knobset_settings.hh
@@ -7,7 +7,7 @@ namespace MetaModule
 {
 
 struct ButtonExpKnobSetSettings {
-	// Bitfield: each expander N (1-4) is represented by (1 << N)
+	// Bitfield: expander #N (1-4) is represented by bit (N-1)
 	static constexpr uint32_t Disabled = 0;
 	static constexpr uint32_t Any = 0b1111;
 	static constexpr uint32_t Exp1 = (1 << 0);

--- a/firmware/src/user_settings/button_exp_knobset_settings.hh
+++ b/firmware/src/user_settings/button_exp_knobset_settings.hh
@@ -1,18 +1,43 @@
 #pragma once
+#include <array>
 #include <cstdint>
+#include <string_view>
 
 namespace MetaModule
 {
 
 struct ButtonExpKnobSetSettings {
-	static constexpr uint32_t DefaultButtonExpander = 0;
-	static constexpr bool DefaultRequireBack = true;
+	// Bitfield: each expander N (1-4) is represented by (1 << N)
+	static constexpr uint32_t Disabled = 0;
+	static constexpr uint32_t Any = 0b1111;
+	static constexpr uint32_t Exp1 = (1 << 0);
+	static constexpr uint32_t Exp2 = (1 << 1);
+	static constexpr uint32_t Exp3 = (1 << 2);
+	static constexpr uint32_t Exp4 = (1 << 3);
 
-	uint32_t button_expander = DefaultButtonExpander; // 0=disabled, 1-4
+	struct Option {
+		uint32_t value;
+		std::string_view label;
+	};
+	static constexpr std::array ValidOptions = {
+		Option{Disabled, "Off"},
+		Option{Any, "Any"},
+		Option{Exp1, "#1"},
+		Option{Exp2, "#2"},
+		Option{Exp3, "#3"},
+		Option{Exp4, "#4"},
+	};
+
+	static constexpr uint32_t DefaultButtonExpander = Disabled;
+	static constexpr bool DefaultRequireBack = true;
+	static constexpr uint32_t ValidMask = Any | Exp1 | Exp2 | Exp3 | Exp4;
+
+	uint32_t button_expander = DefaultButtonExpander;
 	bool require_back = DefaultRequireBack;
 
 	void make_valid() {
-		if (button_expander > 4)
+		// Check that only valid bits are set
+		if (button_expander & ~ValidMask)
 			button_expander = DefaultButtonExpander;
 
 		if (*reinterpret_cast<uint8_t *>(&require_back) != 0)

--- a/firmware/src/user_settings/button_exp_knobset_settings.hh
+++ b/firmware/src/user_settings/button_exp_knobset_settings.hh
@@ -1,0 +1,25 @@
+#pragma once
+#include <cstdint>
+
+namespace MetaModule
+{
+
+struct ButtonExpKnobSetSettings {
+	static constexpr uint32_t DefaultButtonExpander = 0;
+	static constexpr bool DefaultRequireBack = true;
+
+	uint32_t button_expander = DefaultButtonExpander; // 0=disabled, 1-4
+	bool require_back = DefaultRequireBack;
+
+	void make_valid() {
+		if (button_expander > 4)
+			button_expander = DefaultButtonExpander;
+
+		if (*reinterpret_cast<uint8_t *>(&require_back) != 0)
+			require_back = true;
+		else
+			require_back = false;
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/user_settings/notification_settings.hh
+++ b/firmware/src/user_settings/notification_settings.hh
@@ -1,0 +1,38 @@
+#pragma once
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace MetaModule
+{
+
+struct NotificationSettings {
+	enum class Amount : uint8_t { All = 0, Fewer = 1, OnlyCritical = 2 };
+
+	static constexpr auto DefaultAmount = Amount::All;
+
+	struct Option {
+		Amount value;
+		std::string_view label;
+	};
+	static constexpr std::array ValidAmountOptions = {
+		Option{Amount::All, "All"},
+		Option{Amount::Fewer, "Fewer"},
+		Option{Amount::OnlyCritical, "Only Critical"},
+	};
+
+	Amount amount = DefaultAmount;
+	bool animation = true;
+
+	void make_valid() {
+		bool valid = false;
+		for (auto o : ValidAmountOptions) {
+			if (amount == o.value)
+				valid = true;
+		}
+		if (!valid)
+			amount = DefaultAmount;
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/user_settings/settings.hh
+++ b/firmware/src/user_settings/settings.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include "audio_settings.hh"
+#include "button_exp_knobset_settings.hh"
 #include "catchup_settings.hh"
 #include "fs/volumes.hh"
 #include "user_settings/fs_settings.hh"
@@ -30,6 +31,7 @@ struct UserSettings {
 	FilesystemSettings filesystem{};
 	MidiSettings midi{};
 	PatchSuggestedAudioSettings patch_suggested_audio{};
+	ButtonExpKnobSetSettings button_exp_knobset{};
 };
 
 } // namespace MetaModule

--- a/firmware/src/user_settings/settings.hh
+++ b/firmware/src/user_settings/settings.hh
@@ -8,6 +8,7 @@
 #include "user_settings/patch_suggested_audio_settings.hh"
 #include "user_settings/plugin_preload_settings.hh"
 #include "user_settings/missing_plugin_settings.hh"
+#include "user_settings/notification_settings.hh"
 #include "user_settings/screensaver_settings.hh"
 #include "user_settings/view_settings.hh"
 
@@ -32,6 +33,7 @@ struct UserSettings {
 	MidiSettings midi{};
 	PatchSuggestedAudioSettings patch_suggested_audio{};
 	ButtonExpKnobSetSettings button_exp_knobset{};
+	NotificationSettings notifications{};
 };
 
 } // namespace MetaModule

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -172,6 +172,17 @@ static bool read(ryml::ConstNodeRef const &node, PatchSuggestedAudioSettings *se
 	return true;
 }
 
+static bool read(ryml::ConstNodeRef const &node, ButtonExpKnobSetSettings *settings) {
+	if (!node.is_map())
+		return false;
+
+	read_or_default(node, "button_expander", settings, &ButtonExpKnobSetSettings::button_expander);
+	read_or_default(node, "require_back", settings, &ButtonExpKnobSetSettings::require_back);
+	settings->make_valid();
+
+	return true;
+}
+
 static bool read(ryml::ConstNodeRef const &node, MissingPluginSettings *settings) {
 	if (!node.is_map())
 		return false;
@@ -216,6 +227,7 @@ bool parse(std::span<char> yaml, UserSettings *settings) {
 	read_or_default(node, "filesystem", settings, &UserSettings::filesystem);
 	read_or_default(node, "midi", settings, &UserSettings::midi);
 	read_or_default(node, "patch_suggested_audio", settings, &UserSettings::patch_suggested_audio);
+	read_or_default(node, "button_exp_knobset", settings, &UserSettings::button_exp_knobset);
 
 	read_or_default(node, "last_patch_opened", settings, &UserSettings::initial_patch_name);
 	// TODO: cleaner way to parse an enum and reject out of range?

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -183,6 +183,25 @@ static bool read(ryml::ConstNodeRef const &node, ButtonExpKnobSetSettings *setti
 	return true;
 }
 
+static bool read(ryml::ConstNodeRef const &node, NotificationSettings *settings) {
+	if (!node.is_map())
+		return false;
+
+	using enum NotificationSettings::Amount;
+
+	if (node.has_child("amount")) {
+		auto v = node["amount"].val();
+		settings->amount = v == "Fewer" ? Fewer : v == "OnlyCritical" ? OnlyCritical : All;
+	} else {
+		settings->amount = NotificationSettings{}.amount;
+	}
+
+	read_or_default(node, "animation", settings, &NotificationSettings::animation);
+	settings->make_valid();
+
+	return true;
+}
+
 static bool read(ryml::ConstNodeRef const &node, MissingPluginSettings *settings) {
 	if (!node.is_map())
 		return false;
@@ -228,6 +247,7 @@ bool parse(std::span<char> yaml, UserSettings *settings) {
 	read_or_default(node, "midi", settings, &UserSettings::midi);
 	read_or_default(node, "patch_suggested_audio", settings, &UserSettings::patch_suggested_audio);
 	read_or_default(node, "button_exp_knobset", settings, &UserSettings::button_exp_knobset);
+	read_or_default(node, "notifications", settings, &UserSettings::notifications);
 
 	read_or_default(node, "last_patch_opened", settings, &UserSettings::initial_patch_name);
 	// TODO: cleaner way to parse an enum and reject out of range?

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -96,6 +96,13 @@ static void write(ryml::NodeRef *n, PatchSuggestedAudioSettings const &s) {
 	n->append_child() << ryml::key("apply_blocksize") << s.apply_blocksize;
 }
 
+static void write(ryml::NodeRef *n, ButtonExpKnobSetSettings const &s) {
+	*n |= ryml::MAP;
+
+	n->append_child() << ryml::key("button_expander") << s.button_expander;
+	n->append_child() << ryml::key("require_back") << s.require_back;
+}
+
 static void write(ryml::NodeRef *n, MissingPluginSettings const &s) {
 	*n |= ryml::MAP;
 
@@ -131,6 +138,7 @@ uint32_t serialize(UserSettings const &settings, std::span<char> buffer) {
 	data["filesystem"] << settings.filesystem;
 	data["midi"] << settings.midi;
 	data["patch_suggested_audio"] << settings.patch_suggested_audio;
+	data["button_exp_knobset"] << settings.button_exp_knobset;
 
 	auto res = ryml::emit_yaml(tree, c4::substr(buffer.data(), buffer.size()));
 	return res.size();

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -103,6 +103,17 @@ static void write(ryml::NodeRef *n, ButtonExpKnobSetSettings const &s) {
 	n->append_child() << ryml::key("require_back") << s.require_back;
 }
 
+static void write(ryml::NodeRef *n, NotificationSettings const &s) {
+	*n |= ryml::MAP;
+
+	using enum NotificationSettings::Amount;
+	ryml::csubstr amount_string = s.amount == Fewer		   ? "Fewer" :
+								  s.amount == OnlyCritical ? "OnlyCritical" :
+															 "All";
+	n->append_child() << ryml::key("amount") << amount_string;
+	n->append_child() << ryml::key("animation") << s.animation;
+}
+
 static void write(ryml::NodeRef *n, MissingPluginSettings const &s) {
 	*n |= ryml::MAP;
 
@@ -139,6 +150,7 @@ uint32_t serialize(UserSettings const &settings, std::span<char> buffer) {
 	data["midi"] << settings.midi;
 	data["patch_suggested_audio"] << settings.patch_suggested_audio;
 	data["button_exp_knobset"] << settings.button_exp_knobset;
+	data["notifications"] << settings.notifications;
 
 	auto res = ryml::emit_yaml(tree, c4::substr(buffer.data(), buffer.size()));
 	return res.size();

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -74,7 +74,7 @@ TEST_CASE("Parse settings file") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 2
+    button_expander: 8
     require_back: 0
 )";
 	// clang-format on
@@ -140,7 +140,7 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Never);
 
-	CHECK(settings.button_exp_knobset.button_expander == 2);
+	CHECK(settings.button_exp_knobset.button_expander == 8); // (1<<3) = Expander 3
 	CHECK(settings.button_exp_knobset.require_back == false);
 }
 
@@ -341,7 +341,7 @@ TEST_CASE("Serialize settings") {
 	settings.patch_suggested_audio.apply_samplerate = false;
 	settings.patch_suggested_audio.apply_blocksize = true;
 
-	settings.button_exp_knobset.button_expander = 3;
+	settings.button_exp_knobset.button_expander = 8; // (1<<3) = Expander 3
 	settings.button_exp_knobset.require_back = false;
 
 	// clang format-off
@@ -416,7 +416,7 @@ TEST_CASE("Serialize settings") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 3
+    button_expander: 8
     require_back: 0
 )";
 	// clang format-on

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -74,7 +74,7 @@ TEST_CASE("Parse settings file") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 8
+    button_expander: 4
     require_back: 0
 )";
 	// clang-format on
@@ -140,7 +140,7 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Never);
 
-	CHECK(settings.button_exp_knobset.button_expander == 8); // (1<<3) = Expander 3
+	CHECK(settings.button_exp_knobset.button_expander == 4); // (1<<2) = Expander #3
 	CHECK(settings.button_exp_knobset.require_back == false);
 }
 
@@ -341,7 +341,7 @@ TEST_CASE("Serialize settings") {
 	settings.patch_suggested_audio.apply_samplerate = false;
 	settings.patch_suggested_audio.apply_blocksize = true;
 
-	settings.button_exp_knobset.button_expander = 8; // (1<<3) = Expander 3
+	settings.button_exp_knobset.button_expander = 4; // (1<<2) = Expander #3
 	settings.button_exp_knobset.require_back = false;
 
 	// clang format-off
@@ -416,7 +416,7 @@ TEST_CASE("Serialize settings") {
     apply_samplerate: 0
     apply_blocksize: 1
   button_exp_knobset:
-    button_expander: 8
+    button_expander: 4
     require_back: 0
 )";
 	// clang format-on

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -76,6 +76,9 @@ TEST_CASE("Parse settings file") {
   button_exp_knobset:
     button_expander: 4
     require_back: 0
+  notifications:
+    amount: Fewer
+    animation: 0
 )";
 	// clang-format on
 
@@ -142,6 +145,9 @@ TEST_CASE("Parse settings file") {
 
 	CHECK(settings.button_exp_knobset.button_expander == 4); // (1<<2) = Expander #3
 	CHECK(settings.button_exp_knobset.require_back == false);
+
+	CHECK(settings.notifications.amount == MetaModule::NotificationSettings::Amount::Fewer);
+	CHECK(settings.notifications.animation == false);
 }
 
 TEST_CASE("Get default settings if file is missing fields") {
@@ -289,6 +295,9 @@ TEST_CASE("Get default settings if file is missing fields") {
 
 	CHECK(settings.button_exp_knobset.button_expander == 0);
 	CHECK(settings.button_exp_knobset.require_back == true);
+
+	CHECK(settings.notifications.amount == MetaModule::NotificationSettings::Amount::All);
+	CHECK(settings.notifications.animation == true);
 }
 
 TEST_CASE("Serialize settings") {
@@ -343,6 +352,9 @@ TEST_CASE("Serialize settings") {
 
 	settings.button_exp_knobset.button_expander = 4; // (1<<2) = Expander #3
 	settings.button_exp_knobset.require_back = false;
+
+	settings.notifications.amount = MetaModule::NotificationSettings::Amount::OnlyCritical;
+	settings.notifications.animation = false;
 
 	// clang format-off
 	std::string expected = R"(Settings:
@@ -418,6 +430,9 @@ TEST_CASE("Serialize settings") {
   button_exp_knobset:
     button_expander: 4
     require_back: 0
+  notifications:
+    amount: OnlyCritical
+    animation: 0
 )";
 	// clang format-on
 

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -73,6 +73,9 @@ TEST_CASE("Parse settings file") {
   patch_suggested_audio:
     apply_samplerate: 0
     apply_blocksize: 1
+  button_exp_knobset:
+    button_expander: 2
+    require_back: 0
 )";
 	// clang-format on
 
@@ -136,6 +139,9 @@ TEST_CASE("Parse settings file") {
 	CHECK(settings.module_view.show_knobset_name == false);
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Never);
+
+	CHECK(settings.button_exp_knobset.button_expander == 2);
+	CHECK(settings.button_exp_knobset.require_back == false);
 }
 
 TEST_CASE("Get default settings if file is missing fields") {
@@ -280,6 +286,9 @@ TEST_CASE("Get default settings if file is missing fields") {
 	CHECK(settings.patch_suggested_audio.apply_blocksize == true);
 
 	CHECK(settings.missing_plugins.autoload == MetaModule::MissingPluginSettings::Autoload::Ask);
+
+	CHECK(settings.button_exp_knobset.button_expander == 0);
+	CHECK(settings.button_exp_knobset.require_back == true);
 }
 
 TEST_CASE("Serialize settings") {
@@ -331,6 +340,9 @@ TEST_CASE("Serialize settings") {
 
 	settings.patch_suggested_audio.apply_samplerate = false;
 	settings.patch_suggested_audio.apply_blocksize = true;
+
+	settings.button_exp_knobset.button_expander = 3;
+	settings.button_exp_knobset.require_back = false;
 
 	// clang format-off
 	std::string expected = R"(Settings:
@@ -403,6 +415,9 @@ TEST_CASE("Serialize settings") {
   patch_suggested_audio:
     apply_samplerate: 0
     apply_blocksize: 1
+  button_exp_knobset:
+    button_expander: 3
+    require_back: 0
 )";
 	// clang format-on
 


### PR DESCRIPTION
This PR allow users to reduce the number of notifications.

Adds new "Notifications" preferences section with two settings:
- "Show" dropdown:
    -  All: show all notifications (default, current behavior)
    - Fewer: don't show status notifications, only show errors and important information
    - Critical: only show errors and messages that cannot be ignored (file failed to save to disk, patch has unsaved changes and cannot be updated, etc)
-  "Animations" on/off switch. When off, notifications will show/hide instantly instead of the "dropdown" animation.
