### PR TITLE
Patch cpu tests

### DIFF
--- a/firmware/flashing/flash-t32.py
+++ b/firmware/flashing/flash-t32.py
@@ -1,0 +1,33 @@
+import lauterbach.trace32.rcl as t32
+from pathlib import Path
+
+dbg = t32.connect()
+basepath = Path(__file__).parent.parent
+binpath = basepath / "build"/"main.uimg"
+elfpath = basepath / "build"/"mp1corea7"/"medium"/"main.elf"
+
+dbg.print(f"Flashing via python rcl {binpath}...")
+
+dbg.cmd("RESet")
+dbg.cmd("SYStem.RESet")
+
+dbg.cmd("SYStem.CPU STM32MP153D-CA7")
+dbg.cmd("SYStem.JtagClock 50MHz")
+dbg.cmd("CORE.ASSIGN 1. 2.")
+
+dbg.cmd("Trace.DISable")
+dbg.cmd("SYStem.MemAccess DAP")
+dbg.cmd("SYStem.Up")
+
+dbg.cmd(f"Data.LOAD.Binary {binpath} 0xC0000000 /DUALPORT")
+dbg.cmd(f"Data.LOAD.Elf {elfpath} /CPP /NoCode")
+dbg.cmd("PER.Set.simple AZSD:0x0:0x5C00A118 %Long 0xC0000000")
+dbg.cmd("Go")
+
+dbg.cmd("Trace.METHOD ONCHIP")
+dbg.cmd("ETM.Trace ON")
+dbg.cmd("ETM.ON")
+
+dbg.cmd("Trace.arm")
+# dbg.cmd("ENDDO")
+

--- a/firmware/src/conf/hsem_conf.hh
+++ b/firmware/src/conf/hsem_conf.hh
@@ -13,6 +13,7 @@ enum SemaphoreLocks {
 	RamDiskLock,
 	SharedI2CLock,
 	InvalidateICache,
+	RunningPatchTests,
 };
 
 } // namespace MetaModule

