### PR TITLE
Build simulator DSP at -O2 so the audio callback meets its real-time deadline

### DIFF
--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -25,7 +25,11 @@ else()
 
 	message("Building Simulator with GUI")
 
-	add_compile_options(-O0 -g2)
+	# DSP code must be optimized to fill the audio callback in real time:
+	# at -O0, ported VCV modules overrun the 10.7ms buffer budget and the
+	# patch plays silence. The simulator target itself overrides this with
+	# -Og (see target_compile_options below) to stay debuggable.
+	add_compile_options(-O2 -g2)
 
 	add_compile_definitions(SIMULATOR)
 


### PR DESCRIPTION
Fixes #579 (GUI simulator forces -O0 on all DSP code, silencing heavier patches).

Changes the GUI build's directory-wide `-O0 -g2` to `-O2 -g2`, with a comment explaining the real-time constraint. Two design notes:

- The `simulator` target's own `target_compile_options(simulator PRIVATE -Wall -Og)` appears later on the compile line than the directory options, so the simulator target's own sources keep their debuggable -Og exactly as before. The library targets — the DSP brands plus support libs like LVGL, ThorVG, and the slsexport UI — move from -O0 to -O2, the same trade the headless build already makes with -Ofast.
- It has to be fixed in the build file: config flags precede `add_compile_options` flags, so even `-DCMAKE_BUILD_TYPE=Release` couldn't override the -O0 from outside (the same ordering means sanitizer builds also move from -O0 to -O2, and clean builds take somewhat longer — both seemed acceptable against heavier patches being silently broken).

Verified: callback fill time for `Befaco4msPlayground` drops from ~24.8 ms (93/93 buffers over budget, silent) to ~0.3 ms (0/93, audible); both formerly-silent factory patches play correctly by ear; `compile_commands.json` confirms DSP translation units get `-O2` and simulator sources still end with `-Og`; full GUI build compiles cleanly.
