### PR TITLE
Register bundled vcv_ports brands in the headless simulator

### DIFF
--- a/docs/Porting.md
+++ b/docs/Porting.md
@@ -78,7 +78,7 @@ set(brands
 ```
 
 
-5) **Add modules to internal_plugin_manager.hh**
+5) **Add modules to load_internal_plugins.hh**
 
 TODO
 
@@ -93,7 +93,7 @@ extern rack::plugin::Model *modelSomeOtherModule;
 
 
 ```c++
-// add this to internal_plugin_manager.hh:
+// add this to vcv_ports/load_internal_plugins.hh:
 #include "glue/Brand/plugin.hh"
 
 // add this to the end of load_internal_plugins()

--- a/firmware/vcv_ports/internal_plugin_manager.hh
+++ b/firmware/vcv_ports/internal_plugin_manager.hh
@@ -1,16 +1,11 @@
 #pragma once
-#include "convert_plugins.hh"
 #include "dynload/json_parse.hh"
 #include "ext_plugin_builtin.hh"
 #include "fat_file_io.hh"
 #include "fs/asset_drive/asset_fs.hh"
 #include "fs/asset_drive/untar.hh"
-#include "glue/RackCore/plugins.hh"
-#include "glue/Valley/plugins.hh"
 #include "gui/fonts/fonts_init.hh"
-#include "internal_plugins.hh"
-#include "plugin/Plugin.hpp"
-#include <context.hpp>
+#include "load_internal_plugins.hh"
 #include <list>
 #include <span>
 #include <string_view>
@@ -30,7 +25,8 @@ struct InternalPluginManager {
 		, asset_fs{asset_fs} {
 		prepare_ramdisk();
 		load_internal_assets();
-		load_internal_plugins();
+		load_internal_plugins(internal_plugins);
+		parse_plugin_jsons();
 		load_ext_builtin_plugins(internal_plugins);
 		ModuleFactory::setBrandDisplayName("4msCompany", "4ms");
 	}
@@ -69,235 +65,7 @@ struct InternalPluginManager {
 		ramdisk.make_dir("/usr");
 	}
 
-	void load_internal_plugins() {
-		rack::contextSet(nullptr);
-
-		// Set 4ms display names
-		// TODO: read from plugin-mm.json
-		ModuleFactory::setModuleDisplayName("4msCompany:TSP", "Basic Wav Player");
-		ModuleFactory::setModuleDisplayName("4msCompany:BWAVP", "Basic Wav Player");
-		ModuleFactory::setModuleDisplayName("4msCompany:L4", "Listen Four");
-		ModuleFactory::setModuleDisplayName("4msCompany:DEV", "Dual EnvVCA");
-		ModuleFactory::setModuleDisplayName("4msCompany:SHEV", "Shaped Dual EnvVCA");
-		ModuleFactory::setModuleDisplayName("4msCompany:DLD", "Dual Looping Delay");
-		ModuleFactory::setModuleDisplayName("4msCompany:KPLS", "Karplus");
-		ModuleFactory::setModuleDisplayName("4msCompany:PI", "Percussion Interface");
-		ModuleFactory::setModuleDisplayName("4msCompany:SH", "Sample/Hold");
-		ModuleFactory::setModuleDisplayName("4msCompany:StMix", "Stereo Mixer");
-		ModuleFactory::setModuleDisplayName("4msCompany:Switch14", "Switch 1 to 4");
-		ModuleFactory::setModuleDisplayName("4msCompany:Switch41", "Switch 4 to 1");
-		ModuleFactory::setModuleDisplayName("4msCompany:VCAM", "VCAMatrix");
-		ModuleFactory::setModuleDisplayName("4msCompany:Tapo", "Tapographic Delay");
-		ModuleFactory::setModuleDisplayName("4msCompany:CLKD", "Clock Divider");
-		ModuleFactory::setModuleDisplayName("4msCompany:CLKM", "Clock Multiplier");
-		ModuleFactory::setModuleDisplayName("4msCompany:MPEG", "Mini PEG");
-		ModuleFactory::setModuleDisplayName("4msCompany:MNMX", "Min/Max");
-		ModuleFactory::setModuleDisplayName("4msCompany:Atvert2", "Attenuverter");
-
-		//Load internal plugins
-		// TODO: use the glue/BRAND/plugin.cpp::init() function for each brand...
-		// 		 But, somehow get around the issue of multiple definitions of global symbol pluginInstance
-
-#ifdef BUILD_INTERNAL_Befaco
-		pluginInstance = &internal_plugins.emplace_back("Befaco");
-		befacoPluginInstance = pluginInstance;
-		befacoPluginInstance->slug = "Befaco";
-		pluginInstance->addModel(modelEvenVCO);
-		pluginInstance->addModel(modelPonyVCO);
-		pluginInstance->addModel(modelRampage);
-		pluginInstance->addModel(modelABC);
-		pluginInstance->addModel(modelMixer);
-		pluginInstance->addModel(modelSlewLimiter);
-		pluginInstance->addModel(modelDualAtenuverter);
-		pluginInstance->addModel(modelPercall);
-		pluginInstance->addModel(modelHexmixVCA);
-		pluginInstance->addModel(modelChoppingKinky);
-		pluginInstance->addModel(modelKickall);
-		pluginInstance->addModel(modelSamplingModulator);
-		pluginInstance->addModel(modelMorphader);
-		pluginInstance->addModel(modelADSR);
-		pluginInstance->addModel(modelSTMix);
-		pluginInstance->addModel(modelChannelStrip);
-		pluginInstance->addModel(modelMotionMTR);
-		pluginInstance->addModel(modelSpringReverb);
-		pluginInstance->addModel(modelBurst);
-		pluginInstance->addModel(modelVoltio);
-		pluginInstance->addModel(modelOctaves);
-		pluginInstance->addModel(modelNoisePlethora);
-		pluginInstance->addModel(modelMuxlicer);
-		pluginInstance->addModel(modelBandit);
-		pluginInstance->addModel(modelAtte);
-		pluginInstance->addModel(modelAxBC);
-		pluginInstance->addModel(modelMixer2);
-		pluginInstance->addModel(modelMuDi);
-		pluginInstance->addModel(modelSlew);
-#endif
-
-#ifdef BUILD_INTERNAL_AudibleInstruments
-		pluginInstance = &internal_plugins.emplace_back("AudibleInstruments");
-		pluginInstance->slug = "AudibleInstruments";
-		audibleInstrumentsPluginInstance = pluginInstance;
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelBlinds);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelBraids);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelBranches);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelElements);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelKinks);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelLinks);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelMarbles);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelRings);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelRipples);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelShades);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelShelves);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelTides2);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelVeils);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelClouds);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelFrames);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelPlaits);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelStages);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelStreams);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelTides);
-		AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelWarps);
-#endif
-
-#ifdef BUILD_INTERNAL_hetrickcv
-		pluginInstance = &internal_plugins.emplace_back("HetrickCV");
-		pluginInstance->slug = "HetrickCV";
-		hetrickcvPluginInstance = pluginInstance;
-		pluginInstance->addModel(modelTwoToFour);
-		pluginInstance->addModel(modelAnalogToDigital);
-		pluginInstance->addModel(modelASR);
-		pluginInstance->addModel(modelBinaryCounter);
-		pluginInstance->addModel(modelBinaryGate);
-		pluginInstance->addModel(modelBinaryNoise);
-		pluginInstance->addModel(modelBitshift);
-		pluginInstance->addModel(modelBoolean3);
-		pluginInstance->addModel(modelChaos1Op);
-		pluginInstance->addModel(modelChaos2Op);
-		pluginInstance->addModel(modelChaos3Op);
-		pluginInstance->addModel(modelChaoticAttractors);
-		pluginInstance->addModel(modelClockToPhasor);
-		pluginInstance->addModel(modelClockedNoise);
-		pluginInstance->addModel(modelComparator);
-		pluginInstance->addModel(modelContrast);
-		pluginInstance->addModel(modelCrackle);
-		pluginInstance->addModel(modelDataCompander);
-		pluginInstance->addModel(modelDelta);
-		pluginInstance->addModel(modelDigitalToAnalog);
-		pluginInstance->addModel(modelDust);
-		pluginInstance->addModel(modelExponent);
-		pluginInstance->addModel(modelFBSineChaos);
-		pluginInstance->addModel(modelFlipFlop);
-		pluginInstance->addModel(modelFlipPan);
-		pluginInstance->addModel(modelGateDelay);
-		pluginInstance->addModel(modelGateJunction);
-		pluginInstance->addModel(modelGateJunctionExp);
-		pluginInstance->addModel(modelGingerbread);
-		pluginInstance->addModel(modelLogicCombine);
-		pluginInstance->addModel(modelMidSide);
-		pluginInstance->addModel(modelMinMax);
-		pluginInstance->addModel(modelNormals);
-		pluginInstance->addModel(modelPhaseDrivenSequencer);
-		pluginInstance->addModel(modelPhaseDrivenSequencer32);
-		pluginInstance->addModel(modelPhasorAnalyzer);
-		pluginInstance->addModel(modelPhasorBurstGen);
-		pluginInstance->addModel(modelPhasorDivMult);
-		pluginInstance->addModel(modelPhasorEuclidean);
-		pluginInstance->addModel(modelPhasorFreezer);
-		pluginInstance->addModel(modelPhasorGates);
-		pluginInstance->addModel(modelPhasorGates32);
-		pluginInstance->addModel(modelPhasorGates64);
-		pluginInstance->addModel(modelPhasorGen);
-		pluginInstance->addModel(modelPhasorGeometry);
-		pluginInstance->addModel(modelPhasorHumanizer);
-		pluginInstance->addModel(modelPhasorMixer);
-		pluginInstance->addModel(modelPhasorOctature);
-		pluginInstance->addModel(modelPhasorProbability);
-		pluginInstance->addModel(modelPhasorQuadrature);
-		pluginInstance->addModel(modelPhasorRandom);
-		pluginInstance->addModel(modelPhasorRanger);
-		pluginInstance->addModel(modelPhasorReset);
-		pluginInstance->addModel(modelPhasorRhythmGroup);
-		pluginInstance->addModel(modelPhasorShape);
-		pluginInstance->addModel(modelPhasorShift);
-		pluginInstance->addModel(modelPhasorSplitter);
-		pluginInstance->addModel(modelPhasorStutter);
-		pluginInstance->addModel(modelPhasorSubstepShape);
-		pluginInstance->addModel(modelPhasorSwing);
-		pluginInstance->addModel(modelPhasorTimetable);
-		pluginInstance->addModel(modelPhasorToClock);
-		pluginInstance->addModel(modelPhasorToLFO);
-		pluginInstance->addModel(modelPhasorToRandom);
-		pluginInstance->addModel(modelPhasorToWaveforms);
-		pluginInstance->addModel(modelPolymetricPhasors);
-		pluginInstance->addModel(modelProbability);
-		pluginInstance->addModel(modelRandomGates);
-		pluginInstance->addModel(modelRotator);
-		pluginInstance->addModel(modelRungler);
-		pluginInstance->addModel(modelScanner);
-		pluginInstance->addModel(modelTrigShaper);
-		pluginInstance->addModel(modelVectorMix);
-		pluginInstance->addModel(modelWaveshape);
-		pluginInstance->addModel(modelXYToPolar);
-#endif
-
-#ifdef BUILD_INTERNAL_nonlinearcircuits
-		pluginInstance = &internal_plugins.emplace_back("NonlinearCircuits");
-		pluginInstance->slug = "NonlinearCircuits";
-		nonlinearcircuitsPluginInstance = pluginInstance;
-		pluginInstance->addModel(model4Seq);
-		pluginInstance->addModel(modelCipher);
-		pluginInstance->addModel(modelBOOLs);
-		pluginInstance->addModel(modelDivideConquer);
-		pluginInstance->addModel(modelDivineCMOS);
-		pluginInstance->addModel(modelDoubleNeuron);
-		pluginInstance->addModel(modelGenie);
-		pluginInstance->addModel(modelLetsSplosh);
-		pluginInstance->addModel(modelNeuron);
-		pluginInstance->addModel(modelNumberwang);
-		pluginInstance->addModel(modelRouter);
-		pluginInstance->addModel(modelSegue);
-		pluginInstance->addModel(modelSlothApathy);
-		pluginInstance->addModel(modelSlothInertia);
-		pluginInstance->addModel(modelSlothTorpor);
-		pluginInstance->addModel(modelSquidAxon);
-		pluginInstance->addModel(modelSplish);
-		pluginInstance->addModel(modelStatues);
-		pluginInstance->addModel(modelTripleSloth);
-#endif
-
-#ifdef BUILD_INTERNAL_eightfold
-		pluginInstance = &internal_plugins.emplace_back("eightfold");
-		pluginInstance->slug = "eightfold";
-		eightfoldPluginInstance = pluginInstance;
-		pluginInstance->addModel(modelSDOrcasHeartV2);
-#endif
-
-#ifdef BUILD_INTERNAL_Valley
-		pluginInstance = &internal_plugins.emplace_back("Valley");
-		valleyPluginInstance = pluginInstance;
-		pluginInstance->addModel(modelTopograph);
-		pluginInstance->addModel(modelUGraph);
-		pluginInstance->addModel(modelPlateau);
-		pluginInstance->addModel(modelFeline);
-		pluginInstance->addModel(modelAmalgam);
-		pluginInstance->addModel(modelInterzone);
-#endif
-
-#ifdef BUILD_INTERNAL_RackCore
-		pluginInstance = &internal_plugins.emplace_back("RackCore");
-		rackCorePluginInstance = pluginInstance;
-		pluginInstance->addModel(rack::core::modelMIDI_CV);
-		pluginInstance->addModel(rack::core::modelMIDICC_CV);
-		pluginInstance->addModel(rack::core::modelMIDI_Gate);
-		pluginInstance->addModel(rack::core::modelCV_MIDI);
-		pluginInstance->addModel(rack::core::modelCV_MIDICC);
-		pluginInstance->addModel(rack::core::modelGate_MIDI);
-		pluginInstance->addModel(rack::core::modelScope);
-		pluginInstance->addModel(rack::core::modelMerge);
-		pluginInstance->addModel(rack::core::modelSplit);
-		pluginInstance->addModel(rack::core::modelSum);
-#endif
-
+	void parse_plugin_jsons() {
 		parse_jsons("4ms");
 		for (auto &p : internal_plugins) {
 			parse_jsons(p.getBrand());

--- a/firmware/vcv_ports/load_internal_plugins.hh
+++ b/firmware/vcv_ports/load_internal_plugins.hh
@@ -1,0 +1,245 @@
+#pragma once
+#include "convert_plugins.hh"
+#include "glue/RackCore/plugins.hh"
+#include "glue/Valley/plugins.hh"
+#include "internal_plugins.hh"
+#include "plugin/Plugin.hpp"
+#include <context.hpp>
+#include <list>
+
+namespace MetaModule
+{
+
+// Registers the bundled vcv_ports brands (BUILD_INTERNAL_*) with the ModuleFactory.
+// Shared by InternalPluginManager (GUI/firmware) and the headless simulator.
+inline void load_internal_plugins(std::list<rack::plugin::Plugin> &internal_plugins) {
+	rack::contextSet(nullptr);
+
+	// Set 4ms display names
+	// TODO: read from plugin-mm.json
+	ModuleFactory::setModuleDisplayName("4msCompany:TSP", "Basic Wav Player");
+	ModuleFactory::setModuleDisplayName("4msCompany:BWAVP", "Basic Wav Player");
+	ModuleFactory::setModuleDisplayName("4msCompany:L4", "Listen Four");
+	ModuleFactory::setModuleDisplayName("4msCompany:DEV", "Dual EnvVCA");
+	ModuleFactory::setModuleDisplayName("4msCompany:SHEV", "Shaped Dual EnvVCA");
+	ModuleFactory::setModuleDisplayName("4msCompany:DLD", "Dual Looping Delay");
+	ModuleFactory::setModuleDisplayName("4msCompany:KPLS", "Karplus");
+	ModuleFactory::setModuleDisplayName("4msCompany:PI", "Percussion Interface");
+	ModuleFactory::setModuleDisplayName("4msCompany:SH", "Sample/Hold");
+	ModuleFactory::setModuleDisplayName("4msCompany:StMix", "Stereo Mixer");
+	ModuleFactory::setModuleDisplayName("4msCompany:Switch14", "Switch 1 to 4");
+	ModuleFactory::setModuleDisplayName("4msCompany:Switch41", "Switch 4 to 1");
+	ModuleFactory::setModuleDisplayName("4msCompany:VCAM", "VCAMatrix");
+	ModuleFactory::setModuleDisplayName("4msCompany:Tapo", "Tapographic Delay");
+	ModuleFactory::setModuleDisplayName("4msCompany:CLKD", "Clock Divider");
+	ModuleFactory::setModuleDisplayName("4msCompany:CLKM", "Clock Multiplier");
+	ModuleFactory::setModuleDisplayName("4msCompany:MPEG", "Mini PEG");
+	ModuleFactory::setModuleDisplayName("4msCompany:MNMX", "Min/Max");
+	ModuleFactory::setModuleDisplayName("4msCompany:Atvert2", "Attenuverter");
+
+	//Load internal plugins
+	// TODO: use the glue/BRAND/plugin.cpp::init() function for each brand...
+	// 		 But, somehow get around the issue of multiple definitions of global symbol pluginInstance
+
+#ifdef BUILD_INTERNAL_Befaco
+	pluginInstance = &internal_plugins.emplace_back("Befaco");
+	befacoPluginInstance = pluginInstance;
+	befacoPluginInstance->slug = "Befaco";
+	pluginInstance->addModel(modelEvenVCO);
+	pluginInstance->addModel(modelPonyVCO);
+	pluginInstance->addModel(modelRampage);
+	pluginInstance->addModel(modelABC);
+	pluginInstance->addModel(modelMixer);
+	pluginInstance->addModel(modelSlewLimiter);
+	pluginInstance->addModel(modelDualAtenuverter);
+	pluginInstance->addModel(modelPercall);
+	pluginInstance->addModel(modelHexmixVCA);
+	pluginInstance->addModel(modelChoppingKinky);
+	pluginInstance->addModel(modelKickall);
+	pluginInstance->addModel(modelSamplingModulator);
+	pluginInstance->addModel(modelMorphader);
+	pluginInstance->addModel(modelADSR);
+	pluginInstance->addModel(modelSTMix);
+	pluginInstance->addModel(modelChannelStrip);
+	pluginInstance->addModel(modelMotionMTR);
+	pluginInstance->addModel(modelSpringReverb);
+	pluginInstance->addModel(modelBurst);
+	pluginInstance->addModel(modelVoltio);
+	pluginInstance->addModel(modelOctaves);
+	pluginInstance->addModel(modelNoisePlethora);
+	pluginInstance->addModel(modelMuxlicer);
+	pluginInstance->addModel(modelBandit);
+	pluginInstance->addModel(modelAtte);
+	pluginInstance->addModel(modelAxBC);
+	pluginInstance->addModel(modelMixer2);
+	pluginInstance->addModel(modelMuDi);
+	pluginInstance->addModel(modelSlew);
+#endif
+
+#ifdef BUILD_INTERNAL_AudibleInstruments
+	pluginInstance = &internal_plugins.emplace_back("AudibleInstruments");
+	pluginInstance->slug = "AudibleInstruments";
+	audibleInstrumentsPluginInstance = pluginInstance;
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelBlinds);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelBraids);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelBranches);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelElements);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelKinks);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelLinks);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelMarbles);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelRings);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelRipples);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelShades);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelShelves);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelTides2);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelVeils);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelClouds);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelFrames);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelPlaits);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelStages);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelStreams);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelTides);
+	AudibleInstruments::addModel(audibleInstrumentsPluginInstance, modelWarps);
+#endif
+
+#ifdef BUILD_INTERNAL_hetrickcv
+	pluginInstance = &internal_plugins.emplace_back("HetrickCV");
+	pluginInstance->slug = "HetrickCV";
+	hetrickcvPluginInstance = pluginInstance;
+	pluginInstance->addModel(modelTwoToFour);
+	pluginInstance->addModel(modelAnalogToDigital);
+	pluginInstance->addModel(modelASR);
+	pluginInstance->addModel(modelBinaryCounter);
+	pluginInstance->addModel(modelBinaryGate);
+	pluginInstance->addModel(modelBinaryNoise);
+	pluginInstance->addModel(modelBitshift);
+	pluginInstance->addModel(modelBoolean3);
+	pluginInstance->addModel(modelChaos1Op);
+	pluginInstance->addModel(modelChaos2Op);
+	pluginInstance->addModel(modelChaos3Op);
+	pluginInstance->addModel(modelChaoticAttractors);
+	pluginInstance->addModel(modelClockToPhasor);
+	pluginInstance->addModel(modelClockedNoise);
+	pluginInstance->addModel(modelComparator);
+	pluginInstance->addModel(modelContrast);
+	pluginInstance->addModel(modelCrackle);
+	pluginInstance->addModel(modelDataCompander);
+	pluginInstance->addModel(modelDelta);
+	pluginInstance->addModel(modelDigitalToAnalog);
+	pluginInstance->addModel(modelDust);
+	pluginInstance->addModel(modelExponent);
+	pluginInstance->addModel(modelFBSineChaos);
+	pluginInstance->addModel(modelFlipFlop);
+	pluginInstance->addModel(modelFlipPan);
+	pluginInstance->addModel(modelGateDelay);
+	pluginInstance->addModel(modelGateJunction);
+	pluginInstance->addModel(modelGateJunctionExp);
+	pluginInstance->addModel(modelGingerbread);
+	pluginInstance->addModel(modelLogicCombine);
+	pluginInstance->addModel(modelMidSide);
+	pluginInstance->addModel(modelMinMax);
+	pluginInstance->addModel(modelNormals);
+	pluginInstance->addModel(modelPhaseDrivenSequencer);
+	pluginInstance->addModel(modelPhaseDrivenSequencer32);
+	pluginInstance->addModel(modelPhasorAnalyzer);
+	pluginInstance->addModel(modelPhasorBurstGen);
+	pluginInstance->addModel(modelPhasorDivMult);
+	pluginInstance->addModel(modelPhasorEuclidean);
+	pluginInstance->addModel(modelPhasorFreezer);
+	pluginInstance->addModel(modelPhasorGates);
+	pluginInstance->addModel(modelPhasorGates32);
+	pluginInstance->addModel(modelPhasorGates64);
+	pluginInstance->addModel(modelPhasorGen);
+	pluginInstance->addModel(modelPhasorGeometry);
+	pluginInstance->addModel(modelPhasorHumanizer);
+	pluginInstance->addModel(modelPhasorMixer);
+	pluginInstance->addModel(modelPhasorOctature);
+	pluginInstance->addModel(modelPhasorProbability);
+	pluginInstance->addModel(modelPhasorQuadrature);
+	pluginInstance->addModel(modelPhasorRandom);
+	pluginInstance->addModel(modelPhasorRanger);
+	pluginInstance->addModel(modelPhasorReset);
+	pluginInstance->addModel(modelPhasorRhythmGroup);
+	pluginInstance->addModel(modelPhasorShape);
+	pluginInstance->addModel(modelPhasorShift);
+	pluginInstance->addModel(modelPhasorSplitter);
+	pluginInstance->addModel(modelPhasorStutter);
+	pluginInstance->addModel(modelPhasorSubstepShape);
+	pluginInstance->addModel(modelPhasorSwing);
+	pluginInstance->addModel(modelPhasorTimetable);
+	pluginInstance->addModel(modelPhasorToClock);
+	pluginInstance->addModel(modelPhasorToLFO);
+	pluginInstance->addModel(modelPhasorToRandom);
+	pluginInstance->addModel(modelPhasorToWaveforms);
+	pluginInstance->addModel(modelPolymetricPhasors);
+	pluginInstance->addModel(modelProbability);
+	pluginInstance->addModel(modelRandomGates);
+	pluginInstance->addModel(modelRotator);
+	pluginInstance->addModel(modelRungler);
+	pluginInstance->addModel(modelScanner);
+	pluginInstance->addModel(modelTrigShaper);
+	pluginInstance->addModel(modelVectorMix);
+	pluginInstance->addModel(modelWaveshape);
+	pluginInstance->addModel(modelXYToPolar);
+#endif
+
+#ifdef BUILD_INTERNAL_nonlinearcircuits
+	pluginInstance = &internal_plugins.emplace_back("NonlinearCircuits");
+	pluginInstance->slug = "NonlinearCircuits";
+	nonlinearcircuitsPluginInstance = pluginInstance;
+	pluginInstance->addModel(model4Seq);
+	pluginInstance->addModel(modelCipher);
+	pluginInstance->addModel(modelBOOLs);
+	pluginInstance->addModel(modelDivideConquer);
+	pluginInstance->addModel(modelDivineCMOS);
+	pluginInstance->addModel(modelDoubleNeuron);
+	pluginInstance->addModel(modelGenie);
+	pluginInstance->addModel(modelLetsSplosh);
+	pluginInstance->addModel(modelNeuron);
+	pluginInstance->addModel(modelNumberwang);
+	pluginInstance->addModel(modelRouter);
+	pluginInstance->addModel(modelSegue);
+	pluginInstance->addModel(modelSlothApathy);
+	pluginInstance->addModel(modelSlothInertia);
+	pluginInstance->addModel(modelSlothTorpor);
+	pluginInstance->addModel(modelSquidAxon);
+	pluginInstance->addModel(modelSplish);
+	pluginInstance->addModel(modelStatues);
+	pluginInstance->addModel(modelTripleSloth);
+#endif
+
+#ifdef BUILD_INTERNAL_eightfold
+	pluginInstance = &internal_plugins.emplace_back("eightfold");
+	pluginInstance->slug = "eightfold";
+	eightfoldPluginInstance = pluginInstance;
+	pluginInstance->addModel(modelSDOrcasHeartV2);
+#endif
+
+#ifdef BUILD_INTERNAL_Valley
+	pluginInstance = &internal_plugins.emplace_back("Valley");
+	valleyPluginInstance = pluginInstance;
+	pluginInstance->addModel(modelTopograph);
+	pluginInstance->addModel(modelUGraph);
+	pluginInstance->addModel(modelPlateau);
+	pluginInstance->addModel(modelFeline);
+	pluginInstance->addModel(modelAmalgam);
+	pluginInstance->addModel(modelInterzone);
+#endif
+
+#ifdef BUILD_INTERNAL_RackCore
+	pluginInstance = &internal_plugins.emplace_back("RackCore");
+	rackCorePluginInstance = pluginInstance;
+	pluginInstance->addModel(rack::core::modelMIDI_CV);
+	pluginInstance->addModel(rack::core::modelMIDICC_CV);
+	pluginInstance->addModel(rack::core::modelMIDI_Gate);
+	pluginInstance->addModel(rack::core::modelCV_MIDI);
+	pluginInstance->addModel(rack::core::modelCV_MIDICC);
+	pluginInstance->addModel(rack::core::modelGate_MIDI);
+	pluginInstance->addModel(rack::core::modelScope);
+	pluginInstance->addModel(rack::core::modelMerge);
+	pluginInstance->addModel(rack::core::modelSplit);
+	pluginInstance->addModel(rack::core::modelSum);
+#endif
+}
+
+} // namespace MetaModule

