### PR TITLE
Define no-op `plugin` target in simulator's create_plugin() to match real SDK

### DIFF
--- a/docs/simulator-ext-plugins.md
+++ b/docs/simulator-ext-plugins.md
@@ -150,6 +150,24 @@ issue is due to one of these limitations or is an actual bug.
   offending text should tell you if this is happening, or you can try building
   the plugin normally and see if you get the same error.
 
+- The `plugin` target that the real SDK's `create_plugin()` defines (which
+  plugins sometimes attach `add_custom_command(TARGET plugin POST_BUILD ...)`
+  steps to) is created as a no-op by the simulator's fake SDK. CMake target
+  names are global, so if you register more than one external plugin, only the
+  first one gets the `plugin` target — POST_BUILD steps on `plugin` in the
+  other plugins will fail to configure. Register that plugin first, or guard
+  the steps by checking which directory owns the target (a bare
+  `if(TARGET plugin)` won't help — the target exists globally, but
+  `add_custom_command(TARGET ...)` only works from the directory that
+  created it):
+
+  ```cmake
+  get_target_property(plugin_dir plugin SOURCE_DIR)
+  if(plugin_dir STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+      add_custom_command(TARGET plugin POST_BUILD ...)
+  endif()
+  ```
+
 
   I would not be surprised if there are other limitations, so please report it
   (via email, the forum, or open a github issue) if you find something.

--- a/simulator/plugin.cmake
+++ b/simulator/plugin.cmake
@@ -34,8 +34,19 @@ function(create_plugin)
 	)
 
 	add_custom_target(${PLUGIN_OPTIONS_SOURCE_LIB}-assets ALL
-		DEPENDS "${ASSET_DIR}/${PLUGIN_OPTIONS_PLUGIN_NAME}" 
+		DEPENDS "${ASSET_DIR}/${PLUGIN_OPTIONS_PLUGIN_NAME}"
 	)
 
+	# The real SDK's create_plugin() defines a `plugin` target, and plugin
+	# CMakeLists legitimately attach POST_BUILD steps to it. Define a no-op
+	# equivalent so those plugins also configure as simulator built-ins.
+	# Target names are global, so only the first built-in plugin gets it:
+	# add_custom_command(TARGET plugin ...) only works in the directory that
+	# created the target.
+	if (NOT TARGET plugin)
+		add_custom_target(plugin ALL)
+	else()
+		message(STATUS "Target `plugin` already exists, so POST_BUILD steps on it in ${CMAKE_CURRENT_SOURCE_DIR} will fail to configure -- register that plugin first if it needs them")
+	endif()
 
 endfunction()


### PR DESCRIPTION
Fixes #580 (plugins with POST_BUILD steps on `plugin` can't build as simulator built-ins).

Makes the simulator's fake `create_plugin()` define a no-op `add_custom_target(plugin ALL)`, matching the real SDK's target name. Since CMake target names are global, only the first registered built-in plugin can own it; that case prints a STATUS message and is documented in a new Limitations entry in `docs/simulator-ext-plugins.md` (register that plugin first, or guard hooks by checking the target's `SOURCE_DIR` property — a bare `if(TARGET plugin)` is global and doesn't help).

Verified with a minimal plugin using a POST_BUILD hook, registered via `-Dext_builtin_brand_paths=... -Dext_builtin_brand_libname=...`: configure fails before the fix, succeeds after, and the hook runs when the `plugin` target builds.

**Option to consider (not included):** a standalone CMake-level regression test for `create_plugin()` (a tiny fixture plugin with a POST_BUILD hook) would verify this in about a second, but the repo has no harness for CMake tests — happy to add one if you'd like.
