### PR TITLE
Option to Wrap navigation in Module View

### DIFF
--- a/firmware/src/gui/pages/module_view/action_menu.hh
+++ b/firmware/src/gui/pages/module_view/action_menu.hh
@@ -103,7 +103,6 @@ public:
 		base_group = parent_group;
 		confirm_popup.init(lv_layer_top(), group);
 		reset_name_popup.init(lv_layer_top(), base_group);
-		keyboard_entry.prepare_focus(lv_layer_top(), base_group);
 
 		const auto module_slug = std::string{patches.get_view_patch()->module_slugs[module_idx]};
 		const auto module_name = module_slug.substr(module_slug.find_first_of(':') + 1);
@@ -449,6 +448,7 @@ private:
 
 		page->hide_menu();
 		page->pending_alias = alias;
+		page->keyboard_entry.prepare_focus(lv_layer_top(), page->base_group);
 		page->keyboard_entry.show_keyboard(
 			page->rename_textarea,
 			[page](std::string_view text) {

--- a/firmware/src/gui/pages/module_view/element_roller.cc
+++ b/firmware/src/gui/pages/module_view/element_roller.cc
@@ -228,9 +228,17 @@ void ModuleViewPage::roller_scrolled_cb(lv_event_t *event) {
 	auto prev_sel = page->cur_selected;
 	auto cur_idx = page->roller_drawn_el_idx[cur_sel];
 
+	// Wrap off bottom back to button bar:
+	if (prev_sel == (uint32_t)cur_sel && cur_sel == lv_roller_get_option_cnt(ui_ElementRoller) - 1) {
+		page->focus_button_bar(true);
+		page->roller_hover.hide();
+		return;
+	}
+
 	// Skip over headers by scrolling over them in the same direction we just scrolled
 	if (cur_idx == RollerHeaderTag) {
 		if (prev_sel < cur_sel) {
+			// Scroll down:
 			if (cur_sel < lv_roller_get_option_cnt(ui_ElementRoller) - 1)
 				cur_sel++;
 			else
@@ -238,6 +246,7 @@ void ModuleViewPage::roller_scrolled_cb(lv_event_t *event) {
 				cur_sel = prev_sel;
 
 		} else {
+			// Scroll up:
 			if (cur_sel)
 				cur_sel--;
 
@@ -284,17 +293,24 @@ void ModuleViewPage::roller_scrolled_cb(lv_event_t *event) {
 	page->roller_hover.hide();
 }
 
-void ModuleViewPage::focus_button_bar() {
+void ModuleViewPage::focus_button_bar(bool first_item) {
 	if (!full_screen_mode) {
 		if (gui_state.new_cable)
 			lv_group_focus_obj(ui_ModuleViewCableCancelBut);
 		else
-			lv_group_focus_obj(ui_ModuleViewSettingsBut);
+			lv_group_focus_obj(first_item ? ui_ModuleViewHideBut : ui_ModuleViewSettingsBut);
 
 		lv_group_set_editing(group, false);
-		cur_selected = 1;
-		lv_roller_set_selected(ui_ElementRoller, cur_selected, LV_ANIM_OFF);
-		unhighlight_component(cur_selected);
+		if (first_item) {
+			auto cur_sel = lv_roller_get_option_cnt(ui_ElementRoller) - 1;
+			lv_roller_set_selected(ui_ElementRoller, cur_sel, LV_ANIM_OFF);
+			cur_selected = roller_drawn_el_idx[cur_sel];
+			unhighlight_component(cur_sel);
+		} else {
+			cur_selected = 1;
+			lv_roller_set_selected(ui_ElementRoller, cur_selected, LV_ANIM_OFF);
+			unhighlight_component(cur_selected);
+		}
 	}
 }
 
@@ -447,16 +463,28 @@ void ModuleViewPage::roller_focus_cb(lv_event_t *event) {
 
 		// Change to "edit" mode if not already editting
 		if (lv_group_get_editing(page->group) == false) {
+
+			if (page->last_button_focused == ui_ModuleViewHideBut) {
+				auto cur_sel = lv_roller_get_option_cnt(ui_ElementRoller) - 1;
+				lv_roller_set_selected(ui_ElementRoller, cur_sel, LV_ANIM_OFF);
+				page->cur_selected = page->roller_drawn_el_idx[cur_sel];
+			}
+			if (page->last_button_focused == ui_ModuleViewSettingsBut) {
+				auto cur_sel = 1;
+				lv_roller_set_selected(ui_ElementRoller, cur_sel, LV_ANIM_OFF);
+				page->cur_selected = page->roller_drawn_el_idx[cur_sel];
+			}
+
 			// Must send a PRESS event to enter "edit" mode
 			lv_event_send(ui_ElementRoller, LV_EVENT_PRESSED, nullptr);
 			// This sends another FOCUSED event:
 			lv_group_set_editing(page->group, true);
 		}
-
 		if (auto drawn_idx = page->get_drawn_idx(page->cur_selected)) {
 			page->highlight_component(*drawn_idx);
 			move_selected_control_foreground(page->drawn_elements[*drawn_idx]);
 		}
+		page->last_button_focused = nullptr;
 	}
 }
 
@@ -466,6 +494,8 @@ void ModuleViewPage::jump_to_roller_cb(lv_event_t *event) {
 	auto page = static_cast<ModuleViewPage *>(event->user_data);
 	if (page->full_screen_mode) {
 		lv_group_focus_obj(ui_ElementRoller);
+	} else {
+		page->last_button_focused = event->target;
 	}
 }
 

--- a/firmware/src/gui/pages/module_view/element_roller.cc
+++ b/firmware/src/gui/pages/module_view/element_roller.cc
@@ -28,9 +28,9 @@ void ModuleViewPage::show_roller() {
 		lv_show(ui_ElementRollerPanel);
 		lv_group_focus_obj(ui_ElementRoller);
 		lv_group_set_editing(group, true);
-		lv_group_set_wrap(group, false);
 		args.detail_mode = false;
 	}
+	lv_group_set_wrap(group, settings.module_view.nav_wrapping);
 }
 
 void ModuleViewPage::populate_element_objects() {
@@ -229,10 +229,12 @@ void ModuleViewPage::roller_scrolled_cb(lv_event_t *event) {
 	auto cur_idx = page->roller_drawn_el_idx[cur_sel];
 
 	// Wrap off bottom back to button bar:
-	if (prev_sel == (uint32_t)cur_sel && cur_sel == lv_roller_get_option_cnt(ui_ElementRoller) - 1) {
-		page->focus_button_bar(true);
-		page->roller_hover.hide();
-		return;
+	if (page->settings.module_view.nav_wrapping) {
+		if (prev_sel == (uint32_t)cur_sel && cur_sel == lv_roller_get_option_cnt(ui_ElementRoller) - 1) {
+			page->focus_button_bar(true);
+			page->roller_hover.hide();
+			return;
+		}
 	}
 
 	// Skip over headers by scrolling over them in the same direction we just scrolled
@@ -464,7 +466,7 @@ void ModuleViewPage::roller_focus_cb(lv_event_t *event) {
 		// Change to "edit" mode if not already editting
 		if (lv_group_get_editing(page->group) == false) {
 
-			if (page->last_button_focused == ui_ModuleViewHideBut) {
+			if (page->settings.module_view.nav_wrapping && page->last_button_focused == ui_ModuleViewHideBut) {
 				auto cur_sel = lv_roller_get_option_cnt(ui_ElementRoller) - 1;
 				lv_roller_set_selected(ui_ElementRoller, cur_sel, LV_ANIM_OFF);
 				page->cur_selected = page->roller_drawn_el_idx[cur_sel];

--- a/firmware/src/gui/pages/module_view/mapping_pane.hh
+++ b/firmware/src/gui/pages/module_view/mapping_pane.hh
@@ -47,7 +47,6 @@ struct ModuleViewMappingPane {
 		, patch_mod_queue{patch_mod_queue}
 		, patches{patches} {
 
-		lv_obj_add_event_cb(ui_ResetButton, reset_button_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_ControlButton, control_button_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_ControlButton, scroll_to_top, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(ui_CableAddButton, add_cable_button_cb, LV_EVENT_CLICKED, this);
@@ -57,8 +56,6 @@ struct ModuleViewMappingPane {
 
 		lv_obj_set_style_pad_hor(ui_MapList, 3, LV_PART_MAIN);
 		lv_obj_set_style_pad_ver(ui_MapList, 3, LV_PART_MAIN);
-
-		lv_hide(ui_ResetButton);
 	}
 
 	void prepare_focus(lv_group_t *group, uint32_t width, bool patch_playing) {
@@ -257,7 +254,6 @@ private:
 	void prepare_for_element(const BaseElement &) {
 		lv_hide(ui_CableAddButton);
 		lv_hide(ui_ControlButton);
-		lv_hide(ui_ResetButton);
 		lv_hide(ui_CableRemoveButton);
 		lv_hide(ui_CablePanelAddButton);
 		lv_hide(ui_CableMidiAddButton);
@@ -362,7 +358,6 @@ private:
 
 	void prepare_jack_gui() {
 		lv_hide(ui_ControlButton);
-		lv_hide(ui_ResetButton);
 		lv_hide(ui_ControlAlert);
 		lv_hide(ui_AddMapPopUp);
 
@@ -593,10 +588,6 @@ private:
 		lv_show(ui_MappedPanel);
 		lv_show(ui_MappedItemHeader);
 
-		// Do not use Reset Button for individual params until we implement calling
-		// paramQuantity->reset() and/or paramWidget->onReset()
-		lv_hide(ui_ResetButton);
-
 		lv_show(ui_ControlButton, is_patch_playing);
 		lv_label_set_text(ui_ControlButtonLabel, "Adjust");
 		lv_label_set_text(ui_MappedListTitle, "Mappings:");
@@ -624,7 +615,6 @@ private:
 		}
 
 		if (is_patch_playing) {
-			lv_group_add_obj(pane_group, ui_ResetButton);
 			lv_group_focus_obj(ui_ControlButton);
 		}
 	}
@@ -671,7 +661,6 @@ private:
 		lv_hide(ui_CableRemoveButton);
 		lv_hide(ui_CablePanelAddButton);
 		lv_hide(ui_CableMidiAddButton);
-		lv_hide(ui_ResetButton);
 
 		lv_hide(ui_MappedPanel);
 		lv_hide(ui_MappedItemHeader);

--- a/firmware/src/gui/pages/module_view/mapping_pane.hh
+++ b/firmware/src/gui/pages/module_view/mapping_pane.hh
@@ -68,7 +68,6 @@ struct ModuleViewMappingPane {
 		add_cable_popup.init(ui_MappingMenu, pane_group);
 		panel_cable_popup.init(ui_MappingMenu, pane_group);
 		midi_map_popup.init(ui_MappingMenu, pane_group);
-		keyboard_entry.prepare_focus(ui_MappingMenu, pane_group);
 
 		lv_obj_set_y(ui_Keyboard, 144);
 	}
@@ -805,6 +804,7 @@ private:
 			return;
 		}
 
+		keyboard_entry.prepare_focus(ui_MappingMenu, pane_group);
 		keyboard_entry.show_keyboard(alias_text_obj, [panelmap = panelmap, this](std::string_view text) {
 			if (panelmap.is_input)
 				patch->set_panel_in_alias(panelmap.panel_jack_id, text);

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -65,7 +65,7 @@ struct ModuleViewPage : PageBase {
 		lv_group_add_obj(group, ui_ModuleViewExtraMenuRoller);
 		lv_hide(ui_ModuleViewExtraMenuRoller);
 
-		lv_group_set_wrap(group, false);
+		lv_group_set_wrap(group, settings.module_view.nav_wrapping);
 
 		lv_obj_add_event_cb(ui_ElementRoller, roller_scrolled_cb, LV_EVENT_KEY, this);
 		lv_obj_add_event_cb(ui_ElementRoller, roller_click_cb, LV_EVENT_SHORT_CLICKED, this);

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -368,6 +368,7 @@ struct ModuleViewPage : PageBase {
 		action_menu.hide();
 		lv_hide(load_meter);
 		lv_enable_long_press();
+		last_button_focused = nullptr;
 	}
 
 private:
@@ -443,7 +444,7 @@ private:
 	void add_element_highlight(DrawnElement const &drawn_element);
 	void unhighlight_component(uint32_t prev_sel);
 	void highlight_component(size_t idx);
-	void focus_button_bar();
+	void focus_button_bar(bool first_button = false);
 	void click_cable_destination(unsigned drawn_idx);
 	void click_altparam_action(DrawnElement const &drawn_element);
 	void manual_control_popup(DrawnElement const &drawn_element);
@@ -535,6 +536,7 @@ private:
 	Toggler quickmap_rotary_button;
 
 	lv_obj_t *load_meter;
+	lv_obj_t *last_button_focused = nullptr;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -77,6 +77,7 @@ struct ModuleViewPage : PageBase {
 		lv_obj_add_event_cb(ui_ModuleViewHideBut, jump_to_roller_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(ui_ModuleViewActionBut, jump_to_roller_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(ui_ModuleViewSettingsBut, jump_to_roller_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(ui_ModuleViewCableCancelBut, jump_to_roller_cb, LV_EVENT_FOCUSED, this);
 
 		load_meter = create_load_meter(lv_layer_sys());
 		lv_obj_set_align(load_meter, LV_ALIGN_TOP_LEFT);
@@ -291,6 +292,7 @@ struct ModuleViewPage : PageBase {
 		// Hide the hover text if we are on one of the action buttons
 		if (lv_group_get_focused(group) == ui_ModuleViewActionBut ||
 			lv_group_get_focused(group) == ui_ModuleViewSettingsBut ||
+			lv_group_get_focused(group) == ui_ModuleViewCableCancelBut ||
 			lv_group_get_focused(group) == ui_ModuleViewHideBut)
 		{
 			roller_hover.hide();

--- a/firmware/src/gui/pages/module_view/settings_menu.hh
+++ b/firmware/src/gui/pages/module_view/settings_menu.hh
@@ -57,9 +57,16 @@ struct ModuleViewSettingsMenu {
 		lv_obj_set_style_border_width(show_samplerate_cont, 0, 0);
 		show_samplerate_check = lv_obj_get_child(show_samplerate_cont, 1);
 
+		auto nav_title = create_settings_menu_title(ui_MVSettingsMenu, "NAVIGATION");
+
+		auto nav_wrapping_cont = create_settings_menu_switch(ui_MVSettingsMenu, "Allow Wrapping");
+		nav_wrapping_check = lv_obj_get_child(nav_wrapping_cont, 1);
+
 		lv_obj_move_to_index(bar_title, 4);
 		lv_obj_move_to_index(float_samplerate_cont, 5);
 		lv_obj_move_to_index(show_samplerate_cont, 6);
+		lv_obj_move_to_index(nav_title, 7);
+		lv_obj_move_to_index(nav_wrapping_cont, 8);
 
 		lv_obj_add_event_cb(ui_ModuleViewSettingsBut, settings_button_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(ui_MVSettingsCloseButton, settings_button_cb, LV_EVENT_CLICKED, this);
@@ -88,6 +95,8 @@ struct ModuleViewSettingsMenu {
 		lv_obj_add_event_cb(show_samplerate_check, show_titlebar_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(float_audioload_check, show_titlebar_cb, LV_EVENT_VALUE_CHANGED, this);
 
+		lv_obj_add_event_cb(nav_wrapping_check, nav_wrapping_cb, LV_EVENT_VALUE_CHANGED, this);
+
 		lv_obj_set_x(ui_MVSettingsMenu, 220);
 
 		lv_group_add_obj(settings_menu_group, ui_MVSettingsCloseButton);
@@ -97,6 +106,8 @@ struct ModuleViewSettingsMenu {
 
 		lv_group_add_obj(settings_menu_group, float_audioload_check);
 		lv_group_add_obj(settings_menu_group, show_samplerate_check);
+
+		lv_group_add_obj(settings_menu_group, nav_wrapping_check);
 
 		lv_group_add_obj(settings_menu_group, ui_MVShowControlMapsCheck);
 		lv_group_add_obj(settings_menu_group, ui_MVControlMapTranspSlider);
@@ -135,6 +146,7 @@ struct ModuleViewSettingsMenu {
 
 		lv_check(show_jack_aliases_check, settings.show_jack_aliases);
 		lv_check(show_knob_aliases_check, settings.show_knob_aliases);
+		lv_check(nav_wrapping_check, settings.nav_wrapping);
 
 		lv_check(show_samplerate_check, settings.show_samplerate);
 		lv_check(float_audioload_check, settings.float_loadmeter);
@@ -367,6 +379,17 @@ private:
 		page->changed_while_visible = true;
 	}
 
+	static void nav_wrapping_cb(lv_event_t *event) {
+		if (!event || !event->user_data)
+			return;
+		auto page = static_cast<ModuleViewSettingsMenu *>(event->user_data);
+
+		page->settings.nav_wrapping = lv_obj_has_state(page->nav_wrapping_check, LV_STATE_CHECKED);
+
+		page->settings.changed = true;
+		page->changed_while_visible = true;
+	}
+
 	static void show_titlebar_cb(lv_event_t *event) {
 		if (!event || !event->user_data)
 			return;
@@ -390,6 +413,7 @@ private:
 	lv_obj_t *graphics_update_rate_slider;
 	lv_obj_t *show_jack_aliases_check;
 	lv_obj_t *show_knob_aliases_check;
+	lv_obj_t *nav_wrapping_check;
 
 	lv_obj_t *show_samplerate_check;
 	lv_obj_t *float_audioload_check;

--- a/firmware/src/gui/slsexport/meta5/screens/ui_MappingMenu.c
+++ b/firmware/src/gui/slsexport/meta5/screens/ui_MappingMenu.c
@@ -994,45 +994,6 @@ lv_obj_set_style_text_line_space(ui_CableRemoveButtonLabel, 0, LV_PART_MAIN| LV_
 lv_obj_set_style_text_align(ui_CableRemoveButtonLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN| LV_STATE_DEFAULT);
 lv_obj_set_style_text_font(ui_CableRemoveButtonLabel, &ui_font_MuseoSansRounded50016, LV_PART_MAIN| LV_STATE_DEFAULT);
 
-ui_ResetButton = lv_btn_create(ui_MappingParameters);
-lv_obj_set_width( ui_ResetButton, lv_pct(100));
-lv_obj_set_height( ui_ResetButton, LV_SIZE_CONTENT);   /// 1
-lv_obj_set_x( ui_ResetButton, 0 );
-lv_obj_set_y( ui_ResetButton, 88 );
-lv_obj_set_align( ui_ResetButton, LV_ALIGN_CENTER );
-lv_obj_clear_flag( ui_ResetButton, LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SNAPPABLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN );    /// Flags
-lv_obj_set_style_radius(ui_ResetButton, 15, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_bg_color(ui_ResetButton, lv_color_hex(0x777777), LV_PART_MAIN | LV_STATE_DEFAULT );
-lv_obj_set_style_bg_opa(ui_ResetButton, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_pad_left(ui_ResetButton, 8, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_pad_right(ui_ResetButton, 8, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_pad_top(ui_ResetButton, 4, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_pad_bottom(ui_ResetButton, 4, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_outline_color(ui_ResetButton, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_PRESSED );
-lv_obj_set_style_outline_opa(ui_ResetButton, 255, LV_PART_MAIN| LV_STATE_PRESSED);
-lv_obj_set_style_outline_width(ui_ResetButton, 0, LV_PART_MAIN| LV_STATE_PRESSED);
-lv_obj_set_style_outline_pad(ui_ResetButton, 0, LV_PART_MAIN| LV_STATE_PRESSED);
-lv_obj_set_style_outline_color(ui_ResetButton, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUSED );
-lv_obj_set_style_outline_opa(ui_ResetButton, 255, LV_PART_MAIN| LV_STATE_FOCUSED);
-lv_obj_set_style_outline_width(ui_ResetButton, 2, LV_PART_MAIN| LV_STATE_FOCUSED);
-lv_obj_set_style_outline_pad(ui_ResetButton, 3, LV_PART_MAIN| LV_STATE_FOCUSED);
-lv_obj_set_style_outline_color(ui_ResetButton, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_FOCUS_KEY );
-lv_obj_set_style_outline_opa(ui_ResetButton, 255, LV_PART_MAIN| LV_STATE_FOCUS_KEY);
-lv_obj_set_style_outline_width(ui_ResetButton, 2, LV_PART_MAIN| LV_STATE_FOCUS_KEY);
-lv_obj_set_style_outline_pad(ui_ResetButton, 3, LV_PART_MAIN| LV_STATE_FOCUS_KEY);
-
-ui_ResetButtonLabel = lv_label_create(ui_ResetButton);
-lv_obj_set_width( ui_ResetButtonLabel, lv_pct(100));
-lv_obj_set_height( ui_ResetButtonLabel, LV_SIZE_CONTENT);   /// 1
-lv_obj_set_align( ui_ResetButtonLabel, LV_ALIGN_CENTER );
-lv_label_set_text(ui_ResetButtonLabel,"Initialize");
-lv_obj_set_style_text_color(ui_ResetButtonLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT );
-lv_obj_set_style_text_opa(ui_ResetButtonLabel, 255, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_letter_space(ui_ResetButtonLabel, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_line_space(ui_ResetButtonLabel, 0, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_align(ui_ResetButtonLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN| LV_STATE_DEFAULT);
-lv_obj_set_style_text_font(ui_ResetButtonLabel, &ui_font_MuseoSansRounded50016, LV_PART_MAIN| LV_STATE_DEFAULT);
-
 ui_ControlAlert = lv_obj_create(ui_MappingParameters);
 lv_obj_set_width( ui_ControlAlert, lv_pct(100));
 lv_obj_set_height( ui_ControlAlert, LV_SIZE_CONTENT);   /// 1

--- a/firmware/src/gui/slsexport/meta5/ui.c
+++ b/firmware/src/gui/slsexport/meta5/ui.c
@@ -211,8 +211,6 @@ lv_obj_t *ui_CableMidiAddButton;
 lv_obj_t *ui_CableMidiAddLabel;
 lv_obj_t *ui_CableRemoveButton;
 lv_obj_t *ui_CableRemoveButtonLabel;
-lv_obj_t *ui_ResetButton;
-lv_obj_t *ui_ResetButtonLabel;
 lv_obj_t *ui_ControlAlert;
 lv_obj_t *ui_ControlArc;
 lv_obj_t *ui_ControlAlertLabel;

--- a/firmware/src/gui/slsexport/meta5/ui.h
+++ b/firmware/src/gui/slsexport/meta5/ui.h
@@ -217,8 +217,6 @@ extern lv_obj_t *ui_CableMidiAddButton;
 extern lv_obj_t *ui_CableMidiAddLabel;
 extern lv_obj_t *ui_CableRemoveButton;
 extern lv_obj_t *ui_CableRemoveButtonLabel;
-extern lv_obj_t *ui_ResetButton;
-extern lv_obj_t *ui_ResetButtonLabel;
 extern lv_obj_t *ui_ControlAlert;
 extern lv_obj_t *ui_ControlArc;
 extern lv_obj_t *ui_ControlAlertLabel;

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -86,6 +86,7 @@ static bool read(ryml::ConstNodeRef const &node, ModuleDisplaySettings *s) {
 	read_or_default(node, "show_knobset_name", s, &ModuleDisplaySettings::show_knobset_name);
 	read_or_default(node, "show_jack_aliases", s, &ModuleDisplaySettings::show_jack_aliases);
 	read_or_default(node, "show_knob_aliases", s, &ModuleDisplaySettings::show_knob_aliases);
+	read_or_default(node, "nav_wrapping", s, &ModuleDisplaySettings::nav_wrapping);
 
 	return true;
 }

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -37,6 +37,7 @@ static void write(ryml::NodeRef *n, ModuleDisplaySettings const &s) {
 	n->append_child() << ryml::key("show_knobset_name") << s.show_knobset_name;
 	n->append_child() << ryml::key("show_jack_aliases") << s.show_jack_aliases;
 	n->append_child() << ryml::key("show_knob_aliases") << s.show_knob_aliases;
+	n->append_child() << ryml::key("nav_wrapping") << s.nav_wrapping;
 }
 
 static void write(ryml::NodeRef *n, AudioSettings const &s) {

--- a/firmware/src/user_settings/view_settings.hh
+++ b/firmware/src/user_settings/view_settings.hh
@@ -35,6 +35,8 @@ struct ModuleDisplaySettings {
 	bool show_jack_aliases = false;
 	bool show_knob_aliases = false;
 
+	bool nav_wrapping = false;
+
 	constexpr static std::array<unsigned, 6> ThrottleAmounts = {32, 16, 8, 4, 2, 1};
 	unsigned graphic_screen_throttle = 1;
 };

--- a/firmware/system/startup_ca7.s
+++ b/firmware/system/startup_ca7.s
@@ -36,7 +36,7 @@ Reset_Handler:
 	isb
 													// Configure ACTLR
 	mrc     p15, 0, r0, c1, c0, 1 					// Read CP15 Auxiliary Control Register
-	orr     r0, r0, #(1 <<  1) 						// Enable L2 prefetch hint (UNK/WI since r4p1)
+	orr     r0, r0, #(1 <<  6) 						// Enable SMP
 	mcr     p15, 0, r0, c1, c0, 1 					// Write CP15 Auxiliary Control Register
 
 													// Set Vector Base Address Register (VBAR) to point to this application's vector table

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -378,6 +378,7 @@ TEST_CASE("Serialize settings") {
     show_knobset_name: 0
     show_jack_aliases: 0
     show_knob_aliases: 0
+    nav_wrapping: 0
   module_view:
     map_ring_flash_active: 0
     scroll_to_active_param: 1
@@ -398,6 +399,7 @@ TEST_CASE("Serialize settings") {
     show_knobset_name: 0
     show_jack_aliases: 0
     show_knob_aliases: 0
+    nav_wrapping: 0
   audio:
     sample_rate: 24000
     block_size: 512

--- a/firmware/vcv_ports/glue/Valley/CMakeLists.txt
+++ b/firmware/vcv_ports/glue/Valley/CMakeLists.txt
@@ -67,6 +67,7 @@ target_compile_options(ValleyLibrary PRIVATE
 	-Wno-double-promotion 
     -Wno-unused-variable
 	$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-float-conversion>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-implicit-const-int-float-conversion>
 )
 
 # Use floats, not doubles for Plateau


### PR DESCRIPTION
Small feature, but can help with modules that tons of params or jacks
A new option is added to the Module View Settings menu (gear icon on Module View page): Navigation: Allow Wrapping

When checked, scrolling off the bottom of the element roller goes to the button bar, and scrolling backwards from the first button goes to the end of the roller list. When not checked, the behavior is the same.

This works a little differently when in Create Cable mode: scrolling off the Cancel Cable button goes to the last selected item in the roller (so if you were at the bottom of the roller, it goes back to the bottom of the roller). Make this consistent is possible, but is not as useful since the cable mode is not as common.

This also fixes an issue with the Jack Alias keyboard not hiding when clicking the checkmark (this happened with the module alias feature since they share a keyboard).