--- a/firmware/src/core_a7/aux_core_main.cc
+++ b/firmware/src/core_a7/aux_core_main.cc
@@ -78,10 +78,14 @@ extern "C" void aux_core_main() {
 
 	AutoUpdater::run(file_storage_proxy, ui);
 
-	if (CpuLoadTest::should_run_tests(file_storage_proxy)) {
-		CpuLoadTest::run_tests(file_storage_proxy, ui, plugin_manager);
-	} else {
-		ui.preload_plugins(plugin_manager);
+	if (CpuLoadTest::should_run_hil_tests(file_storage_proxy)) {
+		CpuLoadTest::run_hil_tests(file_storage_proxy, ui, plugin_manager);
+	}
+
+	ui.preload_plugins(plugin_manager);
+
+	if (CpuLoadTest::should_run_module_tests(file_storage_proxy)) {
+		CpuLoadTest::run_module_tests(file_storage_proxy, ui);
 	}
 
 	// Signal that we're ready

--- a/firmware/src/core_a7/aux_core_main.cc
+++ b/firmware/src/core_a7/aux_core_main.cc
@@ -84,13 +84,15 @@ extern "C" void aux_core_main() {
 		ui.preload_plugins(plugin_manager);
 	}
 
-	hil_message("*initialized\n");
-
 	// Signal that we're ready
 	printf("A7 Core 2 initialized\n");
 	print_time();
 
 	HWSemaphore<AuxCoreReady>::unlock();
+
+	// Wait for patch tests to be done
+	while (mdrivlib::HWSemaphore<RunningPatchTests>::is_locked())
+		;
 
 	ui.load_initial_patch();
 

--- a/firmware/src/core_a7/main.cc
+++ b/firmware/src/core_a7/main.cc
@@ -10,6 +10,7 @@
 #include "drivers/cache.hh"
 #include "git_version.h"
 #include "hsem_handler.hh"
+#include "load_test/test_manager.hh"
 #include "patch_file/file_storage_proxy.hh"
 #include "patch_play/patch_mod_queue.hh"
 #include "patch_play/patch_player.hh"
@@ -101,12 +102,21 @@ int main() {
 	printf("Using USB buffer\n");
 #endif
 
+	mdrivlib::HWSemaphore<RunningPatchTests>::lock();
+
 	// Tell other cores we're done with init
 	mdrivlib::HWSemaphore<MainCoreReady>::unlock();
 
 	// wait for other cores to be ready: ~2400ms + more for preloading plugins
 	while (mdrivlib::HWSemaphore<M4CoreReady>::is_locked() || mdrivlib::HWSemaphore<AuxCoreReady>::is_locked())
 		;
+
+	if (CpuLoadTest::should_run_tests(file_storage_proxy)) {
+		CpuLoadTest::run_patch_tests(file_storage_proxy);
+	}
+	mdrivlib::HWSemaphore<RunningPatchTests>::unlock();
+
+	hil_message("*initialized\n");
 
 	StaticBuffers::sync_params.clear();
 

--- a/firmware/src/core_a7/main.cc
+++ b/firmware/src/core_a7/main.cc
@@ -111,9 +111,10 @@ int main() {
 	while (mdrivlib::HWSemaphore<M4CoreReady>::is_locked() || mdrivlib::HWSemaphore<AuxCoreReady>::is_locked())
 		;
 
-	if (CpuLoadTest::should_run_tests(file_storage_proxy)) {
-		CpuLoadTest::run_patch_tests(file_storage_proxy);
+	if (CpuLoadTest::should_run_patch_tests(file_storage_proxy)) {
+		CpuLoadTest::run_patch_tests(patch_player, file_storage_proxy);
 	}
+
 	mdrivlib::HWSemaphore<RunningPatchTests>::unlock();
 
 	hil_message("*initialized\n");

--- a/firmware/src/load_test/test_manager.hh
+++ b/firmware/src/load_test/test_manager.hh
@@ -4,6 +4,7 @@
 #include "gui/ui.hh"
 #include "patch_file/file_storage_proxy.hh"
 #include "test_modules.hh"
+#include "test_patches.hh"
 
 namespace MetaModule
 {
@@ -17,46 +18,77 @@ struct CpuLoadTest {
 		std::string should_run;
 		FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
 
-		bool do_tests = false;
-
 		const auto run_all = should_run.starts_with("all\n");
+		const auto run_modules = run_all || should_run.starts_with("modules\n");
+		const auto run_patches = run_all || should_run.starts_with("patches\n");
 		const auto run_hil = should_run.starts_with("hil\n");
+
+		bool do_module_tests = run_modules;
+		bool do_patch_tests = run_patches;
+
 		if (run_hil) {
 			// TODO: auto load all plugins on USB drive
 			if (!preload_all_plugins(plugin_manager)) {
 				hil_message("*failure\n");
 				return;
 			}
-			do_tests = true;
+			do_module_tests = true;
 		}
 
-		if (run_all) {
+		if (run_modules || run_patches) {
 			ui.preload_plugins(plugin_manager);
-			do_tests = true;
 		}
 
 		// TODO: check file contents and only test brands that are in the file
 		// "Brand1\nBrand2\n" => only test Brand1 and Brand2
 
-		if (do_tests) {
+		if (do_module_tests || do_patch_tests) {
 			pr_info("A7 Core 2 running CPU load tests\n");
-
 			hil_message("*loadtesting\n");
+		}
 
-			// clear previous results files
-			FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test.csv", Volume::USB});
-			FS::write_file(file_storage_proxy, std::string(""), {"cpu_test_in_progress.csv", Volume::USB});
+		if (do_module_tests) {
+			run_module_tests(file_storage_proxy, ui);
+		}
 
-			std::string results;
-			results.reserve(1024 * 1024); // reserve a 1MB to reduce memory fragmentation
-			LoadTest::test_all_modules([&file_storage_proxy, &ui, &results](std::string_view csv_line) {
-				results += csv_line;
-				FS::append_file(file_storage_proxy, csv_line, {"cpu_test_in_progress.csv", Volume::USB});
-				ui.update_screen();
-			});
-			FS::write_file(file_storage_proxy, results, {"cpu_test.csv", Volume::USB});
+		if (do_patch_tests) {
+			run_patch_tests(file_storage_proxy, ui);
+		}
+
+		if (do_module_tests || do_patch_tests) {
 			hil_message("*success\n");
 		}
+	}
+
+	static void run_module_tests(FileStorageProxy &file_storage_proxy, Ui &ui) {
+		// clear previous results files
+		FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test.csv", Volume::USB});
+		FS::write_file(file_storage_proxy, std::string(""), {"cpu_test_in_progress.csv", Volume::USB});
+
+		std::string results;
+		results.reserve(1024 * 1024); // reserve a 1MB to reduce memory fragmentation
+		LoadTest::test_all_modules([&file_storage_proxy, &ui, &results](std::string_view csv_line) {
+			results += csv_line;
+			FS::append_file(file_storage_proxy, csv_line, {"cpu_test_in_progress.csv", Volume::USB});
+			ui.update_screen();
+		});
+		FS::write_file(file_storage_proxy, results, {"cpu_test.csv", Volume::USB});
+	}
+
+	static void run_patch_tests(FileStorageProxy &file_storage_proxy, Ui &ui) {
+		FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test_patches.csv", Volume::USB});
+		FS::write_file(file_storage_proxy, std::string(""), {"cpu_test_patches_in_progress.csv", Volume::USB});
+
+		std::string results;
+		results.reserve(64 * 1024);
+		LoadTest::test_all_patches(
+			file_storage_proxy, [&file_storage_proxy, &ui, &results](std::string_view csv_line) {
+				results += csv_line;
+				FS::append_file(
+					file_storage_proxy, csv_line, {"cpu_test_patches_in_progress.csv", Volume::USB});
+				ui.update_screen();
+			});
+		FS::write_file(file_storage_proxy, results, {"cpu_test_patches.csv", Volume::USB});
 	}
 
 	static bool preload_all_plugins(PluginManager &plugin_manager) {

--- a/firmware/src/load_test/test_manager.hh
+++ b/firmware/src/load_test/test_manager.hh
@@ -10,12 +10,25 @@ namespace MetaModule
 {
 
 struct CpuLoadTest {
-	static bool should_run_tests(FileStorageProxy &file_storage_proxy) {
-		return FS::file_size(file_storage_proxy, {"run_cpu_tests", Volume::USB}).has_value();
+	static bool should_run_hil_tests(FileStorageProxy &file_storage_proxy) {
+		if (FS::file_size(file_storage_proxy, {"run_cpu_tests", Volume::USB}).has_value()) {
+			std::string should_run;
+			FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
+			return should_run.starts_with("hil\n");
+		}
+		return false;
+	}
+	static bool should_run_module_tests(FileStorageProxy &file_storage_proxy) {
+		if (FS::file_size(file_storage_proxy, {"run_cpu_tests", Volume::USB}).has_value()) {
+			std::string should_run;
+			FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
+			return should_run.starts_with("all\n") || should_run.starts_with("modules\n");
+		}
+		return false;
 	}
 
 	static bool should_run_patch_tests(FileStorageProxy &file_storage_proxy) {
-		if (should_run_tests(file_storage_proxy)) {
+		if (FS::file_size(file_storage_proxy, {"run_cpu_tests", Volume::USB}).has_value()) {
 			std::string should_run;
 			FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
 			return should_run.starts_with("all\n") || should_run.starts_with("patches\n");
@@ -23,43 +36,25 @@ struct CpuLoadTest {
 		return false;
 	}
 
-	static void run_tests(FileStorageProxy &file_storage_proxy, Ui &ui, PluginManager &plugin_manager) {
-		std::string should_run;
-		FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
-		// TODO: check file contents and only test brands that are in the file
-		// "Brand1\nBrand2\n" => only test Brand1 and Brand2
+	static void run_hil_tests(FileStorageProxy &file_storage_proxy, Ui &ui, PluginManager &plugin_manager) {
+		pr_info("Running HIL CPU load tests\n");
 
-		const auto run_all = should_run.starts_with("all\n");
-		const auto run_modules = run_all || should_run.starts_with("modules\n");
-		const auto run_patches = run_all || should_run.starts_with("patches\n");
-		const auto run_hil = should_run.starts_with("hil\n");
-
-		bool do_module_tests = run_modules;
-
-		if (run_hil) {
-			// TODO: auto load all plugins on USB drive
-			if (!preload_all_plugins(plugin_manager)) {
-				hil_message("*failure\n");
-				return;
-			}
-			do_module_tests = true;
+		if (!preload_all_plugins(plugin_manager)) {
+			pr_err("Failed preloading plugins for HIL CPU load tests\n");
+			hil_message("*failure\n");
+			return;
 		}
+		hil_message("*loadtesting\n");
 
-		if (run_modules || run_patches) {
-			ui.preload_plugins(plugin_manager);
-		}
-
-		if (do_module_tests) {
-			pr_info("A7 Core 2 running CPU load tests\n");
-			hil_message("*loadtesting\n");
-			run_module_tests(file_storage_proxy, ui);
-		}
+		run_module_tests(file_storage_proxy, ui);
 	}
 
 	static void run_module_tests(FileStorageProxy &file_storage_proxy, Ui &ui) {
+		pr_info("Running module CPU load tests\n");
+
 		// clear previous results files
 		FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test.csv", Volume::USB});
-		FS::write_file(file_storage_proxy, std::string(""), {"cpu_test_in_progress.csv", Volume::USB});
+		FS::write_file(file_storage_proxy, std::string("\n"), {"cpu_test_in_progress.csv", Volume::USB});
 
 		std::string results;
 		results.reserve(1024 * 1024); // reserve a 1MB to reduce memory fragmentation
@@ -72,16 +67,18 @@ struct CpuLoadTest {
 		hil_message("*success\n");
 	}
 
-	static void run_patch_tests(FileStorageProxy &file_storage_proxy) {
+	static void run_patch_tests(PatchPlayer &player, FileStorageProxy &file_storage_proxy) {
+		pr_info("Running patch CPU load tests\n");
 		FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test_patches.csv", Volume::USB});
-		FS::write_file(file_storage_proxy, std::string(""), {"cpu_test_patches_in_progress.csv", Volume::USB});
+		FS::write_file(file_storage_proxy, std::string("\n"), {"cpu_test_patches_in_progress.csv", Volume::USB});
 
 		std::string results;
 		results.reserve(64 * 1024);
-		LoadTest::test_all_patches(file_storage_proxy, [&file_storage_proxy, &results](std::string_view csv_line) {
-			results += csv_line;
-			FS::append_file(file_storage_proxy, csv_line, {"cpu_test_patches_in_progress.csv", Volume::USB});
-		});
+		LoadTest::test_all_patches(
+			player, file_storage_proxy, [&file_storage_proxy, &results](std::string_view csv_line) {
+				results += csv_line;
+				FS::append_file(file_storage_proxy, csv_line, {"cpu_test_patches_in_progress.csv", Volume::USB});
+			});
 		FS::write_file(file_storage_proxy, results, {"cpu_test_patches.csv", Volume::USB});
 		hil_message("*success\n");
 	}

--- a/firmware/src/load_test/test_manager.hh
+++ b/firmware/src/load_test/test_manager.hh
@@ -14,9 +14,20 @@ struct CpuLoadTest {
 		return FS::file_size(file_storage_proxy, {"run_cpu_tests", Volume::USB}).has_value();
 	}
 
+	static bool should_run_patch_tests(FileStorageProxy &file_storage_proxy) {
+		if (should_run_tests(file_storage_proxy)) {
+			std::string should_run;
+			FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
+			return should_run.starts_with("all\n") || should_run.starts_with("patches\n");
+		}
+		return false;
+	}
+
 	static void run_tests(FileStorageProxy &file_storage_proxy, Ui &ui, PluginManager &plugin_manager) {
 		std::string should_run;
 		FS::read_file(file_storage_proxy, should_run, {"run_cpu_tests", Volume::USB});
+		// TODO: check file contents and only test brands that are in the file
+		// "Brand1\nBrand2\n" => only test Brand1 and Brand2
 
 		const auto run_all = should_run.starts_with("all\n");
 		const auto run_modules = run_all || should_run.starts_with("modules\n");
@@ -24,7 +35,6 @@ struct CpuLoadTest {
 		const auto run_hil = should_run.starts_with("hil\n");
 
 		bool do_module_tests = run_modules;
-		bool do_patch_tests = run_patches;
 
 		if (run_hil) {
 			// TODO: auto load all plugins on USB drive
@@ -39,24 +49,10 @@ struct CpuLoadTest {
 			ui.preload_plugins(plugin_manager);
 		}
 
-		// TODO: check file contents and only test brands that are in the file
-		// "Brand1\nBrand2\n" => only test Brand1 and Brand2
-
-		if (do_module_tests || do_patch_tests) {
+		if (do_module_tests) {
 			pr_info("A7 Core 2 running CPU load tests\n");
 			hil_message("*loadtesting\n");
-		}
-
-		if (do_module_tests) {
 			run_module_tests(file_storage_proxy, ui);
-		}
-
-		if (do_patch_tests) {
-			run_patch_tests(file_storage_proxy, ui);
-		}
-
-		if (do_module_tests || do_patch_tests) {
-			hil_message("*success\n");
 		}
 	}
 
@@ -73,22 +69,21 @@ struct CpuLoadTest {
 			ui.update_screen();
 		});
 		FS::write_file(file_storage_proxy, results, {"cpu_test.csv", Volume::USB});
+		hil_message("*success\n");
 	}
 
-	static void run_patch_tests(FileStorageProxy &file_storage_proxy, Ui &ui) {
+	static void run_patch_tests(FileStorageProxy &file_storage_proxy) {
 		FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test_patches.csv", Volume::USB});
 		FS::write_file(file_storage_proxy, std::string(""), {"cpu_test_patches_in_progress.csv", Volume::USB});
 
 		std::string results;
 		results.reserve(64 * 1024);
-		LoadTest::test_all_patches(
-			file_storage_proxy, [&file_storage_proxy, &ui, &results](std::string_view csv_line) {
-				results += csv_line;
-				FS::append_file(
-					file_storage_proxy, csv_line, {"cpu_test_patches_in_progress.csv", Volume::USB});
-				ui.update_screen();
-			});
+		LoadTest::test_all_patches(file_storage_proxy, [&file_storage_proxy, &results](std::string_view csv_line) {
+			results += csv_line;
+			FS::append_file(file_storage_proxy, csv_line, {"cpu_test_patches_in_progress.csv", Volume::USB});
+		});
 		FS::write_file(file_storage_proxy, results, {"cpu_test_patches.csv", Volume::USB});
+		hil_message("*success\n");
 	}
 
 	static bool preload_all_plugins(PluginManager &plugin_manager) {

--- a/firmware/src/load_test/test_patches.hh
+++ b/firmware/src/load_test/test_patches.hh
@@ -1,0 +1,232 @@
+#pragma once
+#include "console/pr_dbg.hh"
+#include "fs/dir_tree.hh"
+#include "fs/general_io.hh"
+#include "gui/helpers/lv_helpers.hh"
+#include "gui/slsexport/meta5/ui.h"
+#include "patch-serial/yaml_to_patch.hh"
+#include "patch/patch_data.hh"
+#include "patch_file/file_storage_proxy.hh"
+#include "patch_file/patches_default.hh"
+#include "patch_play/patch_player.hh"
+#include "static_buffers.hh"
+#include "tester.hh"
+#include <chrono>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace MetaModule::LoadTest
+{
+
+struct PatchEntry {
+	static constexpr std::array<unsigned, 5> blocksizes{32, 64, 128, 256, 512};
+	std::string name;
+	bool load_failed{false};
+	std::array<ModuleLoadTester::Measurements, blocksizes.size()> times;
+};
+
+inline std::string patches_csv_header() {
+	std::string s = "Patch,";
+	pr_info("Patch,");
+	for (unsigned int blocksize : PatchEntry::blocksizes) {
+		s += "Block-" + std::to_string(blocksize) + ",";
+		pr_info("Block-%u,", blocksize);
+	}
+	if (s.ends_with(","))
+		s.pop_back();
+	s += "\n";
+	pr_info("\n");
+	return s;
+}
+
+inline std::string patch_entry_to_csv(PatchEntry const &entry) {
+	constexpr float sampletime = 1'000'000.f / 48000.f;
+
+	std::string s = entry.name + ",";
+	pr_info("%s,", entry.name.c_str());
+
+	if (entry.load_failed) {
+		for (auto i = 0u; i < PatchEntry::blocksizes.size(); i++) {
+			s += "FAIL,";
+			pr_info("FAIL,");
+		}
+	} else {
+		for (auto const &m : entry.times) {
+			char buf[16];
+			snprintf(buf, 16, "%.3f,", m.average_run_time_after_first / sampletime);
+			s += buf;
+			pr_info("%.3f,", m.average_run_time_after_first / sampletime);
+		}
+	}
+
+	if (s.ends_with(","))
+		s.pop_back();
+	s += "\n";
+	pr_info("\n");
+	return s;
+}
+
+// Runs PatchPlayer::update_patch() for 2048 total iterations,
+// grouped in chunks of block_size, reporting the worst per-chunk averages.
+inline ModuleLoadTester::Measurements run_loaded_patch(PatchPlayer &player, size_t block_size) {
+	constexpr size_t min_total_iterations = 2048;
+
+	std::vector<uint64_t> times(block_size, 0);
+	ModuleLoadTester::Measurements worst{};
+
+	size_t iterations = 0;
+	while (iterations < min_total_iterations) {
+		for (auto &tm : times) {
+			tm = ModuleLoadTester::measure([&]() { player.update_patch(); });
+		}
+
+		auto current = ModuleLoadTester::Measurements{times};
+
+		worst.first_run_time = std::max(worst.first_run_time, current.first_run_time);
+		worst.average_run_time = std::max(worst.average_run_time, current.average_run_time);
+		worst.worst_run_time_after_first =
+			std::max(worst.worst_run_time_after_first, current.worst_run_time_after_first);
+		worst.average_run_time_after_first =
+			std::max(worst.average_run_time_after_first, current.average_run_time_after_first);
+
+		iterations += block_size;
+	}
+
+	return worst;
+}
+
+inline void run_patch_entry(PatchPlayer &player, PatchData &pd, PatchEntry &entry) {
+	auto res = player.load_patch(pd);
+	if (!res.success) {
+		pr_err("Patch '%s' failed to load: %s\n", entry.name.c_str(), res.error_string.c_str());
+		entry.load_failed = true;
+		return;
+	}
+
+	for (auto i = 0u; auto blocksize : PatchEntry::blocksizes) {
+		hil_message("*ok\n");
+		pr_trace("Patch '%s' block size %u\n", entry.name.c_str(), blocksize);
+		entry.times[i] = run_loaded_patch(player, blocksize);
+		i++;
+	}
+
+	if (player.is_loaded)
+		player.unload_patch();
+}
+
+inline void test_default_patches(PatchPlayer &player, auto append_file) {
+	for (uint32_t i = 0; i < DefaultPatches::num_patches(); i++) {
+		auto raw = DefaultPatches::get_patch(i);
+		auto filename = DefaultPatches::get_filename(i);
+
+		// Strip trailing null terminators so the YAML parser doesn't see them
+		while (!raw.empty() && raw.back() == '\0')
+			raw = raw.subspan(0, raw.size() - 1);
+
+		PatchEntry entry;
+		entry.name = filename.c_str();
+
+		printf("Testing patch %s\n", entry.name.c_str());
+		lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.name.c_str());
+
+		// yaml_raw_to_patch parses in place, so make a writable copy
+		std::string yaml(raw.data(), raw.size());
+
+		PatchData pd;
+		if (!yaml_raw_to_patch(yaml.data(), yaml.size(), pd)) {
+			pr_err("Failed to parse default patch '%s'\n", entry.name.c_str());
+			entry.load_failed = true;
+		} else {
+			pd.trim_empty_knobsets();
+			pd.update_midi_poly_num();
+			run_patch_entry(player, pd, entry);
+		}
+
+		append_file(patch_entry_to_csv(entry));
+	}
+}
+
+inline bool request_test_patch_dir(FileStorageProxy &file_storage_proxy, DirTree<FileEntry> &dir_tree) {
+	uint32_t timeout = get_time();
+	while (!file_storage_proxy.request_dir_entries(&dir_tree, Volume::USB, "test-patches", "yml")) {
+		if (get_time() - timeout > 1000) {
+			pr_err("Dir entries request not made in 1 second\n");
+			return false;
+		}
+	}
+
+	timeout = get_time();
+	while (true) {
+		auto msg = file_storage_proxy.get_message();
+		if (msg.message_type == FileStorageProxy::DirEntriesSuccess)
+			return true;
+		if (msg.message_type == FileStorageProxy::DirEntriesFailed) {
+			pr_err("Dir entries request failed for test-patches/\n");
+			return false;
+		}
+		if (get_time() - timeout > 4000) {
+			pr_err("Dir entries request not responded to in 4 seconds\n");
+			return false;
+		}
+	}
+}
+
+inline void
+test_usb_patches(FileStorageProxy &file_storage_proxy, PatchPlayer &player, auto append_file) {
+	auto &dir_tree = StaticBuffers::dir_tree;
+	dir_tree = DirTree<FileEntry>{};
+
+	if (!request_test_patch_dir(file_storage_proxy, dir_tree)) {
+		pr_info("No test-patches/ directory found on USB drive\n");
+		return;
+	}
+
+	pr_info("Found %zu patch files in test-patches/\n", dir_tree.files.size());
+
+	for (auto const &file : dir_tree.files) {
+		PatchEntry entry;
+		entry.name = file.filename;
+
+		printf("Testing patch %s\n", entry.name.c_str());
+		lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.name.c_str());
+
+		std::string filedata;
+		auto path = "test-patches/" + file.filename;
+		auto bytes_read = FS::read_file(file_storage_proxy, filedata, {path, Volume::USB});
+		if (!bytes_read || *bytes_read == 0) {
+			pr_err("Failed to read patch file '%s'\n", path.c_str());
+			entry.load_failed = true;
+			append_file(patch_entry_to_csv(entry));
+			continue;
+		}
+
+		PatchData pd;
+		if (!yaml_string_to_patch(std::move(filedata), pd)) {
+			pr_err("Failed to parse patch file '%s'\n", path.c_str());
+			entry.load_failed = true;
+		} else {
+			pd.trim_empty_knobsets();
+			pd.update_midi_poly_num();
+			run_patch_entry(player, pd, entry);
+		}
+
+		append_file(patch_entry_to_csv(entry));
+	}
+}
+
+inline void test_all_patches(FileStorageProxy &file_storage_proxy, auto append_file) {
+	lv_show(ui_MainMenuNowPlayingPanel);
+	lv_show(ui_MainMenuNowPlaying);
+
+	append_file(patches_csv_header());
+
+	PatchPlayer player;
+
+	test_default_patches(player, append_file);
+	test_usb_patches(file_storage_proxy, player, append_file);
+
+	lv_label_set_text(ui_MainMenuNowPlaying, "Finished patch load tests");
+}
+
+} // namespace MetaModule::LoadTest

--- a/firmware/src/load_test/test_patches.hh
+++ b/firmware/src/load_test/test_patches.hh
@@ -172,8 +172,7 @@ inline bool request_test_patch_dir(FileStorageProxy &file_storage_proxy, DirTree
 	}
 }
 
-inline void
-test_usb_patches(FileStorageProxy &file_storage_proxy, PatchPlayer &player, auto append_file) {
+inline void test_usb_patches(FileStorageProxy &file_storage_proxy, PatchPlayer &player, auto append_file) {
 	auto &dir_tree = StaticBuffers::dir_tree;
 	dir_tree = DirTree<FileEntry>{};
 
@@ -215,13 +214,11 @@ test_usb_patches(FileStorageProxy &file_storage_proxy, PatchPlayer &player, auto
 	}
 }
 
-inline void test_all_patches(FileStorageProxy &file_storage_proxy, auto append_file) {
+inline void test_all_patches(PatchPlayer &player, FileStorageProxy &file_storage_proxy, auto append_file) {
 	lv_show(ui_MainMenuNowPlayingPanel);
 	lv_show(ui_MainMenuNowPlaying);
 
 	append_file(patches_csv_header());
-
-	PatchPlayer player;
 
 	test_default_patches(player, append_file);
 	test_usb_patches(file_storage_proxy, player, append_file);

--- a/firmware/src/load_test/test_patches.hh
+++ b/firmware/src/load_test/test_patches.hh
@@ -44,26 +44,25 @@ inline std::string patch_entry_to_csv(PatchEntry const &entry) {
 	constexpr float sampletime = 1'000'000.f / 48000.f;
 
 	std::string s = entry.name + ",";
-	pr_info("%s,", entry.name.c_str());
 
 	if (entry.load_failed) {
 		for (auto i = 0u; i < PatchEntry::blocksizes.size(); i++) {
 			s += "FAIL,";
-			pr_info("FAIL,");
 		}
 	} else {
 		for (auto const &m : entry.times) {
 			char buf[16];
-			snprintf(buf, 16, "%.3f,", m.average_run_time_after_first / sampletime);
+			snprintf(buf, 16, "%.3f,", m.average_run_time / sampletime);
 			s += buf;
-			pr_info("%.3f,", m.average_run_time_after_first / sampletime);
 		}
 	}
 
 	if (s.ends_with(","))
 		s.pop_back();
 	s += "\n";
-	pr_info("\n");
+
+	pr_info("%s", s.c_str());
+
 	return s;
 }
 
@@ -80,7 +79,6 @@ inline ModuleLoadTester::Measurements run_loaded_patch(PatchPlayer &player, size
 		for (auto &tm : times) {
 			tm = ModuleLoadTester::measure([&]() { player.update_patch(); });
 		}
-
 		auto current = ModuleLoadTester::Measurements{times};
 
 		worst.first_run_time = std::max(worst.first_run_time, current.first_run_time);
@@ -89,6 +87,12 @@ inline ModuleLoadTester::Measurements run_loaded_patch(PatchPlayer &player, size
 			std::max(worst.worst_run_time_after_first, current.worst_run_time_after_first);
 		worst.average_run_time_after_first =
 			std::max(worst.average_run_time_after_first, current.average_run_time_after_first);
+
+		pr_info("it %d: avg:%f first:%llu worst(>1):%llu\n",
+				iterations,
+				worst.average_run_time,
+				worst.first_run_time,
+				worst.worst_run_time_after_first);
 
 		iterations += block_size;
 	}
@@ -127,19 +131,17 @@ inline void test_default_patches(PatchPlayer &player, auto append_file) {
 		PatchEntry entry;
 		entry.name = filename.c_str();
 
-		printf("Testing patch %s\n", entry.name.c_str());
+		pr_info("Testing patch %s\n", entry.name.c_str());
 		lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.name.c_str());
 
 		// yaml_raw_to_patch parses in place, so make a writable copy
-		std::string yaml(raw.data(), raw.size());
-
 		PatchData pd;
+
+		std::string yaml(raw.data(), raw.size());
 		if (!yaml_raw_to_patch(yaml.data(), yaml.size(), pd)) {
 			pr_err("Failed to parse default patch '%s'\n", entry.name.c_str());
 			entry.load_failed = true;
 		} else {
-			pd.trim_empty_knobsets();
-			pd.update_midi_poly_num();
 			run_patch_entry(player, pd, entry);
 		}
 
@@ -187,7 +189,7 @@ inline void test_usb_patches(FileStorageProxy &file_storage_proxy, PatchPlayer &
 		PatchEntry entry;
 		entry.name = file.filename;
 
-		printf("Testing patch %s\n", entry.name.c_str());
+		pr_info("Testing patch %s\n", entry.name.c_str());
 		lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.name.c_str());
 
 		std::string filedata;

--- a/patches/feature_tests/InternalCableTest.yml
+++ b/patches/feature_tests/InternalCableTest.yml
@@ -1,0 +1,662 @@
+PatchData:
+  patch_name: InternalCableTest
+  description: Benchmark - 50 Atvert2 modules chained in series (Out1->In1, Out2->In2), with panel jacks on the first and last modules
+  module_slugs:
+    0: '4msCompany:HubMedium'
+    1: '4msCompany:Atvert2'
+    2: '4msCompany:Atvert2'
+    3: '4msCompany:Atvert2'
+    4: '4msCompany:Atvert2'
+    5: '4msCompany:Atvert2'
+    6: '4msCompany:Atvert2'
+    7: '4msCompany:Atvert2'
+    8: '4msCompany:Atvert2'
+    9: '4msCompany:Atvert2'
+    10: '4msCompany:Atvert2'
+    11: '4msCompany:Atvert2'
+    12: '4msCompany:Atvert2'
+    13: '4msCompany:Atvert2'
+    14: '4msCompany:Atvert2'
+    15: '4msCompany:Atvert2'
+    16: '4msCompany:Atvert2'
+    17: '4msCompany:Atvert2'
+    18: '4msCompany:Atvert2'
+    19: '4msCompany:Atvert2'
+    20: '4msCompany:Atvert2'
+    21: '4msCompany:Atvert2'
+    22: '4msCompany:Atvert2'
+    23: '4msCompany:Atvert2'
+    24: '4msCompany:Atvert2'
+    25: '4msCompany:Atvert2'
+    26: '4msCompany:Atvert2'
+    27: '4msCompany:Atvert2'
+    28: '4msCompany:Atvert2'
+    29: '4msCompany:Atvert2'
+    30: '4msCompany:Atvert2'
+    31: '4msCompany:Atvert2'
+    32: '4msCompany:Atvert2'
+    33: '4msCompany:Atvert2'
+    34: '4msCompany:Atvert2'
+    35: '4msCompany:Atvert2'
+    36: '4msCompany:Atvert2'
+    37: '4msCompany:Atvert2'
+    38: '4msCompany:Atvert2'
+    39: '4msCompany:Atvert2'
+    40: '4msCompany:Atvert2'
+    41: '4msCompany:Atvert2'
+    42: '4msCompany:Atvert2'
+    43: '4msCompany:Atvert2'
+    44: '4msCompany:Atvert2'
+    45: '4msCompany:Atvert2'
+    46: '4msCompany:Atvert2'
+    47: '4msCompany:Atvert2'
+    48: '4msCompany:Atvert2'
+    49: '4msCompany:Atvert2'
+    50: '4msCompany:Atvert2'
+  int_cables:
+    - out:
+        module_id: 1
+        jack_id: 0
+      ins:
+        - module_id: 2
+          jack_id: 0
+    - out:
+        module_id: 1
+        jack_id: 1
+      ins:
+        - module_id: 2
+          jack_id: 1
+    - out:
+        module_id: 2
+        jack_id: 0
+      ins:
+        - module_id: 3
+          jack_id: 0
+    - out:
+        module_id: 2
+        jack_id: 1
+      ins:
+        - module_id: 3
+          jack_id: 1
+    - out:
+        module_id: 3
+        jack_id: 0
+      ins:
+        - module_id: 4
+          jack_id: 0
+    - out:
+        module_id: 3
+        jack_id: 1
+      ins:
+        - module_id: 4
+          jack_id: 1
+    - out:
+        module_id: 4
+        jack_id: 0
+      ins:
+        - module_id: 5
+          jack_id: 0
+    - out:
+        module_id: 4
+        jack_id: 1
+      ins:
+        - module_id: 5
+          jack_id: 1
+    - out:
+        module_id: 5
+        jack_id: 0
+      ins:
+        - module_id: 6
+          jack_id: 0
+    - out:
+        module_id: 5
+        jack_id: 1
+      ins:
+        - module_id: 6
+          jack_id: 1
+    - out:
+        module_id: 6
+        jack_id: 0
+      ins:
+        - module_id: 7
+          jack_id: 0
+    - out:
+        module_id: 6
+        jack_id: 1
+      ins:
+        - module_id: 7
+          jack_id: 1
+    - out:
+        module_id: 7
+        jack_id: 0
+      ins:
+        - module_id: 8
+          jack_id: 0
+    - out:
+        module_id: 7
+        jack_id: 1
+      ins:
+        - module_id: 8
+          jack_id: 1
+    - out:
+        module_id: 8
+        jack_id: 0
+      ins:
+        - module_id: 9
+          jack_id: 0
+    - out:
+        module_id: 8
+        jack_id: 1
+      ins:
+        - module_id: 9
+          jack_id: 1
+    - out:
+        module_id: 9
+        jack_id: 0
+      ins:
+        - module_id: 10
+          jack_id: 0
+    - out:
+        module_id: 9
+        jack_id: 1
+      ins:
+        - module_id: 10
+          jack_id: 1
+    - out:
+        module_id: 10
+        jack_id: 0
+      ins:
+        - module_id: 11
+          jack_id: 0
+    - out:
+        module_id: 10
+        jack_id: 1
+      ins:
+        - module_id: 11
+          jack_id: 1
+    - out:
+        module_id: 11
+        jack_id: 0
+      ins:
+        - module_id: 12
+          jack_id: 0
+    - out:
+        module_id: 11
+        jack_id: 1
+      ins:
+        - module_id: 12
+          jack_id: 1
+    - out:
+        module_id: 12
+        jack_id: 0
+      ins:
+        - module_id: 13
+          jack_id: 0
+    - out:
+        module_id: 12
+        jack_id: 1
+      ins:
+        - module_id: 13
+          jack_id: 1
+    - out:
+        module_id: 13
+        jack_id: 0
+      ins:
+        - module_id: 14
+          jack_id: 0
+    - out:
+        module_id: 13
+        jack_id: 1
+      ins:
+        - module_id: 14
+          jack_id: 1
+    - out:
+        module_id: 14
+        jack_id: 0
+      ins:
+        - module_id: 15
+          jack_id: 0
+    - out:
+        module_id: 14
+        jack_id: 1
+      ins:
+        - module_id: 15
+          jack_id: 1
+    - out:
+        module_id: 15
+        jack_id: 0
+      ins:
+        - module_id: 16
+          jack_id: 0
+    - out:
+        module_id: 15
+        jack_id: 1
+      ins:
+        - module_id: 16
+          jack_id: 1
+    - out:
+        module_id: 16
+        jack_id: 0
+      ins:
+        - module_id: 17
+          jack_id: 0
+    - out:
+        module_id: 16
+        jack_id: 1
+      ins:
+        - module_id: 17
+          jack_id: 1
+    - out:
+        module_id: 17
+        jack_id: 0
+      ins:
+        - module_id: 18
+          jack_id: 0
+    - out:
+        module_id: 17
+        jack_id: 1
+      ins:
+        - module_id: 18
+          jack_id: 1
+    - out:
+        module_id: 18
+        jack_id: 0
+      ins:
+        - module_id: 19
+          jack_id: 0
+    - out:
+        module_id: 18
+        jack_id: 1
+      ins:
+        - module_id: 19
+          jack_id: 1
+    - out:
+        module_id: 19
+        jack_id: 0
+      ins:
+        - module_id: 20
+          jack_id: 0
+    - out:
+        module_id: 19
+        jack_id: 1
+      ins:
+        - module_id: 20
+          jack_id: 1
+    - out:
+        module_id: 20
+        jack_id: 0
+      ins:
+        - module_id: 21
+          jack_id: 0
+    - out:
+        module_id: 20
+        jack_id: 1
+      ins:
+        - module_id: 21
+          jack_id: 1
+    - out:
+        module_id: 21
+        jack_id: 0
+      ins:
+        - module_id: 22
+          jack_id: 0
+    - out:
+        module_id: 21
+        jack_id: 1
+      ins:
+        - module_id: 22
+          jack_id: 1
+    - out:
+        module_id: 22
+        jack_id: 0
+      ins:
+        - module_id: 23
+          jack_id: 0
+    - out:
+        module_id: 22
+        jack_id: 1
+      ins:
+        - module_id: 23
+          jack_id: 1
+    - out:
+        module_id: 23
+        jack_id: 0
+      ins:
+        - module_id: 24
+          jack_id: 0
+    - out:
+        module_id: 23
+        jack_id: 1
+      ins:
+        - module_id: 24
+          jack_id: 1
+    - out:
+        module_id: 24
+        jack_id: 0
+      ins:
+        - module_id: 25
+          jack_id: 0
+    - out:
+        module_id: 24
+        jack_id: 1
+      ins:
+        - module_id: 25
+          jack_id: 1
+    - out:
+        module_id: 25
+        jack_id: 0
+      ins:
+        - module_id: 26
+          jack_id: 0
+    - out:
+        module_id: 25
+        jack_id: 1
+      ins:
+        - module_id: 26
+          jack_id: 1
+    - out:
+        module_id: 26
+        jack_id: 0
+      ins:
+        - module_id: 27
+          jack_id: 0
+    - out:
+        module_id: 26
+        jack_id: 1
+      ins:
+        - module_id: 27
+          jack_id: 1
+    - out:
+        module_id: 27
+        jack_id: 0
+      ins:
+        - module_id: 28
+          jack_id: 0
+    - out:
+        module_id: 27
+        jack_id: 1
+      ins:
+        - module_id: 28
+          jack_id: 1
+    - out:
+        module_id: 28
+        jack_id: 0
+      ins:
+        - module_id: 29
+          jack_id: 0
+    - out:
+        module_id: 28
+        jack_id: 1
+      ins:
+        - module_id: 29
+          jack_id: 1
+    - out:
+        module_id: 29
+        jack_id: 0
+      ins:
+        - module_id: 30
+          jack_id: 0
+    - out:
+        module_id: 29
+        jack_id: 1
+      ins:
+        - module_id: 30
+          jack_id: 1
+    - out:
+        module_id: 30
+        jack_id: 0
+      ins:
+        - module_id: 31
+          jack_id: 0
+    - out:
+        module_id: 30
+        jack_id: 1
+      ins:
+        - module_id: 31
+          jack_id: 1
+    - out:
+        module_id: 31
+        jack_id: 0
+      ins:
+        - module_id: 32
+          jack_id: 0
+    - out:
+        module_id: 31
+        jack_id: 1
+      ins:
+        - module_id: 32
+          jack_id: 1
+    - out:
+        module_id: 32
+        jack_id: 0
+      ins:
+        - module_id: 33
+          jack_id: 0
+    - out:
+        module_id: 32
+        jack_id: 1
+      ins:
+        - module_id: 33
+          jack_id: 1
+    - out:
+        module_id: 33
+        jack_id: 0
+      ins:
+        - module_id: 34
+          jack_id: 0
+    - out:
+        module_id: 33
+        jack_id: 1
+      ins:
+        - module_id: 34
+          jack_id: 1
+    - out:
+        module_id: 34
+        jack_id: 0
+      ins:
+        - module_id: 35
+          jack_id: 0
+    - out:
+        module_id: 34
+        jack_id: 1
+      ins:
+        - module_id: 35
+          jack_id: 1
+    - out:
+        module_id: 35
+        jack_id: 0
+      ins:
+        - module_id: 36
+          jack_id: 0
+    - out:
+        module_id: 35
+        jack_id: 1
+      ins:
+        - module_id: 36
+          jack_id: 1
+    - out:
+        module_id: 36
+        jack_id: 0
+      ins:
+        - module_id: 37
+          jack_id: 0
+    - out:
+        module_id: 36
+        jack_id: 1
+      ins:
+        - module_id: 37
+          jack_id: 1
+    - out:
+        module_id: 37
+        jack_id: 0
+      ins:
+        - module_id: 38
+          jack_id: 0
+    - out:
+        module_id: 37
+        jack_id: 1
+      ins:
+        - module_id: 38
+          jack_id: 1
+    - out:
+        module_id: 38
+        jack_id: 0
+      ins:
+        - module_id: 39
+          jack_id: 0
+    - out:
+        module_id: 38
+        jack_id: 1
+      ins:
+        - module_id: 39
+          jack_id: 1
+    - out:
+        module_id: 39
+        jack_id: 0
+      ins:
+        - module_id: 40
+          jack_id: 0
+    - out:
+        module_id: 39
+        jack_id: 1
+      ins:
+        - module_id: 40
+          jack_id: 1
+    - out:
+        module_id: 40
+        jack_id: 0
+      ins:
+        - module_id: 41
+          jack_id: 0
+    - out:
+        module_id: 40
+        jack_id: 1
+      ins:
+        - module_id: 41
+          jack_id: 1
+    - out:
+        module_id: 41
+        jack_id: 0
+      ins:
+        - module_id: 42
+          jack_id: 0
+    - out:
+        module_id: 41
+        jack_id: 1
+      ins:
+        - module_id: 42
+          jack_id: 1
+    - out:
+        module_id: 42
+        jack_id: 0
+      ins:
+        - module_id: 43
+          jack_id: 0
+    - out:
+        module_id: 42
+        jack_id: 1
+      ins:
+        - module_id: 43
+          jack_id: 1
+    - out:
+        module_id: 43
+        jack_id: 0
+      ins:
+        - module_id: 44
+          jack_id: 0
+    - out:
+        module_id: 43
+        jack_id: 1
+      ins:
+        - module_id: 44
+          jack_id: 1
+    - out:
+        module_id: 44
+        jack_id: 0
+      ins:
+        - module_id: 45
+          jack_id: 0
+    - out:
+        module_id: 44
+        jack_id: 1
+      ins:
+        - module_id: 45
+          jack_id: 1
+    - out:
+        module_id: 45
+        jack_id: 0
+      ins:
+        - module_id: 46
+          jack_id: 0
+    - out:
+        module_id: 45
+        jack_id: 1
+      ins:
+        - module_id: 46
+          jack_id: 1
+    - out:
+        module_id: 46
+        jack_id: 0
+      ins:
+        - module_id: 47
+          jack_id: 0
+    - out:
+        module_id: 46
+        jack_id: 1
+      ins:
+        - module_id: 47
+          jack_id: 1
+    - out:
+        module_id: 47
+        jack_id: 0
+      ins:
+        - module_id: 48
+          jack_id: 0
+    - out:
+        module_id: 47
+        jack_id: 1
+      ins:
+        - module_id: 48
+          jack_id: 1
+    - out:
+        module_id: 48
+        jack_id: 0
+      ins:
+        - module_id: 49
+          jack_id: 0
+    - out:
+        module_id: 48
+        jack_id: 1
+      ins:
+        - module_id: 49
+          jack_id: 1
+    - out:
+        module_id: 49
+        jack_id: 0
+      ins:
+        - module_id: 50
+          jack_id: 0
+    - out:
+        module_id: 49
+        jack_id: 1
+      ins:
+        - module_id: 50
+          jack_id: 1
+  mapped_ins:
+    - panel_jack_id: 0
+      ins:
+        - module_id: 1
+          jack_id: 0
+    - panel_jack_id: 1
+      ins:
+        - module_id: 1
+          jack_id: 1
+  mapped_outs:
+    - panel_jack_id: 0
+      out:
+        module_id: 50
+        jack_id: 0
+    - panel_jack_id: 1
+      out:
+        module_id: 50
+        jack_id: 1

--- a/patches/feature_tests/PanelJackSplits.yml
+++ b/patches/feature_tests/PanelJackSplits.yml
@@ -1,0 +1,235 @@
+PatchData:
+  patch_name: PanelJackSplits
+  description: Benchmark - 14 panel inputs each fan out to 4 StMix inputs (7 StMix total), 16 panel outputs each sourced from a MultiLFO (16 MultiLFO total)
+  module_slugs:
+    0: '4msCompany:HubMedium'
+    1: '4msCompany:StMix'
+    2: '4msCompany:StMix'
+    3: '4msCompany:StMix'
+    4: '4msCompany:StMix'
+    5: '4msCompany:StMix'
+    6: '4msCompany:StMix'
+    7: '4msCompany:StMix'
+    8: '4msCompany:MultiLFO'
+    9: '4msCompany:MultiLFO'
+    10: '4msCompany:MultiLFO'
+    11: '4msCompany:MultiLFO'
+    12: '4msCompany:MultiLFO'
+    13: '4msCompany:MultiLFO'
+    14: '4msCompany:MultiLFO'
+    15: '4msCompany:MultiLFO'
+    16: '4msCompany:MultiLFO'
+    17: '4msCompany:MultiLFO'
+    18: '4msCompany:MultiLFO'
+    19: '4msCompany:MultiLFO'
+    20: '4msCompany:MultiLFO'
+    21: '4msCompany:MultiLFO'
+    22: '4msCompany:MultiLFO'
+    23: '4msCompany:MultiLFO'
+  int_cables: []
+  mapped_ins:
+    - panel_jack_id: 0
+      ins:
+        - module_id: 1
+          jack_id: 0
+        - module_id: 1
+          jack_id: 1
+        - module_id: 1
+          jack_id: 2
+        - module_id: 1
+          jack_id: 3
+    - panel_jack_id: 1
+      ins:
+        - module_id: 1
+          jack_id: 4
+        - module_id: 1
+          jack_id: 5
+        - module_id: 1
+          jack_id: 6
+        - module_id: 1
+          jack_id: 7
+    - panel_jack_id: 2
+      ins:
+        - module_id: 2
+          jack_id: 0
+        - module_id: 2
+          jack_id: 1
+        - module_id: 2
+          jack_id: 2
+        - module_id: 2
+          jack_id: 3
+    - panel_jack_id: 3
+      ins:
+        - module_id: 2
+          jack_id: 4
+        - module_id: 2
+          jack_id: 5
+        - module_id: 2
+          jack_id: 6
+        - module_id: 2
+          jack_id: 7
+    - panel_jack_id: 4
+      ins:
+        - module_id: 3
+          jack_id: 0
+        - module_id: 3
+          jack_id: 1
+        - module_id: 3
+          jack_id: 2
+        - module_id: 3
+          jack_id: 3
+    - panel_jack_id: 5
+      ins:
+        - module_id: 3
+          jack_id: 4
+        - module_id: 3
+          jack_id: 5
+        - module_id: 3
+          jack_id: 6
+        - module_id: 3
+          jack_id: 7
+    - panel_jack_id: 6
+      ins:
+        - module_id: 4
+          jack_id: 0
+        - module_id: 4
+          jack_id: 1
+        - module_id: 4
+          jack_id: 2
+        - module_id: 4
+          jack_id: 3
+    - panel_jack_id: 7
+      ins:
+        - module_id: 4
+          jack_id: 4
+        - module_id: 4
+          jack_id: 5
+        - module_id: 4
+          jack_id: 6
+        - module_id: 4
+          jack_id: 7
+    - panel_jack_id: 8
+      ins:
+        - module_id: 5
+          jack_id: 0
+        - module_id: 5
+          jack_id: 1
+        - module_id: 5
+          jack_id: 2
+        - module_id: 5
+          jack_id: 3
+    - panel_jack_id: 9
+      ins:
+        - module_id: 5
+          jack_id: 4
+        - module_id: 5
+          jack_id: 5
+        - module_id: 5
+          jack_id: 6
+        - module_id: 5
+          jack_id: 7
+    - panel_jack_id: 10
+      ins:
+        - module_id: 6
+          jack_id: 0
+        - module_id: 6
+          jack_id: 1
+        - module_id: 6
+          jack_id: 2
+        - module_id: 6
+          jack_id: 3
+    - panel_jack_id: 11
+      ins:
+        - module_id: 6
+          jack_id: 4
+        - module_id: 6
+          jack_id: 5
+        - module_id: 6
+          jack_id: 6
+        - module_id: 6
+          jack_id: 7
+    - panel_jack_id: 12
+      ins:
+        - module_id: 7
+          jack_id: 0
+        - module_id: 7
+          jack_id: 1
+        - module_id: 7
+          jack_id: 2
+        - module_id: 7
+          jack_id: 3
+    - panel_jack_id: 13
+      ins:
+        - module_id: 7
+          jack_id: 4
+        - module_id: 7
+          jack_id: 5
+        - module_id: 7
+          jack_id: 6
+        - module_id: 7
+          jack_id: 7
+  mapped_outs:
+    - panel_jack_id: 0
+      out:
+        module_id: 8
+        jack_id: 0
+    - panel_jack_id: 1
+      out:
+        module_id: 9
+        jack_id: 1
+    - panel_jack_id: 2
+      out:
+        module_id: 10
+        jack_id: 2
+    - panel_jack_id: 3
+      out:
+        module_id: 11
+        jack_id: 3
+    - panel_jack_id: 4
+      out:
+        module_id: 12
+        jack_id: 0
+    - panel_jack_id: 5
+      out:
+        module_id: 13
+        jack_id: 1
+    - panel_jack_id: 6
+      out:
+        module_id: 14
+        jack_id: 2
+    - panel_jack_id: 7
+      out:
+        module_id: 15
+        jack_id: 3
+    - panel_jack_id: 8
+      out:
+        module_id: 16
+        jack_id: 0
+    - panel_jack_id: 9
+      out:
+        module_id: 17
+        jack_id: 1
+    - panel_jack_id: 10
+      out:
+        module_id: 18
+        jack_id: 2
+    - panel_jack_id: 11
+      out:
+        module_id: 19
+        jack_id: 3
+    - panel_jack_id: 12
+      out:
+        module_id: 20
+        jack_id: 0
+    - panel_jack_id: 13
+      out:
+        module_id: 21
+        jack_id: 1
+    - panel_jack_id: 14
+      out:
+        module_id: 22
+        jack_id: 2
+    - panel_jack_id: 15
+      out:
+        module_id: 23
+        jack_id: 3

--- a/simulator/stubs/drivers/cycle_counter.hh
+++ b/simulator/stubs/drivers/cycle_counter.hh
@@ -23,6 +23,14 @@ public:
 		_measured_tm = read_cycle_count() - _start_tm;
 	}
 
+	void start_simple_measurement() {
+		_start_tm = read_cycle_count();
+	}
+
+	uint32_t stop_simple_measurement() {
+		return read_cycle_count() - _start_tm;
+	}
+
 	uint32_t get_last_measurement_raw() {
 		return _measured_tm;
 	}

--- a/simulator/stubs/drivers/smp.hh
+++ b/simulator/stubs/drivers/smp.hh
@@ -55,6 +55,17 @@ struct SMPThread {
 	static void execute() {
 	}
 
+	template<typename Fn>
+	static auto run(Fn fn) -> std::invoke_result_t<Fn> {
+		using R = std::invoke_result_t<Fn>;
+
+		if constexpr (std::is_void_v<R>) {
+			fn();
+		} else {
+			return fn();
+		}
+	}
+
 	template<uint32_t command_id>
 	static void split_with_command() {
 	}


### PR DESCRIPTION
This adds the ability to run automatic tests for measuring the CPU load of a stock set of patches.

It also fixes an unreported crash that can happen if a patch file is malformed (missing static_knobs or mapped_knobs keys).

The patches are run on both cores, the same as is done when playing patches live. This tests inter-core SGIs, shared memory, cables that cross cores, etc.