--- a/simulator/src/headless/main-headless.cc
+++ b/simulator/src/headless/main-headless.cc
@@ -2,6 +2,7 @@
 #include "audio_wrapper.hh"
 #include "coreproc_plugin/async_thread_control.hh"
 #include "file_io.hh"
+#include "load_internal_plugins.hh"
 #include "patch-serial/yaml_to_patch.hh"
 #include "plugin/Plugin.hpp"
 // must come after plugin/Plugin.hpp:
@@ -50,8 +51,9 @@ int main(int argc, char *argv[]) {
 	MetaModuleSim::Settings settings;
 	settings.parse(argc, argv);
 
-	// Register VCV-ported built-in brands (see ext-plugins.cmake)
+	// Register the bundled vcv_ports brands and any built-ins from ext-plugins.cmake
 	std::list<rack::plugin::Plugin> builtin_plugins;
+	load_internal_plugins(builtin_plugins);
 	load_ext_builtin_plugins(builtin_plugins);
 
 	const auto samples_to_run = settings.samples_to_run;


### PR DESCRIPTION
Fixes #583 (headless never registers the bundled vcv_ports brands). Follow-up to #587, which covered `ext-plugins.cmake` built-ins.

The fix extracts the registration block — `contextSet(nullptr)`, the 4ms display names, and the `BUILD_INTERNAL_*` sections — verbatim into a free function `MetaModule::load_internal_plugins(std::list<rack::plugin::Plugin>&)` in a new header `firmware/vcv_ports/load_internal_plugins.hh`. `InternalPluginManager` calls it and then runs its asset-dependent `parse_jsons()` pass exactly as before (`parse_plugin_jsons()`); headless `main()` calls it next to the existing `load_ext_builtin_plugins()` call.

Display names, tags, and brand aliases from `plugin.json`/`plugin-mm.json` stay GUI-only (they live in `assets.uimg`, which headless doesn't load). Factory patches reference canonical slugs, so headless rendering doesn't need them.

Two small notes: headless now also runs the `contextSet(nullptr)` and hard-coded 4ms display-name calls that ride along in the registration block — both harmless (fontstash is stubbed; display names are just registry entries). And the porting snippet in `docs/Porting.md` that pointed at the old location is updated to name the new header.

*Rebased onto `main` after #587 merged; the extracted function picks up the RackCore modules added to `main` in the meantime (`MIDICC_CV`, `MIDI_Gate`, `Gate_MIDI`, `Merge`, `Split`, `Sum`).*

### Verification

- Headless: `build-headless/simulator -p ../patches/default/Befaco4msPlayground.yml` renders non-silent audio (float32 WAV, peak amplitude ≈ 7.0); previously an all-zero WAV.
- GUI/firmware build: `load_internal_plugins()` is called in the same order as before, so behavior is unchanged.
- Full headless build links cleanly (859/859).
