### PR TITLE
Fix New Panel Cable showing outputs for a connected module input

### DIFF
--- a/firmware/src/gui/pages/module_view/mapping_pane.hh
+++ b/firmware/src/gui/pages/module_view/mapping_pane.hh
@@ -458,7 +458,7 @@ private:
 		std::string choices;
 		std::optional<unsigned> first_unpatched_jack{};
 
-		if (page->this_jack_type == ElementType::Input && !page->this_jack_has_connections) {
+		if (page->this_jack_type == ElementType::Input) {
 			unsigned num_jacks = PanelDef::NumUserFacingInJacks;
 			num_jacks += Expanders::get_connected().ext_audio_connected ? AudioExpander::NumInJacks : 0;
 			for (auto i = 0u; i < num_jacks; i++) {
@@ -491,20 +491,11 @@ private:
 			AddJackMapping jackmapping{};
 			jackmapping.panel_jack_id = (uint16_t)(choice - 1);
 
-			if (page->this_jack_type == ElementType::Input) {
-				if (auto *cable = page->patch->find_internal_cable_with_injack(page->this_jack)) {
-					// Input jack that's connected to an output -> Panel Out jack
-					jackmapping.jack = cable->out;
-					jackmapping.type = ElementType::Output;
-				} else {
-					// Input jack that's not connected any output -> Panel In jack
-					jackmapping.jack = page->this_jack;
-					jackmapping.type = ElementType::Input;
-				}
-			} else {
-				jackmapping.jack = page->this_jack;
-				jackmapping.type = ElementType::Output;
-			}
+			// Module input jacks map to panel inputs, module output jacks to panel
+			// outputs. If the input already has an internal cable, the panel input is
+			// summed with it automatically by calc_panel_jack_connections().
+			jackmapping.jack = page->this_jack;
+			jackmapping.type = page->this_jack_type;
 
 			page->patch_mod_queue.put(jackmapping);
 			page->notify_queue.put({"Connected to panel"});


### PR DESCRIPTION
## Summary

When a module input is already fed by an internal cable, selecting **New Panel Cable** on that input listed the panel **outputs** instead of the panel **inputs**. The behavior was order-dependent: mapping the panel input *before* adding the internal cable worked correctly, but doing it the other way around did not.

Reported on the forum: https://forum.4ms.info/t/bug-in-poly-firmware-v2-1-99-poly010/2655 (RackCore MIDI>CV pitch out cabled into an Ensemble Osc V/Oct input).

## Root cause

In `add_panel_cable_button_cb` (`firmware/src/gui/pages/module_view/mapping_pane.hh`), the jack list was chosen with `this_jack_type == Input && !this_jack_has_connections`. Any input that already had a connection fell through to the panel-output branch, and the action lambda then deliberately mapped the *driving output* to a panel output ("Input jack that's connected to an output -> Panel Out jack").

## Fix

Input jacks now always offer panel inputs (and map the jack as an input); output jacks offer panel outputs. When the input already has an internal cable, the new panel input is summed with it automatically by `calc_panel_jack_connections()` (this is the same end state that the old "panel-first" ordering produced, which is why that ordering already worked). The "tap a signal to a panel output" behavior is unchanged and still reachable by selecting the driving output jack and choosing New Panel Cable there.

## How to test

1. Add a RackCore MIDI>CV and an Ensemble Osc; cable MIDI>CV pitch out into the Ensemble Osc V/Oct input.
2. Open the Ensemble Osc, select its V/Oct input, and press **New Panel Cable**.
3. Before: the popup lists panel outputs. After: it lists panel inputs.

Verified in the desktop simulator. Note this is GUI-only logic; the headless runner has no UI and so cannot exercise it.
