### PR TITLE
Default simulator LOG_LEVEL to WARN so errors are visible with plain cmake

### DIFF
--- a/docs/simulator-building.md
+++ b/docs/simulator-building.md
@@ -18,6 +18,10 @@ Generate the build system:
 cmake --fresh -B build -GNinja      #Or whatever build system you want
 ```
 
+By default the simulator logs errors and warnings to the console. For more
+verbose logging, add `-DLOG_LEVEL=DEBUG` (levels: NONE, ERROR, WARN, INFO,
+DEBUG, TRACE, DUMP).
+
 Build it:
 
 ```

--- a/docs/simulator-building.md
+++ b/docs/simulator-building.md
@@ -18,9 +18,9 @@ Generate the build system:
 cmake --fresh -B build -GNinja      #Or whatever build system you want
 ```
 
-By default the simulator logs errors and warnings to the console. For more
-verbose logging, add `-DLOG_LEVEL=DEBUG` (levels: NONE, ERROR, WARN, INFO,
-DEBUG, TRACE, DUMP).
+By default the simulator logs at the DEBUG level to the console. To change
+this, add `-DLOG_LEVEL=...` (levels: NONE, ERROR, WARN, INFO, DEBUG, TRACE,
+DUMP).
 
 Build it:
 

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -46,6 +46,11 @@ elseif (ALL_SAN)
 endif()
 
 
+# Default to WARN so errors/warnings are visible when configuring with plain
+# cmake (log_levels.cmake defaults to NONE, which compiles out even pr_err).
+# A -DLOG_LEVEL=... on the command line still takes precedence.
+set(LOG_LEVEL WARN CACHE STRING "Console log level")
+
 include(${FWDIR}/cmake/log_levels.cmake)
 enable_logging()
 

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -46,10 +46,11 @@ elseif (ALL_SAN)
 endif()
 
 
-# Default to WARN so errors/warnings are visible when configuring with plain
-# cmake (log_levels.cmake defaults to NONE, which compiles out even pr_err).
-# A -DLOG_LEVEL=... on the command line still takes precedence.
-set(LOG_LEVEL WARN CACHE STRING "Console log level")
+# Default to DEBUG so logging is visible when configuring with plain cmake,
+# matching the Makefile (log_levels.cmake otherwise defaults to NONE, which
+# compiles out even pr_err). A -DLOG_LEVEL=... on the command line still takes
+# precedence.
+set(LOG_LEVEL DEBUG CACHE STRING "Console log level")
 
 include(${FWDIR}/cmake/log_levels.cmake)
 enable_logging()


### PR DESCRIPTION
Fixes #578 (silent logging).

Defaults the simulator (a desktop developer tool) to `LOG_LEVEL=WARN` via a non-FORCE cache default in `simulator/CMakeLists.txt`, placed before the `log_levels.cmake` include; an explicit `-DLOG_LEVEL=...` (including the Makefile's `-DLOG_LEVEL=DEBUG`) still takes precedence. WARN keeps the default quiet; `make` continues to configure at DEBUG. The default also applies to the headless presets, which previously landed at NONE (the Makefile's `config-headless-min` still pins `-DLOG_LEVEL=NONE` explicitly). Also mentions the option in `docs/simulator-building.md`.

Verified: plain `cmake --fresh -B build -GNinja` now reports `Log Level: Warn` with `LOG_LEVEL=2` in all 1347 compile commands; `-DLOG_LEVEL=DEBUG` still yields `LOG_LEVEL=4`; the full GUI build compiles cleanly at WARN (this matters because enabling `pr_err`/`pr_warn` bodies compiles printf calls that were previously preprocessed out).
