### PR TITLE
Replace module

### DIFF
--- a/firmware/src/gui/pages/base.hh
+++ b/firmware/src/gui/pages/base.hh
@@ -142,6 +142,8 @@ struct PageBase {
 
 	// Some pages call this periodically
 	void poll_patch_file_changed() {
+		if (patch_playloader.is_saving())
+			return;
 
 		file_change_poll.poll(get_time(), [this] {
 			auto playing_patch = patches.get_playing_patch();

--- a/firmware/src/gui/pages/module_list.hh
+++ b/firmware/src/gui/pages/module_list.hh
@@ -4,6 +4,7 @@
 #include "gui/helpers/roller_hover_text.hh"
 #include "gui/pages/base.hh"
 #include "gui/pages/page_list.hh"
+#include "gui/pages/plugin_popup.hh"
 #include "gui/pages/tags.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "src/core/lv_obj_pos.h"
@@ -282,6 +283,10 @@ public:
 	void update() final {
 		roller_hover.update();
 		if (gui_state.back_button.is_just_released()) {
+			if (replace_popup.is_visible()) {
+				replace_popup.hide();
+				return;
+			}
 			roller_hover.hide();
 
 			if (view == View::CategoryRoller) {
@@ -314,6 +319,8 @@ public:
 	}
 
 	void blur() final {
+		if (replace_popup.is_visible())
+			replace_popup.hide();
 		if (draw_timer)
 			lv_timer_del(draw_timer);
 		draw_timer = nullptr;
@@ -360,8 +367,41 @@ private:
 		} else {
 			auto cur_idx = lv_roller_get_selected(ui_ModuleListRoller);
 			if (auto slug = page->get_selected_combined_slug(cur_idx); slug.length()) {
-				page->add_module(slug);
-				page->load_page(PageId::PatchView, page->args);
+				if (page->args.replace_module.value_or(false) && page->args.module_id.has_value()) {
+					page->pending_replace_slug = slug;
+					auto display_name = ModuleFactory::getModuleDisplayName(slug);
+					page->replace_confirm_msg = "Replace module with " + std::string{display_name} + "?";
+					page->replace_popup.init(lv_layer_top(), page->group);
+					page->replace_keep_cables = false;
+					page->replace_popup.show(
+						[page](std::optional<unsigned> button, std::optional<bool> toggle) {
+							if (toggle.has_value()) {
+								page->replace_keep_cables = *toggle;
+							}
+							if (button && *button == 1) {
+								auto module_id = page->args.module_id.value();
+
+								page->patch_playloader.change_module(
+									page->pending_replace_slug, module_id, page->replace_keep_cables);
+
+								page->patches.get_view_patch()->module_slugs[module_id] = page->pending_replace_slug;
+
+								page->patches.mark_view_patch_modified();
+								page->gui_state.force_redraw_patch = true;
+								PageArguments new_args{
+									.patch_loc_hash = page->patches.get_view_patch_loc_hash(),
+									.module_id = module_id,
+								};
+								page->page_list.request_new_page_no_history(PageId::ModuleView, new_args);
+							}
+						},
+						page->replace_confirm_msg.c_str(),
+						"Replace",
+						false);
+				} else {
+					page->add_module(slug);
+					page->load_page(PageId::PatchView, page->args);
+				}
 			} else {
 				page->notify_queue.put({"Cannot add module, slug is empty"});
 			}
@@ -468,7 +508,10 @@ private:
 	std::string selected_module_slug;
 
 	RollerHoverText roller_hover;
-	;
+	PluginPopup replace_popup{"Keep cables and maps"};
+	std::string pending_replace_slug;
+	std::string replace_confirm_msg;
+	bool replace_keep_cables = false;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/module_list.hh
+++ b/firmware/src/gui/pages/module_list.hh
@@ -368,36 +368,7 @@ private:
 			auto cur_idx = lv_roller_get_selected(ui_ModuleListRoller);
 			if (auto slug = page->get_selected_combined_slug(cur_idx); slug.length()) {
 				if (page->args.replace_module.value_or(false) && page->args.module_id.has_value()) {
-					page->pending_replace_slug = slug;
-					auto display_name = ModuleFactory::getModuleDisplayName(slug);
-					page->replace_confirm_msg = "Replace module with " + std::string{display_name} + "?";
-					page->replace_popup.init(lv_layer_top(), page->group);
-					page->replace_keep_cables = false;
-					page->replace_popup.show(
-						[page](std::optional<unsigned> button, std::optional<bool> toggle) {
-							if (toggle.has_value()) {
-								page->replace_keep_cables = *toggle;
-							}
-							if (button && *button == 1) {
-								auto module_id = page->args.module_id.value();
-
-								page->patch_playloader.change_module(
-									page->pending_replace_slug, module_id, page->replace_keep_cables);
-
-								page->patches.get_view_patch()->module_slugs[module_id] = page->pending_replace_slug;
-
-								page->patches.mark_view_patch_modified();
-								page->gui_state.force_redraw_patch = true;
-								PageArguments new_args{
-									.patch_loc_hash = page->patches.get_view_patch_loc_hash(),
-									.module_id = module_id,
-								};
-								page->page_list.request_new_page_no_history(PageId::ModuleView, new_args);
-							}
-						},
-						page->replace_confirm_msg.c_str(),
-						"Replace",
-						false);
+					page->change_module(slug);
 				} else {
 					page->add_module(slug);
 					page->load_page(PageId::PatchView, page->args);
@@ -406,6 +377,36 @@ private:
 				page->notify_queue.put({"Cannot add module, slug is empty"});
 			}
 		}
+	}
+
+	void change_module(std::string const &slug) {
+		pending_replace_slug = slug;
+		auto display_name = ModuleFactory::getModuleDisplayName(slug);
+		replace_confirm_msg = "Replace module with " + std::string{display_name} + "?";
+		replace_popup.init(lv_layer_top(), group);
+		replace_keep_cables = false;
+		replace_popup.show(
+			[this](std::optional<unsigned> button, std::optional<bool> toggle) {
+				if (toggle.has_value()) {
+					replace_keep_cables = *toggle;
+				}
+				if (button && *button == 1) {
+					auto module_id = args.module_id.value();
+
+					patch_playloader.change_module(pending_replace_slug, module_id, replace_keep_cables);
+
+					patches.mark_view_patch_modified();
+					gui_state.force_redraw_patch = true;
+					PageArguments new_args{
+						.patch_loc_hash = patches.get_view_patch_loc_hash(),
+						.module_id = module_id,
+					};
+					page_list.request_new_page_no_history(PageId::ModuleView, new_args);
+				}
+			},
+			replace_confirm_msg.c_str(),
+			"Replace",
+			false);
 	}
 
 	static inline unsigned cur_selected = 0;

--- a/firmware/src/gui/pages/module_view/action_menu.hh
+++ b/firmware/src/gui/pages/module_view/action_menu.hh
@@ -48,7 +48,8 @@ public:
 		, moduleViewActionPresetBut{create_lv_list_button(ui_ModuleViewActionMenu, "Presets")}
 		, moduleViewActionBypassBut{create_lv_list_button(ui_ModuleViewActionMenu, "Bypass: Off")}
 		, moduleViewActionRenameBut{create_lv_list_button(ui_ModuleViewActionMenu, "Rename...")}
-		, moduleViewActionResetNameBut{create_lv_list_button(ui_ModuleViewActionMenu, "Reset name")} {
+		, moduleViewActionResetNameBut{create_lv_list_button(ui_ModuleViewActionMenu, "Reset name")}
+		, moduleViewActionReplaceBut{create_lv_list_button(ui_ModuleViewActionMenu, "Replace...")} {
 		lv_obj_set_parent(ui_ModuleViewActionMenu, lv_layer_top());
 		lv_show(ui_ModuleViewActionMenu);
 		lv_show(moduleViewActionPresetBut);
@@ -84,6 +85,7 @@ public:
 		lv_obj_add_event_cb(moduleViewActionBypassBut, bypass_but_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(moduleViewActionRenameBut, rename_but_cb, LV_EVENT_CLICKED, this);
 		lv_obj_add_event_cb(moduleViewActionResetNameBut, reset_name_but_cb, LV_EVENT_CLICKED, this);
+		lv_obj_add_event_cb(moduleViewActionReplaceBut, replace_but_cb, LV_EVENT_CLICKED, this);
 
 		lv_group_add_obj(group, ui_ModuleViewActionAutopatchBut);
 		lv_group_add_obj(group, ui_ModuleViewActionAutoKnobSet);
@@ -94,6 +96,7 @@ public:
 		lv_group_add_obj(group, moduleViewActionBypassBut);
 		lv_group_add_obj(group, moduleViewActionRenameBut);
 		lv_group_add_obj(group, moduleViewActionResetNameBut);
+		lv_group_add_obj(group, moduleViewActionReplaceBut);
 		lv_group_add_obj(group, ui_ModuleViewActionDeleteBut);
 		lv_group_set_wrap(group, false);
 	}
@@ -430,6 +433,19 @@ private:
 		lv_label_set_text(ui_ElementRollerModuleName, display.data());
 	}
 
+	static void replace_but_cb(lv_event_t *event) {
+		if (!event || !event->user_data)
+			return;
+		auto page = static_cast<ModuleViewActionMenu *>(event->user_data);
+		page->hide();
+		PageArguments new_args{
+			.patch_loc_hash = page->patches.get_view_patch_loc_hash(),
+			.module_id = static_cast<uint16_t>(page->module_idx),
+			.replace_module = true,
+		};
+		page->page_list.request_new_page(PageId::ModuleList, new_args);
+	}
+
 	static void rename_but_cb(lv_event_t *event) {
 		if (!event || !event->user_data)
 			return;
@@ -492,6 +508,7 @@ private:
 	lv_obj_t *moduleViewActionBypassBut;
 	lv_obj_t *moduleViewActionRenameBut;
 	lv_obj_t *moduleViewActionResetNameBut;
+	lv_obj_t *moduleViewActionReplaceBut;
 	lv_obj_t *rename_textarea = nullptr;
 	std::string pending_alias{};
 	KeyboardEntry keyboard_entry;

--- a/firmware/src/gui/pages/page_args.hh
+++ b/firmware/src/gui/pages/page_args.hh
@@ -17,6 +17,7 @@ struct PageArguments {
 	std::optional<ElementCount::Indices> element_indices{};
 	std::optional<bool> detail_mode{};
 	std::optional<std::pair<float, float>> element_mm{};
+	std::optional<bool> replace_module{};
 
 	bool operator==(PageArguments const &that) const = default;
 };

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -264,7 +264,7 @@ public:
 			pc.changed = false;
 
 			for (auto const &entry : info.settings.midi_pc_patch_load.entries) {
-				bool chan_match = (entry.channel == 0) || (entry.channel == pc.channel + 1);
+				bool chan_match = (entry.channel == 0) || (entry.channel == (uint32_t)pc.channel + 1);
 				if (chan_match && entry.pc == pc.pc) {
 					auto [filename, vol] = split_volume(entry.path);
 					midi_pc_target_loc = PatchLocation{std::string(filename), vol};

--- a/firmware/src/gui/pages/plugin_popup.hh
+++ b/firmware/src/gui/pages/plugin_popup.hh
@@ -14,9 +14,9 @@ namespace MetaModule
 {
 
 struct PluginPopup : ConfirmPopup {
-	PluginPopup()
+	PluginPopup(const char *check_label = "Pre-load")
 		: group{lv_group_create()} {
-		auto p = create_labeled_check_obj(panel, "Pre-load");
+		auto p = create_labeled_check_obj(panel, check_label);
 		lv_obj_move_to_index(p, 1);
 		check = lv_obj_get_child(p, -1);
 		lv_obj_add_event_cb(check, toggle_callback, LV_EVENT_VALUE_CHANGED, this);

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -872,6 +872,10 @@ public:
 		modules[module_idx]->set_samplerate(samplerate);
 
 		rebalance_modules();
+
+		// Mark jacks patched
+		mark_patched_jacks(module_idx);
+		mark_patched_panel_jacks(module_idx);
 	}
 
 	void remove_module(uint16_t module_idx) {
@@ -973,8 +977,7 @@ public:
 		if (module_idx >= num_modules)
 			return;
 
-		pr_trace(
-			"Substituting module %u (%s) with %s\n", module_idx, pd.module_slugs[module_idx].c_str(), new_slug.c_str());
+		pr_trace("Subs. module %u (%s) with %s\n", module_idx, pd.module_slugs[module_idx].c_str(), new_slug.c_str());
 
 		// De-init original module
 		plugin_module_deinit(modules[module_idx]);
@@ -984,17 +987,15 @@ public:
 		pd.module_slugs[module_idx] = new_slug;
 		calc_multiple_module_indicies();
 		create_module(new_slug, module_idx);
-
-		// Mark jacks patched
-		mark_patched_jacks(module_idx);
-		mark_patched_panel_jacks(module_idx);
 	}
 
 	void replace_module(uint16_t module_idx, BrandModuleSlug new_slug) {
 		if (module_idx >= num_modules)
 			return;
 
-		// -- Erase cached connections referencing this module (no squashing) --
+		pr_trace("Replace module %u (%s) with %s\n", module_idx, pd.module_slugs[module_idx].c_str(), new_slug.c_str());
+
+		//  Erase cached connections referencing this module (no squashing)
 
 		auto erase_matching = [=](auto &container) {
 			for (auto &item : container) {
@@ -1048,12 +1049,12 @@ public:
 		erase_matching_inner(midi_pulses);
 		erase_matching_inner(midi_divclk_pulses);
 
-		// Clean up PatchData (cables, mapped_ins/outs, static_knobs, etc.)
-		pd.blank_out_module(module_idx);
-
 		// Deinit old module
 		plugin_module_deinit(modules[module_idx]);
 		modules[module_idx].reset();
+
+		// Clean up PatchData (cables, mapped_ins/outs, static_knobs, etc.)
+		pd.blank_out_module(module_idx);
 
 		// Create new module in the same slot
 		pd.module_slugs[module_idx] = new_slug;

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -846,10 +846,14 @@ public:
 	}
 
 	void add_module(BrandModuleSlug slug) {
-		auto module_idx = num_modules;
 		pd.module_slugs.push_back(slug);
 		calc_multiple_module_indicies();
 
+		auto module_idx = num_modules;
+		create_module(slug, module_idx);
+	}
+
+	void create_module(BrandModuleSlug slug, unsigned module_idx) {
 		modules[module_idx] = ModuleFactory::create(slug);
 		if (modules[module_idx] == nullptr) {
 			pr_err("Module %s not found\n", slug.c_str());
@@ -964,66 +968,134 @@ public:
 		rebalance_modules();
 	}
 
-	void replace_module(uint16_t module_idx, BrandModuleSlug new_slug) {
-		// Remove old
-		pd.remove_module(module_idx);
+	// replace a module without changing any mappings or cables
+	void substitute_module(unsigned module_idx, BrandModuleSlug new_slug) {
+		if (module_idx >= num_modules)
+			return;
 
+		pr_trace(
+			"Substituting module %u (%s) with %s\n", module_idx, pd.module_slugs[module_idx].c_str(), new_slug.c_str());
+
+		// De-init original module
 		plugin_module_deinit(modules[module_idx]);
 		modules[module_idx].reset();
 
-		// Add new
-		modules[module_idx] = ModuleFactory::create(new_slug);
-		if (modules[module_idx] == nullptr) {
-			pr_err("Module %s not found\n", new_slug.c_str());
-			return;
-		}
-		pd.module_slugs.push_back(new_slug);
+		// Add new module
+		pd.module_slugs[module_idx] = new_slug;
 		calc_multiple_module_indicies();
-
-		pr_trace("Replaced module %u with %s\n", module_idx, new_slug.c_str());
-
-		modules[module_idx]->id = module_idx;
-
-		// Match order that VCV does: fromJson (via load_state), then onAdd (via plugin_module_init)
-		reset_module(module_idx);
-		plugin_module_init(modules[module_idx]);
-
-		modules[module_idx]->set_samplerate(samplerate);
-
-		modules[module_idx]->mark_all_inputs_unpatched();
-		modules[module_idx]->mark_all_outputs_unpatched();
+		create_module(new_slug, module_idx);
 
 		// Mark jacks patched
-		for (auto const &cable : pd.int_cables) {
-			if (cable.out.module_id == module_idx)
-				modules[cable.out.module_id]->mark_output_patched(cable.out.jack_id);
+		mark_patched_jacks(module_idx);
+		mark_patched_panel_jacks(module_idx);
+	}
 
-			for (auto const &input_jack : cable.ins) {
-				if (input_jack.module_id == module_idx) {
-					modules[input_jack.module_id]->mark_input_patched(input_jack.jack_id);
+	void replace_module(uint16_t module_idx, BrandModuleSlug new_slug) {
+		if (module_idx >= num_modules)
+			return;
+
+		// -- Erase cached connections referencing this module (no squashing) --
+
+		auto erase_matching = [=](auto &container) {
+			for (auto &item : container) {
+				std::erase_if(item, [=](auto &map) { return (map.module_id == module_idx); });
+			}
+		};
+
+		auto erase_matching_inner = [=](auto &container) {
+			for (auto &item : container) {
+				std::erase_if(item.conns, [=](auto &map) { return (map.module_id == module_idx); });
+			}
+		};
+
+		// Panel connections
+		erase_matching(in_conns);
+		erase_matching(out_conns);
+
+		// Inform other modules their jacks are disconnected
+		for (auto &cable : pd.int_cables) {
+			unsigned ins_to_disconnect = 0;
+			for (auto in : cable.ins) {
+				if (cable.out.module_id == module_idx) {
+					modules[in.module_id]->mark_input_unpatched(in.jack_id);
 				}
+				if (in.module_id == module_idx) {
+					ins_to_disconnect++;
+				}
+			}
+			if (ins_to_disconnect == cable.ins.size()) {
+				modules[cable.out.module_id]->mark_output_unpatched(cable.out.jack_id);
 			}
 		}
 
-		// TODO: panel jack maps mark ins/outs as patched
+		// Knob maps
+		for (auto &param_set : knob_maps) {
+			for (auto &set : param_set) {
+				std::erase_if(set, [=](auto &map) { return (map.map.module_id == module_idx); });
+			}
+		}
 
-		// TODO: Can we verify mappings and panel jack mappings are valid?
+		// MIDI maps
+		erase_matching(midi_cc_knob_maps);
+		erase_matching(midi_note_knob_maps);
+		erase_matching(midi_note_pitch_conns);
+		erase_matching(midi_note_gate_conns);
+		erase_matching(midi_note_vel_conns);
+		erase_matching(midi_note_aft_conns);
+		erase_matching(midi_cc_conns);
+		erase_matching(midi_gate_conns);
+		erase_matching_inner(midi_note_retrig);
+		erase_matching_inner(midi_pulses);
+		erase_matching_inner(midi_divclk_pulses);
 
-		rebalance_modules();
+		// Clean up PatchData (cables, mapped_ins/outs, static_knobs, etc.)
+		pd.blank_out_module(module_idx);
+
+		// Deinit old module
+		plugin_module_deinit(modules[module_idx]);
+		modules[module_idx].reset();
+
+		// Create new module in the same slot
+		pd.module_slugs[module_idx] = new_slug;
+		calc_multiple_module_indicies();
+		create_module(new_slug, module_idx);
 	}
-
-	// General info getters:
 
 	// Jack patched/unpatched status
 
 	// Follow every internal cable and tell the modules that their jacks are patched
-	void mark_patched_jacks() {
+	// Optionally filter by module id
+	void mark_patched_jacks(std::optional<uint16_t> module_id = std::nullopt) {
 		for (auto const &cable : pd.int_cables) {
-			modules[cable.out.module_id]->mark_output_patched(cable.out.jack_id);
+			if (!module_id.has_value() || cable.out.module_id == module_id.value())
+				modules[cable.out.module_id]->mark_output_patched(cable.out.jack_id);
+
 			for (auto const &input_jack : cable.ins) {
 				if (input_jack.module_id < num_modules)
-					modules[input_jack.module_id]->mark_input_patched(input_jack.jack_id);
+					if (!module_id.has_value() || input_jack.module_id == module_id.value())
+						modules[input_jack.module_id]->mark_input_patched(input_jack.jack_id);
 			}
+		}
+	}
+
+	void mark_patched_panel_jacks(std::optional<uint16_t> module_idx = std::nullopt) {
+		for (auto i = 0u; auto const &panel_out : out_conns) {
+			if (out_patched[i]) {
+				for (auto const &c : panel_out) {
+					if (!module_idx.has_value() || c.module_id == module_idx)
+						modules[c.module_id]->mark_output_patched(c.jack_id);
+				}
+			}
+			i++;
+		}
+		for (auto i = 0u; auto const &panel_in : in_conns) {
+			if (in_patched[i]) {
+				for (auto const &c : panel_in) {
+					if (!module_idx.has_value() || c.module_id == module_idx)
+						modules[c.module_id]->mark_input_patched(c.jack_id);
+				}
+			}
+			i++;
 		}
 	}
 

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -996,7 +996,7 @@ public:
 
 		pr_trace("Replace module %u (%s) with %s\n", module_idx, pd.module_slugs[module_idx].c_str(), new_slug.c_str());
 
-		//  Erase cached connections referencing this module (no squashing)
+		//  Erase cached connections referencing this module (unlike remove_module, there is no squashing)
 
 		auto erase_matching = [=](auto &container) {
 			for (auto &item : container) {

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -964,6 +964,54 @@ public:
 		rebalance_modules();
 	}
 
+	void replace_module(uint16_t module_idx, BrandModuleSlug new_slug) {
+		// Remove old
+		pd.remove_module(module_idx);
+
+		plugin_module_deinit(modules[module_idx]);
+		modules[module_idx].reset();
+
+		// Add new
+		modules[module_idx] = ModuleFactory::create(new_slug);
+		if (modules[module_idx] == nullptr) {
+			pr_err("Module %s not found\n", new_slug.c_str());
+			return;
+		}
+		pd.module_slugs.push_back(new_slug);
+		calc_multiple_module_indicies();
+
+		pr_trace("Replaced module %u with %s\n", module_idx, new_slug.c_str());
+
+		modules[module_idx]->id = module_idx;
+
+		// Match order that VCV does: fromJson (via load_state), then onAdd (via plugin_module_init)
+		reset_module(module_idx);
+		plugin_module_init(modules[module_idx]);
+
+		modules[module_idx]->set_samplerate(samplerate);
+
+		modules[module_idx]->mark_all_inputs_unpatched();
+		modules[module_idx]->mark_all_outputs_unpatched();
+
+		// Mark jacks patched
+		for (auto const &cable : pd.int_cables) {
+			if (cable.out.module_id == module_idx)
+				modules[cable.out.module_id]->mark_output_patched(cable.out.jack_id);
+
+			for (auto const &input_jack : cable.ins) {
+				if (input_jack.module_id == module_idx) {
+					modules[input_jack.module_id]->mark_input_patched(input_jack.jack_id);
+				}
+			}
+		}
+
+		// TODO: panel jack maps mark ins/outs as patched
+
+		// TODO: Can we verify mappings and panel jack mappings are valid?
+
+		rebalance_modules();
+	}
+
 	// General info getters:
 
 	// Jack patched/unpatched status

--- a/firmware/src/patch_play/patch_player.hh
+++ b/firmware/src/patch_play/patch_player.hh
@@ -846,10 +846,11 @@ public:
 	}
 
 	void add_module(BrandModuleSlug slug) {
+		auto module_idx = num_modules;
+
 		pd.module_slugs.push_back(slug);
 		calc_multiple_module_indicies();
 
-		auto module_idx = num_modules;
 		create_module(slug, module_idx);
 	}
 

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -254,10 +254,16 @@ struct PatchPlayLoader {
 		while (!is_audio_muted())
 			;
 
-		if (keep_cables_and_maps)
+		auto *patch = patches_.get_view_patch();
+
+		if (keep_cables_and_maps) {
+			patch->module_slugs[module_id] = slug;
 			player_.substitute_module(module_id, slug);
-		else
+		} else {
+			patch->blank_out_module(module_id);
+			patch->module_slugs[module_id] = slug;
 			player_.replace_module(module_id, slug);
+		}
 
 		pr_info("Heap: %u\n", get_heap_size());
 		if (should_play)

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -209,6 +209,10 @@ struct PatchPlayLoader {
 		should_save_patch_ = true;
 	}
 
+	bool is_saving() const {
+		return should_save_patch_ || saving_patch_;
+	}
+
 	bool is_renaming_idle() {
 		return rename_state_ == RenameState::Idle;
 	}

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -247,6 +247,23 @@ struct PatchPlayLoader {
 			start_audio();
 	}
 
+	void change_module(std::string_view slug, unsigned module_id, bool keep_cables_and_maps) {
+		bool should_play = is_playing();
+
+		stop_audio();
+		while (!is_audio_muted())
+			;
+
+		if (keep_cables_and_maps)
+			player_.substitute_module(module_id, slug);
+		else
+			player_.replace_module(module_id, slug);
+
+		pr_info("Heap: %u\n", get_heap_size());
+		if (should_play)
+			start_audio();
+	}
+
 	void remove_module(unsigned module_id) {
 		stop_audio();
 		while (!is_audio_muted())

--- a/firmware/tests/patch_player_tests.cc
+++ b/firmware/tests/patch_player_tests.cc
@@ -1789,6 +1789,381 @@ PatchData:
 	}
 }
 
+TEST_CASE("substitute_module preserves all connections and mappings") {
+	// clang-format off
+	std::string patchyml{R"(
+PatchData:
+  patch_name: SubstituteTest
+  module_slugs:
+    0: '4msCompany:HubMedium'
+    1: '4msCompany:MultiLFO'
+    2: '4msCompany:Drum'
+    3: '4msCompany:StMix'
+  int_cables:
+    - out:
+        module_id: 1
+        jack_id: 0
+      ins:
+        - module_id: 3
+          jack_id: 0
+      color: 1000
+  mapped_ins:
+    - panel_jack_id: 0
+      ins:
+        - module_id: 2
+          jack_id: 1
+    - panel_jack_id: 1
+      ins:
+        - module_id: 2
+          jack_id: 2
+        - module_id: 3
+          jack_id: 1
+  mapped_outs:
+    - panel_jack_id: 0
+      out:
+        module_id: 2
+        jack_id: 0
+    - panel_jack_id: 1
+      out:
+        module_id: 3
+        jack_id: 0
+  static_knobs:
+    - module_id: 1
+      param_id: 0
+      value: 0.5
+    - module_id: 2
+      param_id: 0
+      value: 0.25
+    - module_id: 2
+      param_id: 1
+      value: 0.75
+    - module_id: 3
+      param_id: 0
+      value: 0.1
+  mapped_knobs:
+    - name: ''
+      set:
+        - panel_knob_id: 0
+          module_id: 2
+          param_id: 0
+          curve_type: 0
+          min: 0
+          max: 1
+        - panel_knob_id: 1
+          module_id: 3
+          param_id: 0
+          curve_type: 0
+          min: 0
+          max: 1
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+  midi_maps:
+    name: ''
+    set: []
+  midi_poly_num: 0
+  midi_poly_mode: 0
+  midi_pitchwheel_range: 1
+  mapped_lights: []
+  vcvModuleStates: []
+  suggested_samplerate: 0
+  suggested_blocksize: 0
+  bypassed_modules: []
+  module_aliases: []
+)"};
+	// clang-format on
+
+	MetaModule::PatchData pd;
+	yaml_string_to_patch(patchyml, pd);
+
+	MetaModule::PatchPlayer p;
+	p.load_patch(pd);
+
+	// Verify initial state
+	CHECK(p.get_module_slugs().size() == 4);
+	CHECK(p.get_module_slugs()[2].is_equal("4msCompany:Drum"));
+
+	auto orig_num_cables = p.get_int_cables().size();
+	auto orig_in_conns = p.get_inconns();
+	auto orig_out_conns = p.get_outconns();
+
+	// Substitute module 2 (Drum) with a different slug.
+	// Module 2 has no int_cables, but has panel in/out connections and knob maps.
+	p.substitute_module(2, "4msCompany:KPLS");
+
+	SUBCASE("Module count unchanged") {
+		CHECK(p.get_module_slugs().size() == 4);
+	}
+
+	SUBCASE("Slug is updated") {
+		CHECK(p.get_module_slugs()[2].is_equal("4msCompany:KPLS"));
+	}
+
+	SUBCASE("Other slugs unchanged") {
+		CHECK(p.get_module_slugs()[0].is_equal("4msCompany:HubMedium"));
+		CHECK(p.get_module_slugs()[1].is_equal("4msCompany:MultiLFO"));
+		CHECK(p.get_module_slugs()[3].is_equal("4msCompany:StMix"));
+	}
+
+	SUBCASE("Internal cables preserved") {
+		CHECK(p.get_int_cables().size() == orig_num_cables);
+	}
+
+	SUBCASE("Panel input connections preserved") {
+		CHECK(p.get_inconns()[0] == orig_in_conns[0]);
+		CHECK(p.get_inconns()[1] == orig_in_conns[1]);
+	}
+
+	SUBCASE("Panel output connections preserved") {
+		CHECK(p.get_outconns()[0] == orig_out_conns[0]);
+		CHECK(p.get_outconns()[1] == orig_out_conns[1]);
+	}
+
+	SUBCASE("Knob mappings preserved") {
+		auto &knobs = p.get_knobconns();
+		// knob_maps[0] should still have entries for module 2 and module 3
+		bool found_mod2 = false;
+		bool found_mod3 = false;
+		for (auto &param_vec : knobs[0]) {
+			for (auto &mp : param_vec) {
+				if (mp.map.module_id == 2)
+					found_mod2 = true;
+				if (mp.map.module_id == 3)
+					found_mod3 = true;
+			}
+		}
+		CHECK(found_mod2);
+		CHECK(found_mod3);
+	}
+}
+
+TEST_CASE("replace_module removes all connections and mappings for the replaced module") {
+	// clang-format off
+	std::string patchyml{R"(
+PatchData:
+  patch_name: ReplaceTest
+  module_slugs:
+    0: '4msCompany:HubMedium'
+    1: '4msCompany:MultiLFO'
+    2: '4msCompany:Drum'
+    3: '4msCompany:StMix'
+  int_cables:
+    - out:
+        module_id: 1
+        jack_id: 0
+      ins:
+        - module_id: 2
+          jack_id: 3
+      color: 1000
+    - out:
+        module_id: 2
+        jack_id: 0
+      ins:
+        - module_id: 3
+          jack_id: 0
+      color: 2000
+    - out:
+        module_id: 1
+        jack_id: 1
+      ins:
+        - module_id: 3
+          jack_id: 1
+      color: 3000
+  mapped_ins:
+    - panel_jack_id: 0
+      ins:
+        - module_id: 2
+          jack_id: 1
+    - panel_jack_id: 1
+      ins:
+        - module_id: 2
+          jack_id: 2
+        - module_id: 3
+          jack_id: 1
+    - panel_jack_id: 2
+      ins:
+        - module_id: 1
+          jack_id: 0
+  mapped_outs:
+    - panel_jack_id: 0
+      out:
+        module_id: 2
+        jack_id: 0
+    - panel_jack_id: 1
+      out:
+        module_id: 3
+        jack_id: 0
+    - panel_jack_id: 2
+      out:
+        module_id: 1
+        jack_id: 0
+  static_knobs:
+    - module_id: 1
+      param_id: 0
+      value: 0.5
+    - module_id: 2
+      param_id: 0
+      value: 0.25
+    - module_id: 2
+      param_id: 1
+      value: 0.75
+    - module_id: 3
+      param_id: 0
+      value: 0.1
+  mapped_knobs:
+    - name: ''
+      set:
+        - panel_knob_id: 0
+          module_id: 2
+          param_id: 0
+          curve_type: 0
+          min: 0
+          max: 1
+        - panel_knob_id: 1
+          module_id: 1
+          param_id: 0
+          curve_type: 0
+          min: 0
+          max: 1
+        - panel_knob_id: 2
+          module_id: 3
+          param_id: 0
+          curve_type: 0
+          min: 0
+          max: 1
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+  midi_maps:
+    name: ''
+    set: []
+  midi_poly_num: 0
+  midi_poly_mode: 0
+  midi_pitchwheel_range: 1
+  mapped_lights: []
+  vcvModuleStates: []
+  suggested_samplerate: 0
+  suggested_blocksize: 0
+  bypassed_modules: []
+  module_aliases: []
+)"};
+	// clang-format on
+
+	MetaModule::PatchData pd;
+	yaml_string_to_patch(patchyml, pd);
+
+	MetaModule::PatchPlayer p;
+	p.load_patch(pd);
+
+	// Verify initial state
+	CHECK(p.get_module_slugs().size() == 4);
+	CHECK(p.get_module_slugs()[2].is_equal("4msCompany:Drum"));
+
+	// Replace module 2 (Drum) with a different slug
+	p.replace_module(2, "4msCompany:KPLS");
+
+	SUBCASE("Module count unchanged") {
+		CHECK(p.get_module_slugs().size() == 4);
+	}
+
+	SUBCASE("Slug is updated") {
+		CHECK(p.get_module_slugs()[2].is_equal("4msCompany:KPLS"));
+	}
+
+	SUBCASE("Other slugs unchanged") {
+		CHECK(p.get_module_slugs()[0].is_equal("4msCompany:HubMedium"));
+		CHECK(p.get_module_slugs()[1].is_equal("4msCompany:MultiLFO"));
+		CHECK(p.get_module_slugs()[3].is_equal("4msCompany:StMix"));
+	}
+
+	SUBCASE("Internal cables referencing module 2 are removed") {
+		// Cable 1->2 and 2->3 should be removed, cable 1->3 should remain
+		bool found_cable_1_3 = false;
+		for (auto &cable : p.get_int_cables()) {
+			// No cable should reference module 2
+			CHECK(cable.out.module_id != 2);
+			for (auto &in : cable.ins) {
+				CHECK(in.module_id != 2);
+			}
+			if (cable.out == Jack{1, 1} && cable.ins.size() == 1 && cable.ins[0] == Jack{3, 1})
+				found_cable_1_3 = true;
+		}
+		CHECK(found_cable_1_3);
+	}
+
+	SUBCASE("Panel input connections referencing module 2 are removed") {
+		// Panel in 0 was mapped to module 2 only — should be empty
+		CHECK(p.get_inconns()[0].size() == 0);
+		// Panel in 1 had module 2 entry — that's removed, but module 3 entry (via Hub) remains
+		CHECK(p.get_inconns()[1].size() == 1);
+		// The remaining connection is routed through the Hub (module 0) because module 3 jack 1
+		// also has an internal cable to it
+		CHECK(p.get_inconns()[1][0] == Jack{0, 1});
+		// Panel in 2 was mapped to module 1 — unaffected
+		CHECK(p.get_inconns()[2].size() == 1);
+		CHECK(p.get_inconns()[2][0] == Jack{1, 0});
+	}
+
+	SUBCASE("Panel output connections referencing module 2 are removed") {
+		// Panel out 0 was mapped to module 2 — should be empty
+		CHECK(p.get_outconns()[0].size() == 0);
+		// Panel out 1 was mapped to module 3 — unaffected
+		CHECK(p.get_outconns()[1].size() == 1);
+		CHECK(p.get_outconns()[1][0] == Jack{3, 0});
+		// Panel out 2 was mapped to module 1 — unaffected
+		CHECK(p.get_outconns()[2].size() == 1);
+		CHECK(p.get_outconns()[2][0] == Jack{1, 0});
+	}
+
+	SUBCASE("Knob mappings referencing module 2 are removed, others preserved") {
+		auto &knobs = p.get_knobconns();
+		bool found_mod2 = false;
+		bool found_mod1 = false;
+		bool found_mod3 = false;
+		for (auto &param_vec : knobs[0]) {
+			for (auto &mp : param_vec) {
+				if (mp.map.module_id == 2)
+					found_mod2 = true;
+				if (mp.map.module_id == 1)
+					found_mod1 = true;
+				if (mp.map.module_id == 3)
+					found_mod3 = true;
+			}
+		}
+		CHECK_FALSE(found_mod2);
+		CHECK(found_mod1);
+		CHECK(found_mod3);
+	}
+
+	SUBCASE("Module IDs of other modules are unchanged (no squashing)") {
+		// Module 1 and 3 should still be at their original indices
+		CHECK(p.get_modules()[1].get() != nullptr);
+		CHECK(p.get_modules()[3].get() != nullptr);
+	}
+}
+
 TEST_CASE("Summing part of a split: virt output splits to a virt input and panel output. The virt input also sums with "
 		  "a panel input") {
 	// Module 2 input 0 receives both an internal cable (from Module 1 output 0) and a panel input.


### PR DESCRIPTION
Adds a new menu item to the ModuleView action menu: `Replace module`. 
This brings up the module chooser. Picking a module brings up a confirmation box that also has a toggle for keeping the cables and maps. 
If cables and maps are kept, then the new module will replace the old one with everything else in the patch intact. Most of the time this results in useless/bad cable connections, but with carefully chosen modules it can be helpful (e.g. swapping one Airwindows module for another with the same knob count).
If cables and maps are not kept, then this option is almost the same as deleting the old module and adding a new one. The only difference is that the position of the module is maintained.