### PR TITLE
Midi sysex support

### DIFF
--- a/firmware/src/audio/audio.cc
+++ b/firmware/src/audio/audio.cc
@@ -467,8 +467,12 @@ ParamBlock &AudioStream::cache_params(unsigned block) {
 	local_params.metaparams.meta_buttons[0].set_state_no_events(
 		param_blocks[block].metaparams.meta_buttons[0].is_pressed());
 
-	for (auto i = 0u; i < block_size_; i++)
-		local_params.params[i] = param_blocks[block].params[i]; // 45us/49us alt
+	// 31.5 - 31.7us
+	std::memcpy((void *)local_params.params.data(), &param_blocks[block].params, sizeof(Params) * block_size_);
+
+	// 42.5us
+	// for (auto i = 0u; i < block_size_; i++)
+	// 	local_params.params[i] = param_blocks[block].params[i]; // 45us/49us alt
 
 	return local_params;
 }

--- a/firmware/src/audio/audio.hh
+++ b/firmware/src/audio/audio.hh
@@ -95,7 +95,7 @@ private:
 	AudioOverrunHandler overrun_handler;
 
 	// Local
-	ParamBlock local_params;
+	alignas(64) ParamBlock local_params;
 
 	bool ext_audio_connected = false;
 

--- a/firmware/src/core_m4/controls.cc
+++ b/firmware/src/core_m4/controls.cc
@@ -194,7 +194,7 @@ void Controls::start() {
 		bool ignore = false;
 
 		while (rxbuffer.size() >= 4) {
-			auto msg = MidiMessage{rxbuffer[1], rxbuffer[2], rxbuffer[3]};
+			auto msg = MidiMessage{rxbuffer[0], rxbuffer[1], rxbuffer[2], rxbuffer[3]};
 
 			//Starting ignoring from SysEx Start (F0)...
 			if (msg.is_sysex())

--- a/firmware/src/midi/midi_message.hh
+++ b/firmware/src/midi/midi_message.hh
@@ -25,17 +25,17 @@ enum class MidiCommand : uint8_t {
 };
 
 struct MidiStatusByte {
-	MidiCommand command : 4; // these are swapped in position, but doesn't matter
 	uint8_t channel : 4;
+	MidiCommand command : 4;
 
-	static MidiStatusByte make(uint8_t raw) {
+	constexpr static MidiStatusByte make(uint8_t raw) {
 		return MidiStatusByte{
-			.command = MidiCommand(raw >> 4),
 			.channel = uint8_t(raw & 0x0F),
+			.command = MidiCommand(raw >> 4),
 		};
 	}
 
-	operator uint8_t() const {
+	constexpr operator uint8_t() const {
 		return (uint8_t)command << 4 | channel;
 	}
 };
@@ -43,24 +43,29 @@ struct MidiStatusByte {
 struct MidiDataBytes {
 	uint8_t byte[2];
 
-	operator uint16_t() const {
+	constexpr operator uint16_t() const {
 		return ((uint16_t)byte[0] << 8) | byte[1];
 	}
 };
 
 enum MidiSystemCommonCommand : uint8_t {
-	TimeCodeQuarterFrame = 0xF1,
-	SongPositionPtr = 0xF2,
-	SongSelect = 0xF3,
-	TuneRequest = 0xF6,
-	EndExclusive = 0xF7,
+	TimeCodeQuarterFrame = 0xF1, // packet = 2 bytes
+	SongPositionPtr = 0xF2,		 // packet = 3 byte
+	SongSelect = 0xF3,			 // packet = 2 bytes
+	// 0xF4 undefined
+	// 0xF5 undefined
+	TuneRequest = 0xF6,	 // packet = 1 byte
+	EndExclusive = 0xF7, // packet = 1 byte
 };
 
 enum MidiSystemRealTimeCommand : uint8_t {
+	// packet = 1 byte
 	TimingClock = 0xF8,
+	// 0xF9 undefined
 	Start = 0xFA,
 	Continue = 0xFB,
 	Stop = 0xFC,
+	// 0xFD undefined
 	ActiveSending = 0xFE,
 	SystemReset = 0xFF,
 };
@@ -73,11 +78,13 @@ struct UsbCableCodeByte {
 	uint8_t cin : 4 = 0;	   // low nibble
 	uint8_t cable_num : 4 = 0; // high nibble
 
+	constexpr UsbCableCodeByte(uint8_t raw)
+		: cin(raw & 0x0F)
+		, cable_num(raw >> 4) {
+	}
+
 	constexpr static UsbCableCodeByte make(uint8_t raw) {
-		return UsbCableCodeByte{
-			.cin = uint8_t(raw & 0x0F),
-			.cable_num = uint8_t(raw >> 4),
-		};
+		return raw;
 	}
 
 	constexpr operator uint8_t() const {
@@ -85,30 +92,34 @@ struct UsbCableCodeByte {
 	}
 
 	constexpr static uint8_t cin_from_status_byte(uint8_t status) {
-		// 0x5: single-byte messages (system common)
-		// 0x2: two-byte message for Songselect
-		// 0x3: three-byte message for SongPosPtr
-		// 0x0: undefined: F0, F4, F5
-		return (status >= 0xF6) ? 0x5 : (status == 0xF3 || status == 0xF1) ? 0x2 : (status == 0xF2) ? 0x3 : 0x0;
+		// Deduce the CIN code based on the status byte
+		// We cannot deduce SysEx payload size here: that must be set already, so we never set CIN to 0x6 or 0x7 here.
+		return (status >= 0x80 && status < 0xF0)						? (status >> 4) : //voice messages
+			   status == SysEx					  						? 0x4 :
+			   (status == TimeCodeQuarterFrame || status == SongSelect) ? 0x2 :
+			   status == SongPositionPtr					  			? 0x3 :
+			   status == TuneRequest || status == EndExclusive   		? 0x5 : 
+			   status >= 0xF8					  						? 0xF : // single byte System Realtime
+																		  0x4;  // unknown: default to sysex payload
 	}
 };
 static_assert(UsbCableCodeByte::make(0x1B).cable_num == 1);
 static_assert(UsbCableCodeByte::make(0x1B).cin == 0xB);
 
 struct MidiMessage {
-	MidiStatusByte status{MidiCommand::None, 0};
+	MidiStatusByte status{0, MidiCommand::None};
 	MidiDataBytes data{0, 0};
 	UsbCableCodeByte usb_hdr{0};
 
-	MidiMessage() = default;
+	constexpr MidiMessage() = default;
 
-	MidiMessage(uint8_t status_byte, uint8_t data_byte0 = 0, uint8_t data_byte1 = 0)
+	constexpr MidiMessage(uint8_t status_byte, uint8_t data_byte0 = 0, uint8_t data_byte1 = 0)
 		: status{MidiStatusByte::make(status_byte)}
 		, data{data_byte0, data_byte1}
-		, usb_hdr{UsbCableCodeByte::cin_from_status_byte(status)} {
+		, usb_hdr{UsbCableCodeByte::cin_from_status_byte(status_byte)} {
 	}
 
-	MidiMessage(uint8_t usb_header, uint8_t status_byte, uint8_t data_byte0, uint8_t data_byte1)
+	constexpr MidiMessage(uint8_t usb_header, uint8_t status_byte, uint8_t data_byte0, uint8_t data_byte1)
 		: status{MidiStatusByte::make(status_byte)}
 		, data{data_byte0, data_byte1}
 		, usb_hdr{usb_header} {
@@ -150,27 +161,20 @@ struct MidiMessage {
 	}
 
 	uint32_t raw() const {
-		return (status << 16) | data;
+		return (usb_hdr << 24) | (status << 16) | data;
 	}
 
+	// Fill given `bytes` array with a valid usb midi packet
 	void make_usb_msg(std::array<uint8_t, 4> &bytes) {
-		bytes[0] = usb_hdr;
-		if (bytes[0] == 0)
-			bytes[0] = (uint8_t)status.command;
-
-		if (is_timing_transport()) {
-			bytes[1] = status;
-			bytes[2] = 0;
-			bytes[3] = 0;
-		} else if (status.command == MidiCommand::ChannelPressure) {
-			bytes[1] = status;
-			bytes[2] = data.byte[0];
-			bytes[3] = 0;
-		} else {
-			bytes[1] = status;
-			bytes[2] = data.byte[0];
-			bytes[3] = data.byte[1];
+		// If usb CIN field is not set, then deduce it from the status byte
+		if (usb_hdr.cin == 0) {
+			usb_hdr.cin = UsbCableCodeByte::cin_from_status_byte(status);
 		}
+
+		bytes[0] = usb_hdr;
+		bytes[1] = status;
+		bytes[2] = data.byte[0];
+		bytes[3] = data.byte[1];
 	}
 
 	uint8_t note() const {
@@ -210,6 +214,10 @@ struct MidiMessage {
 		if (is_timing_transport()) {
 			return 1;
 		} else if (status.command == MidiCommand::ChannelPressure) {
+			return 2;
+		} else if (usb_hdr.cin == 0x5) {
+			return 1;
+		} else if (usb_hdr.cin == 0x6) {
 			return 2;
 		} else {
 			return 3;
@@ -285,3 +293,6 @@ struct MidiMessage {
 		return std::string(nts[midi_val % 12]) + std::to_string(oct);
 	}
 };
+
+static_assert(MidiMessage(0x3B, 0xB0, 0x10, 0x20).usb_hdr.cin == 0xB);
+static_assert(MidiMessage(0x3B, 0xB0, 0x10, 0x20).usb_hdr.cable_num == 0x3);

--- a/firmware/src/midi/midi_sync.hh
+++ b/firmware/src/midi/midi_sync.hh
@@ -56,7 +56,7 @@ public:
 
 		if (cc_val != cc_value) {
 			MidiMessage cc_msg;
-			cc_msg.status = MidiStatusByte{MidiCommand::ControlChange, midi_chan};
+			cc_msg.status = MidiStatusByte{midi_chan, MidiCommand::ControlChange};
 			cc_msg.data.byte[0] = cc_num;
 			cc_msg.data.byte[1] = cc_value;
 
@@ -77,13 +77,13 @@ public:
 		if (note_val != gate_on) {
 			if (gate_on) {
 				MidiMessage note_msg;
-				note_msg.status = MidiStatusByte{MidiCommand::NoteOn, midi_chan};
+				note_msg.status = MidiStatusByte{midi_chan, MidiCommand::NoteOn};
 				note_msg.data.byte[0] = note_num;
 				note_msg.data.byte[1] = 127;
 				midi_out_queue.put(note_msg);
 			} else {
 				MidiMessage note_msg;
-				note_msg.status = MidiStatusByte{MidiCommand::NoteOff, midi_chan};
+				note_msg.status = MidiStatusByte{midi_chan, MidiCommand::NoteOff};
 				note_msg.data.byte[0] = note_num;
 				note_msg.data.byte[1] = 0;
 				midi_out_queue.put(note_msg);
@@ -108,7 +108,7 @@ public:
 
 		if (pitch_val != pitchwheel_value) {
 			MidiMessage pitchwheel_msg;
-			pitchwheel_msg.status = MidiStatusByte{MidiCommand::PitchBend, midi_chan};
+			pitchwheel_msg.status = MidiStatusByte{midi_chan, MidiCommand::PitchBend};
 			pitchwheel_msg.data.byte[0] = pitchwheel_value & 0x7F;
 			pitchwheel_msg.data.byte[1] = (pitchwheel_value >> 7) & 0x7F;
 

--- a/firmware/src/params/param_block.hh
+++ b/firmware/src/params/param_block.hh
@@ -7,7 +7,7 @@ namespace MetaModule
 {
 
 struct ParamBlock {
-	std::array<Params, StreamConf::Audio::MaxBlockSize> params{};
+	alignas(64) std::array<Params, StreamConf::Audio::MaxBlockSize> params{};
 	MetaParams metaparams{};
 };
 

--- a/firmware/src/params/params.hh
+++ b/firmware/src/params/params.hh
@@ -2,7 +2,7 @@
 #include "conf/panel_conf.hh"
 #include "midi/midi_message.hh"
 #include "midi_params.hh"
-#include "util/debouncer.hh"
+#include "util/debouncer_compact.hh"
 #include <array>
 
 namespace MetaModule
@@ -11,10 +11,10 @@ namespace MetaModule
 struct Params {
 	std::array<float, PanelDef::NumPot> knobs{};
 
+	MidiMessage raw_msg{};	  //4B
 	Midi::Event midi_event{}; //6B
-	MidiMessage raw_msg{};	  //3B
 	uint8_t gate_ins{};
-	Toggler button{};
+	TogglerCompact button{};
 
 	void clear() {
 		gate_ins = 0;
@@ -28,6 +28,7 @@ struct Params {
 	}
 };
 
+// 60B
 static constexpr auto Params_Size = sizeof(Params);
 
 } // namespace MetaModule

--- a/firmware/vcv_plugin/export/src/midi_input_queue.cpp
+++ b/firmware/vcv_plugin/export/src/midi_input_queue.cpp
@@ -38,6 +38,7 @@ bool InputQueue::tryPop(rack::midi::Message *messageOut, int64_t maxFrame) {
 				messageOut->bytes[0] = msg->status;
 				messageOut->bytes[1] = msg->data.byte[0];
 				messageOut->bytes[2] = msg->data.byte[1];
+				messageOut->usb_cable = msg->usb_hdr.cable_num;
 				return true;
 			}
 		}

--- a/firmware/vcv_plugin/export/src/midi_input_queue.cpp
+++ b/firmware/vcv_plugin/export/src/midi_input_queue.cpp
@@ -32,15 +32,13 @@ bool InputQueue::tryPop(rack::midi::Message *messageOut, int64_t maxFrame) {
 
 	if (auto msg = internal->queue.get()) {
 		// Convert to rack::midi::Message
-		if (msg->status & 0x80) { // status byte
-			if (channel < 0 || (channel == msg->status.channel)) {
-				messageOut->setSize(msg->message_size());
-				messageOut->bytes[0] = msg->status;
-				messageOut->bytes[1] = msg->data.byte[0];
-				messageOut->bytes[2] = msg->data.byte[1];
-				messageOut->usb_cable = msg->usb_hdr.cable_num;
-				return true;
-			}
+		if (channel < 0 || (channel == msg->status.channel)) {
+			messageOut->bytes[0] = msg->status;
+			messageOut->bytes[1] = msg->data.byte[0];
+			messageOut->bytes[2] = msg->data.byte[1];
+			messageOut->usb_cable = msg->usb_hdr.cable_num;
+			messageOut->usb_code = msg->usb_hdr.cin;
+			return true;
 		}
 	}
 

--- a/firmware/vcv_ports/RackCore/MIDI_CV.cpp
+++ b/firmware/vcv_ports/RackCore/MIDI_CV.cpp
@@ -495,6 +495,8 @@ struct MIDI_CV : Module {
 			if (s.length()) {
 				if (i != 0)
 					chars += "\n\n";
+				if (msg.usb_cable != 0)
+					chars += "CN" + std::to_string(msg.usb_cable) + " ";
 				chars += s;
 			}
 		}


### PR DESCRIPTION
Passes the full MIDI USB message to modules using the rack::midi_queue. This allows modules to interpret SysEx and filter based on MIDI USB cable ID and code byte.

This does not actually do anything special with SysEx or USB MIDI codes, it just passes them to the modules. 

In doing so, the Params shared data grew in size, so I compacted it a bit by using an alternative Toggler implementation. This actually reduced the overall size, so the net effect is a reduction in CPU usage.