### PR TITLE
MIDI PC patch loading

### DIFF
--- a/firmware/src/audio/midi.hh
+++ b/firmware/src/audio/midi.hh
@@ -20,6 +20,10 @@ struct AudioStreamMidi {
 
 	void process(bool is_connected, Midi::Event const &event, unsigned poly_num, MidiMessage *raw_msg) {
 
+		if (event.type == Midi::Event::Type::PC) {
+			sync_params.midi_events.put(event);
+		}
+
 		if (!player.is_loaded)
 			return;
 
@@ -74,9 +78,6 @@ struct AudioStreamMidi {
 
 		} else if (event.type == Midi::Event::Type::CC) {
 			player.set_midi_cc(event.note, event.val, event.midi_chan);
-			sync_params.midi_events.put(event);
-
-		} else if (event.type == Midi::Event::Type::PC) {
 			sync_params.midi_events.put(event);
 
 		} else if (event.type == Midi::Event::Type::Bend) {

--- a/firmware/src/audio/midi.hh
+++ b/firmware/src/audio/midi.hh
@@ -76,6 +76,9 @@ struct AudioStreamMidi {
 			player.set_midi_cc(event.note, event.val, event.midi_chan);
 			sync_params.midi_events.put(event);
 
+		} else if (event.type == Midi::Event::Type::PC) {
+			sync_params.midi_events.put(event);
+
 		} else if (event.type == Midi::Event::Type::Bend) {
 			player.set_midi_cc(128, event.val, event.midi_chan);
 

--- a/firmware/src/gui/pages/midi_pc_assign_dialog.hh
+++ b/firmware/src/gui/pages/midi_pc_assign_dialog.hh
@@ -30,7 +30,6 @@ struct MidiPCAssignDialog : ConfirmPopup {
 	}
 
 	void show(std::string_view path) {
-		// TODO: move settings and gs to constructor
 		current_path = path;
 
 		uint32_t init_chan = 0;
@@ -74,8 +73,8 @@ struct MidiPCAssignDialog : ConfirmPopup {
 			"OK");
 
 		lv_group_remove_all_objs(group);
-		lv_group_add_obj(group, chan_dropdown);
 		lv_group_add_obj(group, pc_dropdown);
+		lv_group_add_obj(group, chan_dropdown);
 		lv_group_add_obj(group, cancel_button);
 		lv_group_add_obj(group, confirm_button);
 		lv_group_set_wrap(group, false);
@@ -145,31 +144,26 @@ private:
 	}
 
 	void init_widgets() {
-		lv_obj_set_width(panel, 310);
-		lv_obj_set_style_pad_row(panel, 6, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_left(panel, 8, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_right(panel, 8, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_top(panel, 8, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_bottom(panel, 8, LV_STATE_DEFAULT);
+		lv_obj_set_width(panel, 300);
 		lv_obj_set_width(message_label, LV_SIZE_CONTENT);
 
+		auto pc_row = create_labeled_dropdown(panel);
+		lv_obj_set_width(pc_row, 290);
+		lv_obj_move_to_index(pc_row, 1);
+		lv_label_set_text(lv_obj_get_child(pc_row, 0), "PC #:");
+		pc_dropdown = lv_obj_get_child(pc_row, 1);
+		lv_obj_set_width(pc_dropdown, 220);
+
 		auto chan_row = create_labeled_dropdown(panel);
-		lv_obj_set_width(chan_row, 300);
-		lv_obj_move_to_index(chan_row, 1);
-		lv_label_set_text(lv_obj_get_child(chan_row, 0), "Channel:");
+		lv_obj_set_width(chan_row, 290);
+		lv_obj_move_to_index(chan_row, 2);
+		lv_label_set_text(lv_obj_get_child(chan_row, 0), "MIDI Channel:");
 		chan_dropdown = lv_obj_get_child(chan_row, 1);
 
 		lv_dropdown_set_options(chan_dropdown,
 								"Any\nChan. 1\nChan. 2\nChan. 3\nChan. 4\nChan. 5\nChan. 6\nChan. 7\nChan. 8\nChan. "
 								"9\nChan. 10\nChan. 11\nChan. 12\nChan. 13\nChan. 14\nChan. 15\nChan. 16");
 		lv_obj_set_width(chan_dropdown, 100);
-
-		auto pc_row = create_labeled_dropdown(panel);
-		lv_obj_set_width(pc_row, 300);
-		lv_obj_move_to_index(pc_row, 2);
-		lv_label_set_text(lv_obj_get_child(pc_row, 0), "PC #:");
-		pc_dropdown = lv_obj_get_child(pc_row, 1);
-		lv_obj_set_width(pc_dropdown, 210);
 	}
 
 	static void chan_changed_cb(lv_event_t *event) {

--- a/firmware/src/gui/pages/midi_pc_assign_dialog.hh
+++ b/firmware/src/gui/pages/midi_pc_assign_dialog.hh
@@ -1,8 +1,7 @@
 #pragma once
 #include "fs/helpers.hh"
 #include "gui/gui_state.hh"
-#include "gui/helpers/lv_helpers.hh"
-#include "gui/slsexport/meta5/ui.h"
+#include "gui/pages/confirm_popup.hh"
 #include "gui/slsexport/ui_local.h"
 #include "user_settings/midi_pc_settings.hh"
 #include <algorithm>
@@ -11,41 +10,33 @@
 namespace MetaModule
 {
 
-struct MidiPCAssignDialog {
-	lv_obj_t *panel;
-	lv_obj_t *chan_dropdown;
-	lv_obj_t *pc_dropdown;
-	lv_obj_t *cancel_button;
-	lv_obj_t *ok_button;
+struct MidiPCAssignDialog : ConfirmPopup {
+	lv_obj_t *chan_dropdown = nullptr;
+	lv_obj_t *pc_dropdown = nullptr;
 
-	lv_group_t *group;
-	lv_group_t *base_group = nullptr;
-	bool visible = false;
-
-	MidiPCPatchLoadSettings *midi_settings = nullptr;
-	GuiState *gui_state = nullptr;
+	MidiPCPatchLoadSettings &midi_settings;
+	GuiState &gui_state;
 	std::string current_path;
 
-	MidiPCAssignDialog()
-		: group(lv_group_create()) {
+	MidiPCAssignDialog(MidiPCPatchLoadSettings &settings, GuiState &gs)
+		: ConfirmPopup{}
+		, midi_settings{settings}
+		, gui_state{gs} {
 		init_widgets();
 	}
 
 	void init(lv_obj_t *base, lv_group_t *parent_group) {
-		lv_obj_set_parent(panel, base);
-		base_group = parent_group;
-		lv_hide(panel);
+		ConfirmPopup::init(base, parent_group);
 	}
 
-	void show(std::string_view path, MidiPCPatchLoadSettings &settings, GuiState &gs) {
-		midi_settings = &settings;
-		gui_state = &gs;
+	void show(std::string_view path) {
+		// TODO: move settings and gs to constructor
 		current_path = path;
 
 		uint32_t init_chan = 0;
 		uint32_t init_pc = 0;
 		bool found = false;
-		for (auto const &e : settings.entries) {
+		for (auto const &e : midi_settings.entries) {
 			if (e.path == current_path) {
 				init_chan = e.channel;
 				init_pc = e.pc;
@@ -58,31 +49,51 @@ struct MidiPCAssignDialog {
 			init_pc = find_free_pc(0);
 		}
 
-		// Remove callback before setting initial values to avoid spurious rebuilds
 		lv_obj_remove_event_cb(chan_dropdown, chan_changed_cb);
 		lv_dropdown_set_selected(chan_dropdown, init_chan);
 		rebuild_pc_options(init_chan);
 		lv_dropdown_set_selected(pc_dropdown, init_pc);
 		lv_obj_add_event_cb(chan_dropdown, chan_changed_cb, LV_EVENT_VALUE_CHANGED, this);
 
+		ConfirmPopup::show(
+			[this](unsigned) {
+				uint32_t chan = lv_dropdown_get_selected(chan_dropdown);
+				uint32_t pc = lv_dropdown_get_selected(pc_dropdown);
+
+				auto &entries = midi_settings.entries;
+				std::erase_if(entries, [=, this](auto const &e) {
+					bool path_match = e.path == current_path;
+					bool pc_match = e.pc == pc && (chan == 0 || e.channel == 0 || (chan == e.channel));
+					return path_match || pc_match;
+				});
+				entries.push_back({current_path, chan, pc});
+
+				gui_state.do_write_settings = true;
+			},
+			"Load on MIDI PC",
+			"OK");
+
 		lv_group_remove_all_objs(group);
 		lv_group_add_obj(group, chan_dropdown);
 		lv_group_add_obj(group, pc_dropdown);
 		lv_group_add_obj(group, cancel_button);
-		lv_group_add_obj(group, ok_button);
+		lv_group_add_obj(group, confirm_button);
 		lv_group_set_wrap(group, false);
-
-		lv_show(panel);
-		lv_group_activate(group);
-		lv_group_focus_obj(ok_button);
-		visible = true;
+		lv_group_focus_obj(confirm_button);
 	}
 
 	void hide() {
-		lv_obj_remove_event_cb(chan_dropdown, chan_changed_cb);
-		lv_hide(panel);
-		lv_group_activate(base_group);
-		visible = false;
+		if (lv_dropdown_is_open(chan_dropdown)) {
+			lv_dropdown_close(chan_dropdown);
+			lv_obj_clear_state(chan_dropdown, LV_STATE_EDITED);
+			lv_group_set_editing(group, false);
+		} else if (lv_dropdown_is_open(pc_dropdown)) {
+			lv_dropdown_close(pc_dropdown);
+			lv_obj_clear_state(pc_dropdown, LV_STATE_EDITED);
+			lv_group_set_editing(group, false);
+		} else {
+			ConfirmPopup::hide();
+		}
 	}
 
 	bool is_visible() {
@@ -93,7 +104,7 @@ private:
 	uint32_t find_free_pc(uint32_t channel) {
 		for (uint32_t pc = 0; pc <= 127; pc++) {
 			bool taken = false;
-			for (auto const &e : midi_settings->entries) {
+			for (auto const &e : midi_settings.entries) {
 				if (e.path == current_path)
 					continue;
 				bool chan_match = (channel == 0) || (e.channel == 0) || (e.channel == channel);
@@ -112,9 +123,9 @@ private:
 		std::string options;
 		for (uint32_t pc = 0; pc <= 127; pc++) {
 			options += std::to_string(pc);
-			for (auto const &e : midi_settings->entries) {
-				if (e.path == current_path)
-					continue;
+			for (auto const &e : midi_settings.entries) {
+				// if (e.path == current_path)
+				// 	continue;
 				bool chan_match = (channel == 0) || (e.channel == 0) || (e.channel == channel);
 				if (chan_match && e.pc == pc) {
 					auto [fname, vol] = split_volume(e.path);
@@ -124,7 +135,7 @@ private:
 					if (name.ends_with(".yml"))
 						name.resize(name.size() - 4);
 					options += " [" + name + "]";
-					break;
+					// break;
 				}
 			}
 			if (pc < 127)
@@ -133,132 +144,41 @@ private:
 		lv_dropdown_set_options(pc_dropdown, options.c_str());
 	}
 
-	static void chan_changed_cb(lv_event_t *event) {
-		auto self = static_cast<MidiPCAssignDialog *>(event->user_data);
-		uint32_t chan = lv_dropdown_get_selected(self->chan_dropdown);
-		uint32_t cur_pc = lv_dropdown_get_selected(self->pc_dropdown);
-		self->rebuild_pc_options(chan);
-		lv_dropdown_set_selected(self->pc_dropdown, cur_pc);
-	}
-
-	static void button_cb(lv_event_t *event) {
-		auto self = static_cast<MidiPCAssignDialog *>(event->user_data);
-
-		if (event->target == self->ok_button && self->midi_settings) {
-			uint32_t chan = lv_dropdown_get_selected(self->chan_dropdown);
-			uint32_t pc = lv_dropdown_get_selected(self->pc_dropdown);
-
-			auto &entries = self->midi_settings->entries;
-			entries.erase(
-				std::remove_if(entries.begin(), entries.end(),
-					[self](auto const &e) { return e.path == self->current_path; }),
-				entries.end());
-			entries.push_back({self->current_path, chan, pc});
-
-			if (self->gui_state)
-				self->gui_state->do_write_settings = true;
-		}
-
-		self->hide();
-	}
-
-	lv_obj_t *make_dialog_button(lv_obj_t *parent, const char *text, uint32_t bg_color) {
-		auto btn = lv_btn_create(parent);
-		lv_obj_set_width(btn, LV_SIZE_CONTENT);
-		lv_obj_set_height(btn, LV_SIZE_CONTENT);
-		lv_obj_set_align(btn, LV_ALIGN_CENTER);
-		lv_obj_add_flag(btn, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
-		lv_obj_clear_flag(btn,
-						  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE |
-							  LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN);
-		lv_obj_set_style_radius(btn, 20, LV_STATE_DEFAULT);
-		lv_obj_set_style_bg_color(btn, lv_color_hex(bg_color), LV_STATE_DEFAULT);
-		lv_obj_set_style_bg_opa(btn, 255, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_left(btn, 10, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_right(btn, 10, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_top(btn, 6, LV_STATE_DEFAULT);
-		lv_obj_set_style_pad_bottom(btn, 6, LV_STATE_DEFAULT);
-		lv_obj_set_style_outline_opa(btn, 0, LV_STATE_PRESSED);
-		lv_obj_set_style_outline_color(btn, lv_color_hex(0xFFFFFF), LV_STATE_FOCUS_KEY);
-		lv_obj_set_style_outline_opa(btn, 255, LV_STATE_FOCUS_KEY);
-		lv_obj_set_style_outline_width(btn, 2, LV_STATE_FOCUS_KEY);
-		lv_obj_set_style_outline_pad(btn, 3, LV_STATE_FOCUS_KEY);
-
-		auto label = lv_label_create(btn);
-		lv_obj_set_align(label, LV_ALIGN_CENTER);
-		lv_label_set_text(label, text);
-		lv_obj_set_style_text_color(label, lv_color_hex(0xFFFFFF), LV_STATE_DEFAULT);
-		lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded50016, LV_STATE_DEFAULT);
-
-		return btn;
-	}
-
 	void init_widgets() {
-		panel = lv_obj_create(lv_layer_top());
-		lv_obj_set_width(panel, 200);
-		lv_obj_set_height(panel, LV_SIZE_CONTENT);
-		lv_obj_set_align(panel, LV_ALIGN_CENTER);
-		lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
-		lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-		lv_obj_add_flag(panel, LV_OBJ_FLAG_FLOATING | LV_OBJ_FLAG_SCROLL_ON_FOCUS);
-		lv_obj_clear_flag(panel,
-						  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE |
-							  LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC |
-							  LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN);
-		lv_obj_set_style_radius(panel, 4, LV_STATE_DEFAULT);
-		lv_obj_set_style_bg_color(panel, lv_color_hex(0x333333), LV_STATE_DEFAULT);
-		lv_obj_set_style_bg_opa(panel, 255, LV_STATE_DEFAULT);
-		lv_obj_set_style_border_width(panel, 0, LV_STATE_DEFAULT);
-		lv_obj_set_style_outline_color(panel, lv_color_hex(0x777777), LV_STATE_DEFAULT);
-		lv_obj_set_style_outline_opa(panel, 255, LV_STATE_DEFAULT);
-		lv_obj_set_style_outline_width(panel, 2, LV_STATE_DEFAULT);
-		lv_obj_set_style_outline_pad(panel, 1, LV_STATE_DEFAULT);
+		lv_obj_set_width(panel, 310);
 		lv_obj_set_style_pad_row(panel, 6, LV_STATE_DEFAULT);
 		lv_obj_set_style_pad_left(panel, 8, LV_STATE_DEFAULT);
 		lv_obj_set_style_pad_right(panel, 8, LV_STATE_DEFAULT);
 		lv_obj_set_style_pad_top(panel, 8, LV_STATE_DEFAULT);
 		lv_obj_set_style_pad_bottom(panel, 8, LV_STATE_DEFAULT);
-
-		auto title = lv_label_create(panel);
-		lv_obj_set_width(title, LV_SIZE_CONTENT);
-		lv_obj_set_height(title, LV_SIZE_CONTENT);
-		lv_obj_set_align(title, LV_ALIGN_CENTER);
-		lv_label_set_text(title, "Load on MIDI PC");
-		lv_obj_set_style_text_color(title, lv_color_hex(0xEEEEEE), LV_STATE_DEFAULT);
-		lv_obj_set_style_text_font(title, &ui_font_MuseoSansRounded70016, LV_STATE_DEFAULT);
+		lv_obj_set_width(message_label, LV_SIZE_CONTENT);
 
 		auto chan_row = create_labeled_dropdown(panel);
+		lv_obj_set_width(chan_row, 300);
+		lv_obj_move_to_index(chan_row, 1);
 		lv_label_set_text(lv_obj_get_child(chan_row, 0), "Channel:");
 		chan_dropdown = lv_obj_get_child(chan_row, 1);
+
 		lv_dropdown_set_options(chan_dropdown,
 								"Any\nChan. 1\nChan. 2\nChan. 3\nChan. 4\nChan. 5\nChan. 6\nChan. 7\nChan. 8\nChan. "
 								"9\nChan. 10\nChan. 11\nChan. 12\nChan. 13\nChan. 14\nChan. 15\nChan. 16");
-		lv_obj_set_width(chan_dropdown, 80);
+		lv_obj_set_width(chan_dropdown, 100);
 
 		auto pc_row = create_labeled_dropdown(panel);
+		lv_obj_set_width(pc_row, 300);
+		lv_obj_move_to_index(pc_row, 2);
 		lv_label_set_text(lv_obj_get_child(pc_row, 0), "PC #:");
 		pc_dropdown = lv_obj_get_child(pc_row, 1);
-		lv_obj_set_width(pc_dropdown, 110);
+		lv_obj_set_width(pc_dropdown, 210);
+	}
 
-		auto button_row = lv_obj_create(panel);
-		lv_obj_remove_style_all(button_row);
-		lv_obj_set_width(button_row, LV_SIZE_CONTENT);
-		lv_obj_set_height(button_row, LV_SIZE_CONTENT);
-		lv_obj_set_align(button_row, LV_ALIGN_CENTER);
-		lv_obj_set_flex_flow(button_row, LV_FLEX_FLOW_ROW);
-		lv_obj_set_flex_align(button_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-		lv_obj_clear_flag(button_row,
-						  LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM |
-							  LV_OBJ_FLAG_SCROLL_CHAIN);
-		lv_obj_set_style_pad_column(button_row, 12, LV_STATE_DEFAULT);
-
-		cancel_button = make_dialog_button(button_row, "Cancel", 0x777777);
-		ok_button = make_dialog_button(button_row, "OK", 0x2095F6);
-
-		lv_obj_add_event_cb(cancel_button, button_cb, LV_EVENT_CLICKED, this);
-		lv_obj_add_event_cb(ok_button, button_cb, LV_EVENT_CLICKED, this);
-
-		lv_hide(panel);
+	static void chan_changed_cb(lv_event_t *event) {
+		printf("chan changed\n");
+		auto self = static_cast<MidiPCAssignDialog *>(event->user_data);
+		uint32_t chan = lv_dropdown_get_selected(self->chan_dropdown);
+		uint32_t cur_pc = lv_dropdown_get_selected(self->pc_dropdown);
+		self->rebuild_pc_options(chan);
+		lv_dropdown_set_selected(self->pc_dropdown, cur_pc);
 	}
 };
 

--- a/firmware/src/gui/pages/midi_pc_assign_dialog.hh
+++ b/firmware/src/gui/pages/midi_pc_assign_dialog.hh
@@ -1,0 +1,265 @@
+#pragma once
+#include "fs/helpers.hh"
+#include "gui/gui_state.hh"
+#include "gui/helpers/lv_helpers.hh"
+#include "gui/slsexport/meta5/ui.h"
+#include "gui/slsexport/ui_local.h"
+#include "user_settings/midi_pc_settings.hh"
+#include <algorithm>
+#include <string>
+
+namespace MetaModule
+{
+
+struct MidiPCAssignDialog {
+	lv_obj_t *panel;
+	lv_obj_t *chan_dropdown;
+	lv_obj_t *pc_dropdown;
+	lv_obj_t *cancel_button;
+	lv_obj_t *ok_button;
+
+	lv_group_t *group;
+	lv_group_t *base_group = nullptr;
+	bool visible = false;
+
+	MidiPCPatchLoadSettings *midi_settings = nullptr;
+	GuiState *gui_state = nullptr;
+	std::string current_path;
+
+	MidiPCAssignDialog()
+		: group(lv_group_create()) {
+		init_widgets();
+	}
+
+	void init(lv_obj_t *base, lv_group_t *parent_group) {
+		lv_obj_set_parent(panel, base);
+		base_group = parent_group;
+		lv_hide(panel);
+	}
+
+	void show(std::string_view path, MidiPCPatchLoadSettings &settings, GuiState &gs) {
+		midi_settings = &settings;
+		gui_state = &gs;
+		current_path = path;
+
+		uint32_t init_chan = 0;
+		uint32_t init_pc = 0;
+		bool found = false;
+		for (auto const &e : settings.entries) {
+			if (e.path == current_path) {
+				init_chan = e.channel;
+				init_pc = e.pc;
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			init_chan = 0;
+			init_pc = find_free_pc(0);
+		}
+
+		// Remove callback before setting initial values to avoid spurious rebuilds
+		lv_obj_remove_event_cb(chan_dropdown, chan_changed_cb);
+		lv_dropdown_set_selected(chan_dropdown, init_chan);
+		rebuild_pc_options(init_chan);
+		lv_dropdown_set_selected(pc_dropdown, init_pc);
+		lv_obj_add_event_cb(chan_dropdown, chan_changed_cb, LV_EVENT_VALUE_CHANGED, this);
+
+		lv_group_remove_all_objs(group);
+		lv_group_add_obj(group, chan_dropdown);
+		lv_group_add_obj(group, pc_dropdown);
+		lv_group_add_obj(group, cancel_button);
+		lv_group_add_obj(group, ok_button);
+		lv_group_set_wrap(group, false);
+
+		lv_show(panel);
+		lv_group_activate(group);
+		lv_group_focus_obj(ok_button);
+		visible = true;
+	}
+
+	void hide() {
+		lv_obj_remove_event_cb(chan_dropdown, chan_changed_cb);
+		lv_hide(panel);
+		lv_group_activate(base_group);
+		visible = false;
+	}
+
+	bool is_visible() {
+		return visible;
+	}
+
+private:
+	uint32_t find_free_pc(uint32_t channel) {
+		for (uint32_t pc = 0; pc <= 127; pc++) {
+			bool taken = false;
+			for (auto const &e : midi_settings->entries) {
+				if (e.path == current_path)
+					continue;
+				bool chan_match = (channel == 0) || (e.channel == 0) || (e.channel == channel);
+				if (chan_match && e.pc == pc) {
+					taken = true;
+					break;
+				}
+			}
+			if (!taken)
+				return pc;
+		}
+		return 0;
+	}
+
+	void rebuild_pc_options(uint32_t channel) {
+		std::string options;
+		for (uint32_t pc = 0; pc <= 127; pc++) {
+			options += std::to_string(pc);
+			for (auto const &e : midi_settings->entries) {
+				if (e.path == current_path)
+					continue;
+				bool chan_match = (channel == 0) || (e.channel == 0) || (e.channel == channel);
+				if (chan_match && e.pc == pc) {
+					auto [fname, vol] = split_volume(e.path);
+					auto name = std::string(fname);
+					if (auto pos = name.rfind('/'); pos != std::string::npos)
+						name = name.substr(pos + 1);
+					if (name.ends_with(".yml"))
+						name.resize(name.size() - 4);
+					options += " [" + name + "]";
+					break;
+				}
+			}
+			if (pc < 127)
+				options += '\n';
+		}
+		lv_dropdown_set_options(pc_dropdown, options.c_str());
+	}
+
+	static void chan_changed_cb(lv_event_t *event) {
+		auto self = static_cast<MidiPCAssignDialog *>(event->user_data);
+		uint32_t chan = lv_dropdown_get_selected(self->chan_dropdown);
+		uint32_t cur_pc = lv_dropdown_get_selected(self->pc_dropdown);
+		self->rebuild_pc_options(chan);
+		lv_dropdown_set_selected(self->pc_dropdown, cur_pc);
+	}
+
+	static void button_cb(lv_event_t *event) {
+		auto self = static_cast<MidiPCAssignDialog *>(event->user_data);
+
+		if (event->target == self->ok_button && self->midi_settings) {
+			uint32_t chan = lv_dropdown_get_selected(self->chan_dropdown);
+			uint32_t pc = lv_dropdown_get_selected(self->pc_dropdown);
+
+			auto &entries = self->midi_settings->entries;
+			entries.erase(
+				std::remove_if(entries.begin(), entries.end(),
+					[self](auto const &e) { return e.path == self->current_path; }),
+				entries.end());
+			entries.push_back({self->current_path, chan, pc});
+
+			if (self->gui_state)
+				self->gui_state->do_write_settings = true;
+		}
+
+		self->hide();
+	}
+
+	lv_obj_t *make_dialog_button(lv_obj_t *parent, const char *text, uint32_t bg_color) {
+		auto btn = lv_btn_create(parent);
+		lv_obj_set_width(btn, LV_SIZE_CONTENT);
+		lv_obj_set_height(btn, LV_SIZE_CONTENT);
+		lv_obj_set_align(btn, LV_ALIGN_CENTER);
+		lv_obj_add_flag(btn, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+		lv_obj_clear_flag(btn,
+						  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE |
+							  LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN);
+		lv_obj_set_style_radius(btn, 20, LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_color(btn, lv_color_hex(bg_color), LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(btn, 255, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_left(btn, 10, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(btn, 10, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(btn, 6, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(btn, 6, LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_opa(btn, 0, LV_STATE_PRESSED);
+		lv_obj_set_style_outline_color(btn, lv_color_hex(0xFFFFFF), LV_STATE_FOCUS_KEY);
+		lv_obj_set_style_outline_opa(btn, 255, LV_STATE_FOCUS_KEY);
+		lv_obj_set_style_outline_width(btn, 2, LV_STATE_FOCUS_KEY);
+		lv_obj_set_style_outline_pad(btn, 3, LV_STATE_FOCUS_KEY);
+
+		auto label = lv_label_create(btn);
+		lv_obj_set_align(label, LV_ALIGN_CENTER);
+		lv_label_set_text(label, text);
+		lv_obj_set_style_text_color(label, lv_color_hex(0xFFFFFF), LV_STATE_DEFAULT);
+		lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded50016, LV_STATE_DEFAULT);
+
+		return btn;
+	}
+
+	void init_widgets() {
+		panel = lv_obj_create(lv_layer_top());
+		lv_obj_set_width(panel, 200);
+		lv_obj_set_height(panel, LV_SIZE_CONTENT);
+		lv_obj_set_align(panel, LV_ALIGN_CENTER);
+		lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
+		lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+		lv_obj_add_flag(panel, LV_OBJ_FLAG_FLOATING | LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+		lv_obj_clear_flag(panel,
+						  LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE |
+							  LV_OBJ_FLAG_GESTURE_BUBBLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC |
+							  LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN);
+		lv_obj_set_style_radius(panel, 4, LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_color(panel, lv_color_hex(0x333333), LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(panel, 255, LV_STATE_DEFAULT);
+		lv_obj_set_style_border_width(panel, 0, LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_color(panel, lv_color_hex(0x777777), LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_opa(panel, 255, LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_width(panel, 2, LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_pad(panel, 1, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_row(panel, 6, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_left(panel, 8, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(panel, 8, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(panel, 8, LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(panel, 8, LV_STATE_DEFAULT);
+
+		auto title = lv_label_create(panel);
+		lv_obj_set_width(title, LV_SIZE_CONTENT);
+		lv_obj_set_height(title, LV_SIZE_CONTENT);
+		lv_obj_set_align(title, LV_ALIGN_CENTER);
+		lv_label_set_text(title, "Load on MIDI PC");
+		lv_obj_set_style_text_color(title, lv_color_hex(0xEEEEEE), LV_STATE_DEFAULT);
+		lv_obj_set_style_text_font(title, &ui_font_MuseoSansRounded70016, LV_STATE_DEFAULT);
+
+		auto chan_row = create_labeled_dropdown(panel);
+		lv_label_set_text(lv_obj_get_child(chan_row, 0), "Channel:");
+		chan_dropdown = lv_obj_get_child(chan_row, 1);
+		lv_dropdown_set_options(chan_dropdown,
+								"Any\nChan. 1\nChan. 2\nChan. 3\nChan. 4\nChan. 5\nChan. 6\nChan. 7\nChan. 8\nChan. "
+								"9\nChan. 10\nChan. 11\nChan. 12\nChan. 13\nChan. 14\nChan. 15\nChan. 16");
+		lv_obj_set_width(chan_dropdown, 80);
+
+		auto pc_row = create_labeled_dropdown(panel);
+		lv_label_set_text(lv_obj_get_child(pc_row, 0), "PC #:");
+		pc_dropdown = lv_obj_get_child(pc_row, 1);
+		lv_obj_set_width(pc_dropdown, 110);
+
+		auto button_row = lv_obj_create(panel);
+		lv_obj_remove_style_all(button_row);
+		lv_obj_set_width(button_row, LV_SIZE_CONTENT);
+		lv_obj_set_height(button_row, LV_SIZE_CONTENT);
+		lv_obj_set_align(button_row, LV_ALIGN_CENTER);
+		lv_obj_set_flex_flow(button_row, LV_FLEX_FLOW_ROW);
+		lv_obj_set_flex_align(button_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+		lv_obj_clear_flag(button_row,
+						  LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_MOMENTUM |
+							  LV_OBJ_FLAG_SCROLL_CHAIN);
+		lv_obj_set_style_pad_column(button_row, 12, LV_STATE_DEFAULT);
+
+		cancel_button = make_dialog_button(button_row, "Cancel", 0x777777);
+		ok_button = make_dialog_button(button_row, "OK", 0x2095F6);
+
+		lv_obj_add_event_cb(cancel_button, button_cb, LV_EVENT_CLICKED, this);
+		lv_obj_add_event_cb(ok_button, button_cb, LV_EVENT_CLICKED, this);
+
+		lv_hide(panel);
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include "fs/helpers.hh"
 #include "gui/elements/screensaver.hh"
 #include "gui/knobset_button.hh"
 #include "gui/notify/display.hh"
@@ -56,6 +57,10 @@ class PageManager {
 	MidiMapViewPage page_midimap{info};
 	FullscreenGraphicPage page_fullscreen_graphic{info};
 
+	enum class MidiPCLoadState { Idle, Requesting, Loading };
+	MidiPCLoadState midi_pc_load_state = MidiPCLoadState::Idle;
+	PatchLocation midi_pc_target_loc{};
+
 public:
 	PageBase *cur_page = &page_mainmenu;
 
@@ -103,6 +108,8 @@ public:
 	void update_current_page() {
 
 		handle_knobset_change();
+
+		handle_midi_pc_patch_load();
 
 		update_screensaver();
 
@@ -237,6 +244,57 @@ public:
 
 		if (button_light.display_knobset() != info.page_list.get_active_knobset()) {
 			button_light.display_knobset(info.page_list.get_active_knobset());
+		}
+	}
+
+	void handle_midi_pc_patch_load() {
+		if (!info.settings.midi_pc_patch_load.enabled)
+			return;
+
+		switch (midi_pc_load_state) {
+			case MidiPCLoadState::Idle: {
+				auto &pc = info.params.last_midi_pc;
+				if (!pc.changed)
+					return;
+				pc.changed = false;
+
+				uint32_t recv_chan = uint32_t(pc.channel) + 1; // 0-15 → 1-16
+				uint32_t recv_pc = pc.pc;
+
+				for (auto const &entry : info.settings.midi_pc_patch_load.entries) {
+					bool chan_match = (entry.channel == 0) || (entry.channel == recv_chan);
+					if (chan_match && entry.pc == recv_pc) {
+						auto [filename, vol] = split_volume(entry.path);
+						midi_pc_target_loc = PatchLocation{std::string(filename), vol};
+						midi_pc_load_state = MidiPCLoadState::Requesting;
+						break;
+					}
+				}
+			} break;
+
+			case MidiPCLoadState::Requesting: {
+				if (info.patch_storage.request_load_patch(midi_pc_target_loc)) {
+					info.patch_playloader.stop_audio();
+					midi_pc_load_state = MidiPCLoadState::Loading;
+				}
+			} break;
+
+			case MidiPCLoadState::Loading: {
+				auto message = info.patch_storage.get_message();
+				if (message.message_type == FileStorageProxy::LoadFileOK) {
+					auto data = info.patch_storage.get_patch_data(message.bytes_read);
+					if (info.open_patch_manager.open_patch(data, midi_pc_target_loc, message.timestamp)) {
+						info.open_patch_manager.start_viewing(midi_pc_target_loc);
+						info.patch_playloader.request_load_view_patch();
+					} else {
+						info.notify_queue.put({"MIDI PC: error loading patch", Notification::Priority::Error, 2000});
+					}
+					midi_pc_load_state = MidiPCLoadState::Idle;
+				} else if (message.message_type == FileStorageProxy::LoadFileFailed) {
+					info.notify_queue.put({"MIDI PC: patch file not found", Notification::Priority::Error, 2000});
+					midi_pc_load_state = MidiPCLoadState::Idle;
+				}
+			} break;
 		}
 	}
 

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -62,7 +62,6 @@ class PageManager {
 	FullscreenGraphicPage page_fullscreen_graphic{info};
 
 	enum class MidiPCLoadState { Idle, Requesting, Loading };
-	MidiPCLoadState midi_pc_load_state = MidiPCLoadState::Idle;
 	PatchLocation midi_pc_target_loc{};
 
 public:

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -286,7 +286,21 @@ public:
 					auto data = info.patch_storage.get_patch_data(message.bytes_read);
 					if (info.open_patch_manager.open_patch(data, midi_pc_target_loc, message.timestamp)) {
 						info.open_patch_manager.start_viewing(midi_pc_target_loc);
-						info.patch_playloader.request_load_view_patch();
+
+						// Clear cc events so we don't change knobsets with stale events
+						for (auto &cc : info.params.midi_ccs)
+							cc.changed = false;
+
+						missing_plugins.start(
+							info.open_patch_manager.get_view_patch(), lv_group_get_default(), [this](bool) {
+								PageArguments args;
+								args.patch_loc_hash = PatchLocHash{midi_pc_target_loc};
+								gui_state.force_redraw_patch = true;
+								page_list.request_new_page(PageId::PatchView, args);
+								info.patch_playloader.request_load_view_patch();
+								midi_pc_load_state = MidiPCLoadState::Idle;
+							});
+
 					} else {
 						info.notify_queue.put({"MIDI PC: error loading patch", Notification::Priority::Error, 2000});
 					}

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -256,6 +256,7 @@ public:
 				auto &pc = info.params.last_midi_pc;
 				if (!pc.changed)
 					return;
+				printf("PC %d ch:%d\n", pc.pc, pc.changed);
 				pc.changed = false;
 
 				uint32_t recv_chan = uint32_t(pc.channel) + 1; // 0-15 → 1-16

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -8,6 +8,7 @@
 #include "metaparams.hh"
 #include "params_state.hh"
 #include "patch_file/file_storage_proxy.hh"
+#include "patch_file/patch_switcher.hh"
 #include "patch_play/patch_mod_queue.hh"
 #include "patch_play/patch_playloader.hh"
 #include "user_settings/settings_file.hh"
@@ -24,6 +25,7 @@
 #include "gui/pages/patch_selector.hh"
 #include "gui/pages/patch_view.hh"
 #include "gui/pages/system_menu.hh"
+
 #include "vcv_plugin/internal/osdialog-mm.hh"
 
 namespace MetaModule
@@ -44,6 +46,8 @@ class PageManager {
 	GuiState gui_state;
 	ButtonLight button_light;
 	Screensaver &screensaver;
+	ReloadPatch patch_reloader;
+	PatchSwitcher patch_switch;
 
 	MainMenuPage page_mainmenu{info};
 	PatchSelectorPage page_patchsel{info, subdir_panel};
@@ -94,7 +98,9 @@ public:
 			   .file_change_checker = file_change_checker,
 			   .file_browser = file_browser,
 			   .missing_plugins = missing_plugins}
-		, screensaver{screensaver} {
+		, screensaver{screensaver}
+		, patch_reloader{patch_storage, open_patch_manager, settings.filesystem}
+		, patch_switch{patch_reloader, info.patch_playloader, missing_plugins} {
 
 		// Register file browser with VCV to support osdialog/async_dialog_filebrowser
 		register_file_browser_vcv(file_browser, file_save_dialog);
@@ -123,32 +129,7 @@ public:
 				cur_page->focus(newpage->args);
 			}
 		} else {
-			if (file_browser.is_visible()) {
-				if (gui_state.back_button.is_just_released())
-					file_browser.back_event();
-				file_browser.update();
-
-				gui_state.file_browser_visible.register_state(true);
-
-			} else if (file_save_dialog.is_visible()) {
-				if (gui_state.back_button.is_just_released())
-					file_save_dialog.back_event();
-
-				file_save_dialog.update();
-
-				gui_state.file_browser_visible.register_state(true);
-
-			} else if (missing_plugins.is_active()) {
-				missing_plugins.process();
-
-			} else {
-				gui_state.file_browser_visible.register_state(false);
-
-				cur_page->update();
-
-				// Don't let old events do surprising things when you change pages
-				gui_state.file_browser_visible.clear_events();
-			}
+			handle_dialog_popups();
 		}
 
 		handle_audio_errors();
@@ -158,6 +139,35 @@ public:
 		handle_write_settings();
 
 		screensaver.update();
+	}
+
+	void handle_dialog_popups() {
+		if (file_browser.is_visible()) {
+			if (gui_state.back_button.is_just_released())
+				file_browser.back_event();
+			file_browser.update();
+
+			gui_state.file_browser_visible.register_state(true);
+
+		} else if (file_save_dialog.is_visible()) {
+			if (gui_state.back_button.is_just_released())
+				file_save_dialog.back_event();
+
+			file_save_dialog.update();
+
+			gui_state.file_browser_visible.register_state(true);
+
+		} else if (missing_plugins.is_active()) {
+			missing_plugins.process();
+
+		} else {
+			gui_state.file_browser_visible.register_state(false);
+
+			cur_page->update();
+
+			// Don't let old events do surprising things when you change pages
+			gui_state.file_browser_visible.clear_events();
+		}
 	}
 
 	void handle_knobset_change() {
@@ -251,65 +261,33 @@ public:
 		if (!info.settings.midi_pc_patch_load.enabled)
 			return;
 
-		switch (midi_pc_load_state) {
-			case MidiPCLoadState::Idle: {
-				auto &pc = info.params.last_midi_pc;
-				if (!pc.changed)
-					return;
-				printf("PC %d ch:%d\n", pc.pc, pc.changed);
-				pc.changed = false;
+		if (auto &pc = info.params.last_midi_pc; pc.changed) {
+			pc.changed = false;
 
-				uint32_t recv_chan = uint32_t(pc.channel) + 1; // 0-15 → 1-16
-				uint32_t recv_pc = pc.pc;
+			for (auto const &entry : info.settings.midi_pc_patch_load.entries) {
+				bool chan_match = (entry.channel == 0) || (entry.channel == pc.channel + 1);
+				if (chan_match && entry.pc == pc.pc) {
+					auto [filename, vol] = split_volume(entry.path);
+					midi_pc_target_loc = PatchLocation{std::string(filename), vol};
 
-				for (auto const &entry : info.settings.midi_pc_patch_load.entries) {
-					bool chan_match = (entry.channel == 0) || (entry.channel == recv_chan);
-					if (chan_match && entry.pc == recv_pc) {
-						auto [filename, vol] = split_volume(entry.path);
-						midi_pc_target_loc = PatchLocation{std::string(filename), vol};
-						midi_pc_load_state = MidiPCLoadState::Requesting;
-						break;
+					// Clear cc events so we don't change knobsets with stale events
+					for (auto &cc : info.params.midi_ccs)
+						cc.changed = false;
+
+					auto result = patch_switch.jump_to_patch(midi_pc_target_loc, [this]() {
+						PageArguments args;
+						args.patch_loc_hash = PatchLocHash{midi_pc_target_loc};
+						gui_state.force_redraw_patch = true;
+						page_list.request_new_page(PageId::PatchView, args);
+						info.patch_playloader.request_load_view_patch();
+					});
+					if (!result.success) {
+						info.notify_queue.put({"MIDI PC: error loading patch: " + result.error_string,
+											   Notification::Priority::Error,
+											   2000});
 					}
 				}
-			} break;
-
-			case MidiPCLoadState::Requesting: {
-				if (info.patch_storage.request_load_patch(midi_pc_target_loc)) {
-					info.patch_playloader.stop_audio();
-					midi_pc_load_state = MidiPCLoadState::Loading;
-				}
-			} break;
-
-			case MidiPCLoadState::Loading: {
-				auto message = info.patch_storage.get_message();
-				if (message.message_type == FileStorageProxy::LoadFileOK) {
-					auto data = info.patch_storage.get_patch_data(message.bytes_read);
-					if (info.open_patch_manager.open_patch(data, midi_pc_target_loc, message.timestamp)) {
-						info.open_patch_manager.start_viewing(midi_pc_target_loc);
-
-						// Clear cc events so we don't change knobsets with stale events
-						for (auto &cc : info.params.midi_ccs)
-							cc.changed = false;
-
-						missing_plugins.start(
-							info.open_patch_manager.get_view_patch(), lv_group_get_default(), [this](bool) {
-								PageArguments args;
-								args.patch_loc_hash = PatchLocHash{midi_pc_target_loc};
-								gui_state.force_redraw_patch = true;
-								page_list.request_new_page(PageId::PatchView, args);
-								info.patch_playloader.request_load_view_patch();
-								midi_pc_load_state = MidiPCLoadState::Idle;
-							});
-
-					} else {
-						info.notify_queue.put({"MIDI PC: error loading patch", Notification::Priority::Error, 2000});
-					}
-					midi_pc_load_state = MidiPCLoadState::Idle;
-				} else if (message.message_type == FileStorageProxy::LoadFileFailed) {
-					info.notify_queue.put({"MIDI PC: patch file not found", Notification::Priority::Error, 2000});
-					midi_pc_load_state = MidiPCLoadState::Idle;
-				}
-			} break;
+			}
 		}
 	}
 

--- a/firmware/src/gui/pages/patch_selector.hh
+++ b/firmware/src/gui/pages/patch_selector.hh
@@ -11,6 +11,7 @@
 #include "gui/pages/patch_selector_subdir_panel.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/styles.hh"
+#include "patch_file/patch_switcher.hh"
 #include "patch_file/reload_patch.hh"
 #include "pr_dbg.hh"
 
@@ -26,6 +27,7 @@ struct PatchSelectorPage : PageBase {
 		, subdir_panel{subdir_panel}
 		, patchfiles{patch_storage.get_patch_list()}
 		, patchloader{patch_storage, patches, settings.filesystem}
+		, patch_switch{patchloader, patch_playloader, missing_plugins}
 		, roller_hover(ui_PatchSelectorPage, ui_PatchListRoller, [this] { redraw_cb(); }) {
 
 		init_bg(ui_PatchSelectorPage);
@@ -357,53 +359,47 @@ struct PatchSelectorPage : PageBase {
 				break;
 
 			case State::LoadPatchFile: {
+				hide_spinner();
+				// Clear cc events so we don't change knobsets with stale events
+				for (auto &cc : params.midi_ccs)
+					cc.changed = false;
 
-				// If the patch is not open, or if it's opened but modified on disk only
-				// then (re)load it from disk, checking for missing plugins
-				if (patchloader.needs_reloading(selected_patch)) {
-					show_spinner();
-
-					auto result = patchloader.reload_patch_file(selected_patch, [this] {
-						update_spinner();
-						lv_timer_handler();
-					});
-
-					if (result.success) {
-						patches.start_viewing(selected_patch);
-
-						// Clear cc events so we don't change knobsets with stale events
-						for (auto &cc : params.midi_ccs)
-							cc.changed = false;
-
-						missing_plugins.start(
-							patches.get_view_patch(), group, [this](bool) { exit_to_patch_view_page(); });
-						state = State::Closing;
-
-					} else {
-						lv_group_set_editing(group, true);
-						notify_queue.put({.message = result.error_string, .priority = Notification::Priority::Error});
-						state = State::Idle;
-					}
+				auto result = patch_switch.jump_to_patch(selected_patch, [this]() { exit_to_patch_view_page(); });
+				if (result.success) {
+					state = State::Closing;
 				} else {
-					// Here we know the patch is open already.
-					patches.start_viewing(selected_patch);
-
-					// If patch is unmodifed in RAM, then check for missing plugins
-					if (patches.find_open_patch(selected_patch)->modification_count == 0) {
-						missing_plugins.start(patches.get_view_patch(), group, [this](bool did_reload) {
-							if (did_reload)
-								patch_playloader.request_reload_playing_patch(false);
-							exit_to_patch_view_page();
-						});
-						state = State::Closing;
-
-					} else {
-						// Otherwise the patch has unsaved changes so just view it, don't reload/load anything
-						exit_to_patch_view_page();
-					}
+					lv_group_set_editing(group, true);
+					notify_queue.put({.message = result.error_string, .priority = Notification::Priority::Error});
+					state = State::Idle;
 				}
 
-				hide_spinner();
+				// If the patch is not open, or if it's opened but been modified via wifi or disk,
+				// then (re)load it from disk
+				// if (patchloader.needs_reloading(selected_patch)) {
+				// 	auto result = patchloader.reload_patch_file(selected_patch, [] { lv_timer_handler(); });
+				// 	if (!result.success) {
+				// 		lv_group_set_editing(group, true);
+				// 		notify_queue.put({.message = result.error_string, .priority = Notification::Priority::Error});
+				// 		state = State::Idle;
+				// 		break;
+				// 	}
+				// }
+				// patches.start_viewing(selected_patch);
+
+				// // If patch is unmodifed in RAM, then check for missing plugins
+				// if (patches.get_view_patch_modification_count() == 0) {
+				// 	missing_plugins.start(patches.get_view_patch(), group, [this](bool did_reload) {
+				// 		// If we loaded new plugins AND the patch was already playing, then reload patch into the player
+				// 		if (did_reload && patch_playloader.is_view_patch_playing())
+				// 			patch_playloader.request_load_view_patch();
+				// 		exit_to_patch_view_page();
+				// 	});
+				// 	state = State::Closing;
+
+				// } else {
+				// 	// Otherwise the patch has unsaved changes so just view it, don't reload/load anything
+				// 	exit_to_patch_view_page();
+				// }
 			} break;
 
 			case State::Closing:
@@ -525,6 +521,7 @@ private:
 	PatchDirList &patchfiles;
 	bool patchfiles_locked = true;
 	ReloadPatch patchloader;
+	PatchSwitcher patch_switch;
 
 	bool is_populating_subdir_panel = false;
 

--- a/firmware/src/gui/pages/patch_view_file_menu.hh
+++ b/firmware/src/gui/pages/patch_view_file_menu.hh
@@ -1,8 +1,10 @@
 #pragma once
+#include "fs/helpers.hh"
 #include "gui/helpers/lv_helpers.hh"
 #include "gui/notify/queue.hh"
 #include "gui/pages/confirm_popup.hh"
 #include "gui/pages/make_cable.hh"
+#include "gui/pages/midi_pc_assign_dialog.hh"
 #include "gui/pages/missing_plugin_scan.hh"
 #include "gui/pages/page_list.hh"
 #include "gui/pages/patch_save_dialog.hh"
@@ -52,12 +54,17 @@ struct PatchViewFileMenu {
 		lv_obj_move_to_index(make_default_patch_menu, 6);
 		lv_obj_add_event_cb(make_default_patch_menu, make_startup_patch, LV_EVENT_CLICKED, this);
 
+		midi_pc_menu_item = create_file_menu_item(ui_PatchFileMenu, "Load on MIDI PC");
+		lv_obj_move_to_index(midi_pc_menu_item, 7);
+		lv_obj_add_event_cb(midi_pc_menu_item, midi_pc_but_cb, LV_EVENT_CLICKED, this);
+
 		lv_group_add_obj(group, ui_PatchFileMenuCloseButton);
 		lv_group_add_obj(group, ui_PatchFileSaveBut);
 		lv_group_add_obj(group, ui_PatchFileDuplicateBut);
 		lv_group_add_obj(group, ui_PatchFileRenameBut);
 		lv_group_add_obj(group, ui_PatchFileRevertBut);
 		lv_group_add_obj(group, make_default_patch_menu);
+		lv_group_add_obj(group, midi_pc_menu_item);
 		lv_group_add_obj(group, ui_PatchFileDeleteBut);
 
 		lv_obj_set_width(ui_PatchFileMenu, 140);
@@ -67,6 +74,7 @@ struct PatchViewFileMenu {
 	void prepare_focus(lv_group_t *parent_group) {
 		base_group = parent_group;
 		confirm_popup.init(lv_layer_top(), base_group);
+		midi_pc_dialog.init(lv_layer_top(), base_group);
 	}
 
 	void back() {
@@ -78,6 +86,9 @@ struct PatchViewFileMenu {
 			missing_plugins.hide();
 			hide_menu();
 
+		} else if (midi_pc_dialog.is_visible()) {
+			midi_pc_dialog.hide();
+
 		} else if (visible) {
 			hide();
 		}
@@ -86,6 +97,7 @@ struct PatchViewFileMenu {
 	void hide() {
 		patch_save_dialog.hide();
 		confirm_popup.hide();
+		midi_pc_dialog.hide();
 		hide_menu();
 	}
 
@@ -110,6 +122,7 @@ struct PatchViewFileMenu {
 			lv_disable(ui_PatchFileDuplicateBut);
 			lv_disable(ui_PatchFileRenameBut);
 			lv_enable(ui_PatchFileDeleteBut);
+			lv_disable(midi_pc_menu_item);
 			lv_label_set_text(lv_obj_get_child(make_default_patch_menu, 0), "Startup Patch");
 		} else {
 			lv_group_focus_obj(ui_PatchFileSaveBut);
@@ -117,6 +130,7 @@ struct PatchViewFileMenu {
 			lv_enable(ui_PatchFileRenameBut);
 			lv_enable(ui_PatchFileDeleteBut);
 			lv_enable(ui_PatchFileRevertBut);
+			lv_enable(midi_pc_menu_item);
 
 			if (is_viewpatch_default()) {
 				lv_label_set_text(lv_obj_get_child(make_default_patch_menu, 0), "\xEF\x80\x8C Startup Patch");
@@ -141,7 +155,8 @@ struct PatchViewFileMenu {
 	}
 
 	bool is_visible() {
-		return confirm_popup.is_visible() || patch_save_dialog.is_visible() || missing_plugins.is_visible() || visible;
+		return confirm_popup.is_visible() || patch_save_dialog.is_visible() || missing_plugins.is_visible() ||
+			   midi_pc_dialog.is_visible() || visible;
 	}
 
 	bool is_active() {
@@ -413,6 +428,17 @@ private:
 			lv_label_get_text(ui_PatchFileRevertLabel));
 	}
 
+	static void midi_pc_but_cb(lv_event_t *event) {
+		if (!event || !event->user_data)
+			return;
+		auto page = static_cast<PatchViewFileMenu *>(event->user_data);
+
+		auto path = std::string(volume_string(page->patches.get_view_patch_vol())) +
+					page->patches.get_view_patch_filename();
+		page->hide_menu();
+		page->midi_pc_dialog.show(path, page->settings.midi_pc_patch_load, page->gui_state);
+	}
+
 	static void make_startup_patch(lv_event_t *event) {
 		if (!event || !event->user_data)
 			return;
@@ -437,8 +463,10 @@ private:
 
 	PatchSaveDialog patch_save_dialog;
 	ConfirmPopup confirm_popup;
+	MidiPCAssignDialog midi_pc_dialog;
 
 	lv_obj_t *make_default_patch_menu = nullptr;
+	lv_obj_t *midi_pc_menu_item = nullptr;
 
 	lv_group_t *group;
 	lv_group_t *base_group = nullptr;

--- a/firmware/src/gui/pages/patch_view_file_menu.hh
+++ b/firmware/src/gui/pages/patch_view_file_menu.hh
@@ -36,6 +36,7 @@ struct PatchViewFileMenu {
 		, gui_state{gui_state}
 		, settings{settings}
 		, patch_save_dialog{patch_storage, patches, play_loader, file_save_dialog, notify_queue, page_list}
+		, midi_pc_dialog{settings.midi_pc_patch_load, gui_state}
 		, group(lv_group_create())
 		, missing_plugins{missing_plugins} {
 		lv_obj_set_parent(ui_PatchFileMenu, lv_layer_top());
@@ -433,10 +434,10 @@ private:
 			return;
 		auto page = static_cast<PatchViewFileMenu *>(event->user_data);
 
-		auto path = std::string(volume_string(page->patches.get_view_patch_vol())) +
-					page->patches.get_view_patch_filename();
+		auto path =
+			std::string(volume_string(page->patches.get_view_patch_vol())) + page->patches.get_view_patch_filename();
 		page->hide_menu();
-		page->midi_pc_dialog.show(path, page->settings.midi_pc_patch_load, page->gui_state);
+		page->midi_pc_dialog.show(path);
 	}
 
 	static void make_startup_patch(lv_event_t *event) {

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -185,6 +185,10 @@ struct PrefsTab : SystemMenuTab {
 		return true;
 	}
 
+	void set_patch_clicked_callback(auto cb) {
+		midi_section.on_patch_clicked = std::move(cb);
+	}
+
 private:
 	static std::string samplerate_string(uint32_t sr) {
 		return std::to_string(sr / 1000) + "kHz";

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -30,6 +30,7 @@ struct PrefsTab : SystemMenuTab {
 		, gui_state{gui_state}
 		, fs{settings.filesystem}
 		, midi{settings.midi}
+		, midi_pc_patch_load{settings.midi_pc_patch_load}
 		, missing_plugins{settings.missing_plugins}
 		, button_exp_knobset{settings.button_exp_knobset}
 		, notifications{settings.notifications}
@@ -67,6 +68,7 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(fs_section.startup_patch_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(fs_section.max_patches_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(midi_section.feedback_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(midi_section.pc_patch_load_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(midi_section.knobset_control_check, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(midi_section.knobset_cc_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(midi_section.knobset_channel_dropdown, changed_cb, LV_EVENT_VALUE_CHANGED, this);
@@ -88,6 +90,7 @@ struct PrefsTab : SystemMenuTab {
 		lv_obj_add_event_cb(fs_section.startup_patch_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(fs_section.max_patches_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(midi_section.feedback_check, focus_cb, LV_EVENT_FOCUSED, this);
+		lv_obj_add_event_cb(midi_section.pc_patch_load_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(midi_section.knobset_control_check, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(midi_section.knobset_cc_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
 		lv_obj_add_event_cb(midi_section.knobset_channel_dropdown, focus_cb, LV_EVENT_FOCUSED, this);
@@ -226,6 +229,7 @@ private:
 		lv_show(catchup_section.allowjump_cont, catchup.mode == CatchupParam::Mode::ResumeOnEqual);
 
 		lv_check(midi_section.feedback_check, midi.midi_feedback == MidiSettings::MidiFeedback::Enabled);
+		lv_check(midi_section.pc_patch_load_check, midi_pc_patch_load.enabled);
 		lv_check(midi_section.knobset_control_check, midi.knobset_control == MidiSettings::KnobsetControl::Enabled);
 		lv_dropdown_set_selected(midi_section.knobset_cc_dropdown, midi.knobset_cc);
 		lv_dropdown_set_selected(midi_section.knobset_channel_dropdown, midi.knobset_channel - 1);
@@ -369,6 +373,10 @@ private:
 																				 MidiSettings::MidiFeedback::Disabled;
 	}
 
+	bool read_midi_pc_enabled_check() {
+		return lv_obj_has_state(midi_section.pc_patch_load_check, LV_STATE_CHECKED);
+	}
+
 	auto read_knobset_control_check() {
 		return lv_obj_has_state(midi_section.knobset_control_check, LV_STATE_CHECKED) ?
 				   MidiSettings::KnobsetControl::Enabled :
@@ -487,6 +495,12 @@ private:
 		auto midi_feedback = read_midi_feedback_check();
 		if (midi.midi_feedback != midi_feedback) {
 			midi.midi_feedback = midi_feedback;
+			gui_state.do_write_settings = true;
+		}
+
+		auto midi_pc_enabled = read_midi_pc_enabled_check();
+		if (midi_pc_patch_load.enabled != midi_pc_enabled) {
+			midi_pc_patch_load.enabled = midi_pc_enabled;
 			gui_state.do_write_settings = true;
 		}
 
@@ -675,6 +689,7 @@ private:
 		auto catchup_exclude_buttons = read_catchup_exclude_check();
 		auto fs_max_patches = read_fs_max_open_patches();
 		auto midi_feedback = read_midi_feedback_check();
+		auto midi_pc_enabled = read_midi_pc_enabled_check();
 		auto knobset_control = read_knobset_control_check();
 		auto knobset_cc = read_knobset_cc_dropdown();
 		auto knobset_channel = read_knobset_channel_dropdown();
@@ -696,7 +711,8 @@ private:
 			knobwake == screensaver.knobs_can_wake && catchupmode == catchup.mode &&
 			catchup_exclude_buttons == catchup.allow_jump_outofrange &&
 			load_initial_patch == settings.load_initial_patch && fs_max_patches == fs.max_open_patches &&
-			midi_feedback == midi.midi_feedback && knobset_control == midi.knobset_control &&
+			midi_feedback == midi.midi_feedback && midi_pc_enabled == midi_pc_patch_load.enabled &&
+			knobset_control == midi.knobset_control &&
 			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
 			mp_mode == missing_plugins.autoload && apply_sr == settings.patch_suggested_audio.apply_samplerate &&
 			apply_bs == settings.patch_suggested_audio.apply_blocksize && bexp == button_exp_knobset.button_expander &&
@@ -740,6 +756,7 @@ private:
 	GuiState &gui_state;
 	FilesystemSettings &fs;
 	MidiSettings &midi;
+	MidiPCPatchLoadSettings &midi_pc_patch_load;
 	MissingPluginSettings &missing_plugins;
 	ButtonExpKnobSetSettings &button_exp_knobset;
 	NotificationSettings &notifications;

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -148,6 +148,8 @@ struct PrefsTab : SystemMenuTab {
 	void prepare_focus(lv_group_t *group) override {
 		this->group = group;
 
+		midi_section.init_popup(ui_SystemMenuPrefsTab, group, settings.midi_pc_patch_load);
+
 		// Remove all objects and re-add the tab side bar
 		lv_group_remove_all_objs(group);
 		lv_group_add_obj(group, lv_tabview_get_tab_btns(ui_SystemMenuTabView));
@@ -647,6 +649,8 @@ private:
 			lv_group_set_editing(group, false);
 			return true;
 
+		} else if (midi_section.close_popup()) {
+			return true;
 		} else {
 			update_settings_from_dropdown();
 			return false;
@@ -712,9 +716,9 @@ private:
 			catchup_exclude_buttons == catchup.allow_jump_outofrange &&
 			load_initial_patch == settings.load_initial_patch && fs_max_patches == fs.max_open_patches &&
 			midi_feedback == midi.midi_feedback && midi_pc_enabled == midi_pc_patch_load.enabled &&
-			knobset_control == midi.knobset_control &&
-			knobset_cc == midi.knobset_cc && knobset_channel == midi.knobset_channel &&
-			mp_mode == missing_plugins.autoload && apply_sr == settings.patch_suggested_audio.apply_samplerate &&
+			knobset_control == midi.knobset_control && knobset_cc == midi.knobset_cc &&
+			knobset_channel == midi.knobset_channel && mp_mode == missing_plugins.autoload &&
+			apply_sr == settings.patch_suggested_audio.apply_samplerate &&
 			apply_bs == settings.patch_suggested_audio.apply_blocksize && bexp == button_exp_knobset.button_expander &&
 			bexp_back == button_exp_knobset.require_back && notif_amount == notifications.amount &&
 			notif_anim == notifications.animation)

--- a/firmware/src/gui/pages/system_menu.hh
+++ b/firmware/src/gui/pages/system_menu.hh
@@ -9,6 +9,7 @@
 #include "gui/pages/system_info_tab.hh"
 #include "gui/pages/system_tab.hh"
 #include "gui/slsexport/meta5/ui.h"
+#include "patch_file/patch_switcher.hh"
 #include "patch_file/reload_patch.hh"
 
 namespace MetaModule
@@ -29,6 +30,8 @@ struct SystemMenuPage : PageBase {
 					 info.settings,
 					 info.notify_queue}
 		, fwupdate_tab{patch_storage, patch_playloader}
+		, patch_reloader{patch_storage, patches, settings.filesystem}
+		, patch_switcher{patch_reloader, patch_playloader, missing_plugins}
 		, tab_bar(lv_tabview_get_tab_btns(ui_SystemMenuTabView)) {
 
 		init_bg(ui_SystemMenu);
@@ -62,22 +65,17 @@ struct SystemMenuPage : PageBase {
 
 		if (pending_patch_view) {
 			auto loc = *pending_patch_view;
+			pending_patch_view_args.patch_loc_hash = PatchLocHash{loc};
 			pending_patch_view.reset();
 
-			ReloadPatch patchloader{patch_storage, patches, settings.filesystem};
-			if (patchloader.needs_reloading(loc)) {
-				auto result = patchloader.reload_patch_file(loc, [] { lv_timer_handler(); });
-				if (!result.success) {
-					notify_queue.put({result.error_string, Notification::Priority::Error});
-					return;
-				}
+			auto result = patch_switcher.jump_to_patch(loc, [this]() {
+				gui_state.force_redraw_patch = true;
+				page_list.request_new_page(PageId::PatchView, pending_patch_view_args);
+			});
+			if (!result.success) {
+				notify_queue.put({result.error_string, Notification::Priority::Error});
+				return;
 			}
-			patches.start_viewing(loc);
-
-			args.patch_loc_hash = PatchLocHash{loc};
-			gui_state.force_redraw_patch = true;
-			page_list.request_new_page(PageId::PatchView, args);
-			return;
 		}
 
 		if (gui_state.back_button.is_just_released()) {
@@ -128,10 +126,13 @@ private:
 	FirmwareUpdateTab fwupdate_tab;
 	std::array<SystemMenuTab *, 5> tabs{&info_tab, &plugin_tab, &prefs_tab, &system_tab, &fwupdate_tab};
 	SystemMenuTab *active_tab = &info_tab;
+	ReloadPatch patch_reloader;
+	PatchSwitcher patch_switcher;
 
 	lv_obj_t *tab_bar;
 
 	std::optional<PatchLocation> pending_patch_view;
+	PageArguments pending_patch_view_args;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/system_menu.hh
+++ b/firmware/src/gui/pages/system_menu.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include "fs/helpers.hh"
 #include "gui/helpers/lv_helpers.hh"
 #include "gui/pages/base.hh"
 #include "gui/pages/firmware_update_tab.hh"
@@ -8,6 +9,7 @@
 #include "gui/pages/system_info_tab.hh"
 #include "gui/pages/system_tab.hh"
 #include "gui/slsexport/meta5/ui.h"
+#include "patch_file/reload_patch.hh"
 
 namespace MetaModule
 {
@@ -47,11 +49,36 @@ struct SystemMenuPage : PageBase {
 		lv_group_add_obj(group, tab_bar);
 		lv_group_focus_obj(tab_bar);
 		lv_group_set_editing(group, true);
+
+		prefs_tab.set_patch_clicked_callback([this](std::string_view path) {
+			auto [filename, vol] = split_volume(path);
+			pending_patch_view = PatchLocation{std::string(filename), vol};
+		});
 	}
 
 	void update() final {
 
 		active_tab->update();
+
+		if (pending_patch_view) {
+			auto loc = *pending_patch_view;
+			pending_patch_view.reset();
+
+			ReloadPatch patchloader{patch_storage, patches, settings.filesystem};
+			if (patchloader.needs_reloading(loc)) {
+				auto result = patchloader.reload_patch_file(loc, [] { lv_timer_handler(); });
+				if (!result.success) {
+					notify_queue.put({result.error_string, Notification::Priority::Error});
+					return;
+				}
+			}
+			patches.start_viewing(loc);
+
+			args.patch_loc_hash = PatchLocHash{loc};
+			gui_state.force_redraw_patch = true;
+			page_list.request_new_page(PageId::PatchView, args);
+			return;
+		}
 
 		if (gui_state.back_button.is_just_released()) {
 			if (!active_tab->consume_back_event()) {
@@ -103,6 +130,8 @@ private:
 	SystemMenuTab *active_tab = &info_tab;
 
 	lv_obj_t *tab_bar;
+
+	std::optional<PatchLocation> pending_patch_view;
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/CMakeLists.txt
+++ b/firmware/src/gui/slsexport/CMakeLists.txt
@@ -18,6 +18,9 @@ target_sources(
           filebrowser/screens/ui_FileBrowserPage.c
 )
 
+target_include_directories(ui_lvgl PRIVATE ${FWDIR}/src)
+target_compile_features(ui_lvgl PRIVATE cxx_std_20)
+
 set_source_files_properties(
   prefs_section_audio.cc
   prefs_section_screensaver.cc

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -80,14 +80,14 @@ void PrefsSectionMidi::show_pc_table(lv_event_t *event) {
 		return;
 	auto page = static_cast<PrefsSectionMidi *>(event->user_data);
 
-	std::string text = "";
-	auto sorted = page->settings->entries;
-	std::ranges::sort(sorted, std::less{}, &MidiPCPatchLoadSettings::Entry::pc);
+	page->sorted_entries = page->settings->entries;
+	std::ranges::sort(page->sorted_entries, std::less{}, &MidiPCPatchLoadSettings::Entry::pc);
 
-	for (auto const &entry : sorted) {
+	std::string text = "";
+	for (auto const &entry : page->sorted_entries) {
 
 		char c[8];
-		snprintf(c, 8, "PC%03d", entry.pc);
+		snprintf(c, 8, "PC%03d", (int)entry.pc);
 		text += c;
 
 		if (entry.channel > 0)
@@ -101,7 +101,15 @@ void PrefsSectionMidi::show_pc_table(lv_event_t *event) {
 	if (text.size())
 		text.pop_back();
 
-	page->pc_roller.show([](unsigned) {}, "", text.c_str(), 0);
+	page->pc_roller.show(
+		[page](unsigned idx) {
+			if (page->on_patch_clicked && idx < page->sorted_entries.size()) {
+				page->on_patch_clicked(page->sorted_entries[idx].path);
+			}
+		},
+		"",
+		text.c_str(),
+		0);
 }
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -1,5 +1,6 @@
 #include "prefs_section_midi.hh"
 #include "ui_local.h"
+#include <algorithm>
 #include <string>
 
 namespace MetaModule
@@ -80,7 +81,10 @@ void PrefsSectionMidi::show_pc_table(lv_event_t *event) {
 	auto page = static_cast<PrefsSectionMidi *>(event->user_data);
 
 	std::string text = "";
-	for (auto const &entry : page->settings->entries) {
+	auto sorted = page->settings->entries;
+	std::ranges::sort(sorted, std::less{}, &MidiPCPatchLoadSettings::Entry::pc);
+
+	for (auto const &entry : sorted) {
 
 		char c[8];
 		snprintf(c, 8, "PC%03d", entry.pc);

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -20,6 +20,9 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	auto pc_cont = create_prefs_labeled_check(parent, "Enable:");
 	pc_patch_load_check = lv_obj_get_child(pc_cont, 1);
 
+	show_pc_table_button = create_button(pc_cont, "Show List");
+	lv_obj_add_event_cb(show_pc_table_button, show_pc_table, LV_EVENT_CLICKED, this);
+
 	create_prefs_note(pc_cont, "Load patches via MIDI\nProgram Change events");
 
 	// Knob Set Control
@@ -49,6 +52,52 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 	auto ch_cont = create_prefs_labeled_dropdown(parent, "MIDI Channel:", ch_opts);
 	knobset_channel_dropdown = lv_obj_get_child(ch_cont, 1);
 	lv_obj_set_width(knobset_channel_dropdown, 50);
+}
+
+void PrefsSectionMidi::init_popup(lv_obj_t *parent, lv_group_t *group, MidiPCPatchLoadSettings &settings) {
+	this->settings = &settings;
+
+	pc_roller.init(lv_layer_top(), group);
+	lv_obj_set_width(pc_roller.popup, 312);
+	lv_obj_set_height(pc_roller.popup, 230);
+	lv_obj_set_width(pc_roller.roller, 290);
+	lv_obj_set_style_text_font(pc_roller.roller, &ui_font_MuseoSansRounded50014, LV_PART_MAIN);
+	lv_obj_set_style_text_font(pc_roller.roller, &ui_font_MuseoSansRounded50014, LV_STATE_EDITED);
+	lv_obj_set_style_text_font(pc_roller.roller, &ui_font_MuseoSansRounded50014, LV_PART_ITEMS);
+}
+
+bool PrefsSectionMidi::close_popup() {
+	if (pc_roller.is_visible()) {
+		pc_roller.hide();
+		return true;
+	}
+	return false;
+}
+
+void PrefsSectionMidi::show_pc_table(lv_event_t *event) {
+	if (!event || !event->user_data)
+		return;
+	auto page = static_cast<PrefsSectionMidi *>(event->user_data);
+
+	std::string text = "";
+	for (auto const &entry : page->settings->entries) {
+
+		char c[8];
+		snprintf(c, 8, "PC%03d", entry.pc);
+		text += c;
+
+		if (entry.channel > 0)
+			text += " Ch. " + std::to_string(entry.channel);
+		else
+			text += " Any Ch.";
+
+		text += " " + entry.path;
+		text += "\n";
+	}
+	if (text.size())
+		text.pop_back();
+
+	page->pc_roller.show([](unsigned) {}, "", text.c_str(), 0);
 }
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_midi.cc
+++ b/firmware/src/gui/slsexport/prefs_section_midi.cc
@@ -14,6 +14,14 @@ void PrefsSectionMidi::create(lv_obj_t *parent) {
 
 	create_prefs_note(midi_cont, "Sends MIDI to controller\nwhen MIDI-mapped params\nchange");
 
+	// MIDI PC Patch Load
+	create_prefs_section_title(parent, "MIDI PC PATCH LOAD");
+
+	auto pc_cont = create_prefs_labeled_check(parent, "Enable:");
+	pc_patch_load_check = lv_obj_get_child(pc_cont, 1);
+
+	create_prefs_note(pc_cont, "Load patches via MIDI\nProgram Change events");
+
 	// Knob Set Control
 	create_prefs_section_title(parent, "MIDI KNOB SET SELECT");
 

--- a/firmware/src/gui/slsexport/prefs_section_midi.hh
+++ b/firmware/src/gui/slsexport/prefs_section_midi.hh
@@ -1,4 +1,6 @@
+#include "gui/pages/roller_popup.hh"
 #include "lvgl.h"
+#include "user_settings/midi_pc_settings.hh"
 
 namespace MetaModule
 {
@@ -10,7 +12,18 @@ struct PrefsSectionMidi {
 	lv_obj_t *knobset_cc_dropdown;
 	lv_obj_t *knobset_channel_dropdown;
 
+	lv_obj_t *show_pc_table_button;
+
+	MidiPCPatchLoadSettings *settings;
+
 	void create(lv_obj_t *parent);
+
+	void init_popup(lv_obj_t *parent, lv_group_t *group, MidiPCPatchLoadSettings &settings);
+	bool close_popup();
+
+	RollerPopup pc_roller{"MIDI PC LOAD PATCH:"};
+
+	static void show_pc_table(lv_event_t *event);
 };
 
 } // namespace MetaModule

--- a/firmware/src/gui/slsexport/prefs_section_midi.hh
+++ b/firmware/src/gui/slsexport/prefs_section_midi.hh
@@ -1,6 +1,8 @@
+#include "../lib/cpputil/util/callable.hh"
 #include "gui/pages/roller_popup.hh"
 #include "lvgl.h"
 #include "user_settings/midi_pc_settings.hh"
+#include <vector>
 
 namespace MetaModule
 {
@@ -22,6 +24,9 @@ struct PrefsSectionMidi {
 	bool close_popup();
 
 	RollerPopup pc_roller{"MIDI PC LOAD PATCH:"};
+
+	Function<void(std::string_view path)> on_patch_clicked;
+	std::vector<MidiPCPatchLoadSettings::Entry> sorted_entries;
 
 	static void show_pc_table(lv_event_t *event);
 };

--- a/firmware/src/gui/slsexport/prefs_section_midi.hh
+++ b/firmware/src/gui/slsexport/prefs_section_midi.hh
@@ -5,6 +5,7 @@ namespace MetaModule
 
 struct PrefsSectionMidi {
 	lv_obj_t *feedback_check;
+	lv_obj_t *pc_patch_load_check;
 	lv_obj_t *knobset_control_check;
 	lv_obj_t *knobset_cc_dropdown;
 	lv_obj_t *knobset_channel_dropdown;

--- a/firmware/src/gui/slsexport/ui_local.cc
+++ b/firmware/src/gui/slsexport/ui_local.cc
@@ -793,7 +793,7 @@ lv_obj_t *create_file_menu_item(lv_obj_t *parent, std::string_view text) {
 	lv_obj_set_align(label, LV_ALIGN_LEFT_MID);
 	lv_label_set_text(label, text.data());
 
-	auto button = lv_btn_create(ui_PatchFileMenu);
+	auto button = lv_btn_create(parent);
 	lv_obj_set_height(button, 25);
 	lv_obj_set_width(button, lv_pct(100));
 	lv_obj_set_align(button, LV_ALIGN_CENTER);

--- a/firmware/src/midi/midi_message.hh
+++ b/firmware/src/midi/midi_message.hh
@@ -202,7 +202,7 @@ struct MidiMessage {
 	}
 
 	uint8_t pcval() const {
-		return data.byte[1];
+		return data.byte[0];
 	}
 
 	// -8192 .. 8191

--- a/firmware/src/params/params_state.hh
+++ b/firmware/src/params/params_state.hh
@@ -128,6 +128,13 @@ struct ParamsMidiState : ParamsState {
 	uint8_t last_midi_note_channel;
 	bool midi_gate = false;
 
+	struct MidiPCEvent {
+		bool changed = false;
+		uint8_t channel = 0; // MIDI channel 0-15
+		uint8_t pc = 0;      // Program Change number 0-127
+	};
+	MidiPCEvent last_midi_pc;
+
 	TextDisplayWatcher text_displays;
 
 	void clear() {
@@ -140,6 +147,7 @@ struct ParamsMidiState : ParamsState {
 
 		midi_gate = false;
 		last_midi_note.changed = 0;
+		last_midi_pc.changed = false;
 	}
 };
 

--- a/firmware/src/params/sync_params.hh
+++ b/firmware/src/params/sync_params.hh
@@ -56,6 +56,11 @@ public:
 					params.midi_ccs[e.note].val = e.midi_chan;
 					params.midi_ccs[e.note].value = e.val;
 				}
+				if (e.type == Midi::Event::Type::PC) {
+					params.last_midi_pc.changed = true;
+					params.last_midi_pc.channel = e.midi_chan;
+					params.last_midi_pc.pc = static_cast<uint8_t>(e.val);
+				}
 				if (e.type == Midi::Event::Type::NoteOn && e.note < NumMidiNotes) {
 					params.last_midi_note.changed = 1;
 					params.last_midi_note.val = e.note;

--- a/firmware/src/patch_file/patch_switcher.hh
+++ b/firmware/src/patch_file/patch_switcher.hh
@@ -1,0 +1,63 @@
+#pragma once
+#include "gui/pages/missing_plugin_scan.hh"
+#include "patch_file/reload_patch.hh"
+#include "patch_play/patch_playloader.hh"
+#include "src/misc/lv_timer.h"
+
+namespace MetaModule
+{
+
+struct PatchSwitcher {
+	// // Pending:
+	// enum Result { Idle, Pending, Sucess, Failure };
+
+	// // Switches to a patch.
+	// // Handles all cases of patch's state: open/closed, un/modified via disk/wifi, un/modified in ram, missing plugins or not, is already playing or not, is being viewed or not.
+	// Result process_jump_to_patch(PatchLocation patch_loc,
+	// 							 ReloadPatch &patchloader,
+	// 							 PatchPlayLoader &patch_playloader,
+	// 							 MissingPluginAutoload &missing_plugins) {
+
+	// 	return Pending;
+	// }
+	ReloadPatch &patchloader;
+	PatchPlayLoader &patch_playloader;
+	MissingPluginScanner &missing_plugins;
+	Callback cb;
+
+	PatchSwitcher(ReloadPatch &patchloader, PatchPlayLoader &patch_playloader, MissingPluginScanner &missing_plugins)
+		: patchloader{patchloader}
+		, patch_playloader{patch_playloader}
+		, missing_plugins{missing_plugins} {
+	}
+
+	Result jump_to_patch(PatchLocation patch_loc, Callback &&success) {
+		cb = std::move(success);
+
+		if (patchloader.needs_reloading(patch_loc)) {
+			auto result = patchloader.reload_patch_file(patch_loc, [] { lv_timer_handler(); });
+			if (!result.success) {
+				return result;
+			}
+		}
+		auto &patches = patchloader.patches;
+		patches.start_viewing(patch_loc);
+
+		// If patch is unmodifed in RAM, then check for missing plugins
+		if (patches.get_view_patch_modification_count() == 0) {
+			missing_plugins.start(patches.get_view_patch(), lv_group_get_default(), [=, this](bool did_reload) {
+				// If we loaded new plugins AND the patch was already playing, then reload patch into the player
+				if (did_reload && patch_playloader.is_view_patch_playing())
+					patch_playloader.request_load_view_patch();
+				cb();
+			});
+
+		} else {
+			// Otherwise the patch has unsaved changes so just view it, don't reload/load anything
+			success();
+		}
+		return {.success = true};
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/patch_file/reload_patch.hh
+++ b/firmware/src/patch_file/reload_patch.hh
@@ -10,11 +10,11 @@ namespace MetaModule
 {
 
 class ReloadPatch {
+public:
 	FileStorageProxy &patch_storage;
 	OpenPatchManager &patches;
 	FilesystemSettings &fs_settings;
 
-public:
 	struct FileTimeSize {
 		uint32_t timestamp;
 		uint32_t filesize;

--- a/firmware/src/patch_play/patch_playloader.hh
+++ b/firmware/src/patch_play/patch_playloader.hh
@@ -161,6 +161,10 @@ struct PatchPlayLoader {
 		return !audio_is_muted_ && player_.is_loaded;
 	}
 
+	bool is_view_patch_playing() {
+		return is_playing() && patches_.get_view_patch() == patches_.get_playing_patch();
+	}
+
 	bool did_audio_overrun() {
 		return audio_overrun_;
 	}

--- a/firmware/src/user_settings/midi_pc_settings.hh
+++ b/firmware/src/user_settings/midi_pc_settings.hh
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace MetaModule
+{
+
+struct MidiPCPatchLoadSettings {
+	struct Entry {
+		std::string path;
+		uint32_t channel{1}; // 1-16, 0 = any/omni
+		uint32_t pc{0};      // 0-127
+	};
+
+	bool enabled{false};
+	std::vector<Entry> entries;
+
+	void make_valid() {
+		for (auto &e : entries) {
+			if (e.channel > 16)
+				e.channel = 0;
+			if (e.pc > 127)
+				e.pc = 0;
+		}
+	}
+};
+
+} // namespace MetaModule

--- a/firmware/src/user_settings/settings.hh
+++ b/firmware/src/user_settings/settings.hh
@@ -4,6 +4,7 @@
 #include "catchup_settings.hh"
 #include "fs/volumes.hh"
 #include "user_settings/fs_settings.hh"
+#include "user_settings/midi_pc_settings.hh"
 #include "user_settings/midi_settings.hh"
 #include "user_settings/patch_suggested_audio_settings.hh"
 #include "user_settings/plugin_preload_settings.hh"
@@ -31,6 +32,7 @@ struct UserSettings {
 	CatchupSettings catchup{};
 	FilesystemSettings filesystem{};
 	MidiSettings midi{};
+	MidiPCPatchLoadSettings midi_pc_patch_load{};
 	PatchSuggestedAudioSettings patch_suggested_audio{};
 	ButtonExpKnobSetSettings button_exp_knobset{};
 	NotificationSettings notifications{};

--- a/firmware/src/user_settings/settings_parse.cc
+++ b/firmware/src/user_settings/settings_parse.cc
@@ -203,6 +203,35 @@ static bool read(ryml::ConstNodeRef const &node, NotificationSettings *settings)
 	return true;
 }
 
+static bool read(ryml::ConstNodeRef const &node, MidiPCPatchLoadSettings *settings) {
+	if (!node.is_map())
+		return false;
+
+	read_or_default(node, "enabled", settings, &MidiPCPatchLoadSettings::enabled);
+
+	settings->entries.clear();
+	if (node.has_child("entries")) {
+		auto entries_node = node["entries"];
+		if (entries_node.is_seq()) {
+			for (auto const entry_node : entries_node.children()) {
+				if (!entry_node.is_map())
+					continue;
+				MidiPCPatchLoadSettings::Entry entry;
+				if (entry_node.has_child("path"))
+					entry_node["path"] >> entry.path;
+				if (entry_node.has_child("channel"))
+					entry_node["channel"] >> entry.channel;
+				if (entry_node.has_child("pc"))
+					entry_node["pc"] >> entry.pc;
+				settings->entries.push_back(std::move(entry));
+			}
+		}
+	}
+
+	settings->make_valid();
+	return true;
+}
+
 static bool read(ryml::ConstNodeRef const &node, MissingPluginSettings *settings) {
 	if (!node.is_map())
 		return false;
@@ -246,6 +275,7 @@ bool parse(std::span<char> yaml, UserSettings *settings) {
 	read_or_default(node, "catchup", settings, &UserSettings::catchup);
 	read_or_default(node, "filesystem", settings, &UserSettings::filesystem);
 	read_or_default(node, "midi", settings, &UserSettings::midi);
+	read_or_default(node, "midi_pc_patch_load", settings, &UserSettings::midi_pc_patch_load);
 	read_or_default(node, "patch_suggested_audio", settings, &UserSettings::patch_suggested_audio);
 	read_or_default(node, "button_exp_knobset", settings, &UserSettings::button_exp_knobset);
 	read_or_default(node, "notifications", settings, &UserSettings::notifications);

--- a/firmware/src/user_settings/settings_serialize.cc
+++ b/firmware/src/user_settings/settings_serialize.cc
@@ -115,6 +115,23 @@ static void write(ryml::NodeRef *n, NotificationSettings const &s) {
 	n->append_child() << ryml::key("animation") << s.animation;
 }
 
+static void write(ryml::NodeRef *n, MidiPCPatchLoadSettings const &s) {
+	*n |= ryml::MAP;
+	n->append_child() << ryml::key("enabled") << s.enabled;
+
+	auto entries_node = n->append_child();
+	entries_node << ryml::key("entries");
+	entries_node |= ryml::SEQ;
+
+	for (auto const &e : s.entries) {
+		auto entry = entries_node.append_child();
+		entry |= ryml::MAP;
+		entry.append_child() << ryml::key("path") << e.path;
+		entry.append_child() << ryml::key("channel") << e.channel;
+		entry.append_child() << ryml::key("pc") << e.pc;
+	}
+}
+
 static void write(ryml::NodeRef *n, MissingPluginSettings const &s) {
 	*n |= ryml::MAP;
 
@@ -149,6 +166,7 @@ uint32_t serialize(UserSettings const &settings, std::span<char> buffer) {
 	data["catchup"] << settings.catchup;
 	data["filesystem"] << settings.filesystem;
 	data["midi"] << settings.midi;
+	data["midi_pc_patch_load"] << settings.midi_pc_patch_load;
 	data["patch_suggested_audio"] << settings.patch_suggested_audio;
 	data["button_exp_knobset"] << settings.button_exp_knobset;
 	data["notifications"] << settings.notifications;

--- a/firmware/tests/settings_parse_tests.cc
+++ b/firmware/tests/settings_parse_tests.cc
@@ -426,6 +426,9 @@ TEST_CASE("Serialize settings") {
     knobset_control: 0
     knobset_cc: 0
     knobset_channel: 16
+  midi_pc_patch_load:
+    enabled: 0
+    entries: []
   patch_suggested_audio:
     apply_samplerate: 0
     apply_blocksize: 1


### PR DESCRIPTION
This adds the ability to load a patch file with a MIDI PC message.
The Patch View file menu has a new item under Startup Patch called "Load on MIDI PC".
This brings up a dialog box where you can pick a MIDI PC number and MIDI channel (or select "All" for the channel).
Existing PC assignments are shown, so you can choose whether to overwrite one.

When a matching MIDI PC message is received, the patch will be loaded and played, and the GUI will jump to the PatchView.
If the patch has plugins that aren't loaded, the missing plugins pop-up will come up if this is enabled in the preferences. If a different patch is playing, it will be stopped. If the patch has changed on disk via wifi or disk eject/mount, then the new version will be loaded and played. There were quite a few edge cases here, so I ended up unifying the method for loading a patch from the Patch Selector page and via MIDI PC.

The entire feature has a global on/off toggle in the Prefs. Next to this toggle is a button that brings up a list of all the assignments, so you can review them all in one place. Clicking one of those assignments takes you to that patch (but does not start playing it).

Regarding the "all" or "any" MIDI channel: if you create a PC assignment and select "Any" for the MIDI channel, and there is an existing PC assignment with the same PC number but on a specific channel, then the new assignment will replace the old one. Similarly if there is an "any" assignment and you make a new one with the same PC number but on a specific channel, it will replace the old one. Doing it this way gets around needing a hierarchy of channels. There is no conflict if you have two assignments on different channels but with the same PC number.

