### PR TITLE
Fix cable node list

### DIFF
--- a/firmware/src/gui/pages/jackmaps.hh
+++ b/firmware/src/gui/pages/jackmaps.hh
@@ -80,20 +80,21 @@ struct JackMapViewPage : PageBase {
 
 			// If the panel jack has an alias, show it as a header carrying the
 			// circle+number; the jack rows then align beneath the alias text.
-			bool has_alias = mapped->alias_name.size() > 0;
-			if (has_alias)
-				add_alias_header(ui_JackMapLeftItems, MapButtonType::Input, pj, mapped->alias_name.data());
+			lv_obj_t *header =
+				mapped->alias_name.size() ?
+					add_alias_header(ui_JackMapLeftItems, MapButtonType::Input, pj, mapped->alias_name.data()) :
+					nullptr;
 
 			for (auto [k, jack] : enumerate(mapped->ins)) {
 				auto name = get_full_element_name(jack.module_id, jack.jack_id, ElementType::Input, *patch);
-				add_jack_row(
-					ui_JackMapLeftItems,
-					MapButtonType::Input,
-					pj,
-					!has_alias && k == 0,
-					name,
-					(uint16_t)jack.module_id,
-					ElementCount::mark_unused_indices({.input_idx = (uint8_t)jack.jack_id}, {.num_inputs = 1}));
+				add_jack_row(ui_JackMapLeftItems,
+							 MapButtonType::Input,
+							 pj,
+							 !header && k == 0,
+							 name,
+							 (uint16_t)jack.module_id,
+							 ElementCount::mark_unused_indices({.input_idx = (uint8_t)jack.jack_id}, {.num_inputs = 1}),
+							 header);
 			}
 		}
 
@@ -117,8 +118,8 @@ struct JackMapViewPage : PageBase {
 				continue;
 			}
 
-			if (alias)
-				add_alias_header(ui_JackMapRightItems, MapButtonType::Output, pj, alias);
+			lv_obj_t *header =
+				alias ? add_alias_header(ui_JackMapRightItems, MapButtonType::Output, pj, alias) : nullptr;
 
 			bool first = true;
 			for (auto &map : patch->mapped_outs) {
@@ -130,10 +131,11 @@ struct JackMapViewPage : PageBase {
 					ui_JackMapRightItems,
 					MapButtonType::Output,
 					pj,
-					!alias && first,
+					!header && first,
 					name,
 					(uint16_t)map.out.module_id,
-					ElementCount::mark_unused_indices({.output_idx = (uint8_t)map.out.jack_id}, {.num_outputs = 1}));
+					ElementCount::mark_unused_indices({.output_idx = (uint8_t)map.out.jack_id}, {.num_outputs = 1}),
+					header);
 				first = false;
 			}
 		}
@@ -164,7 +166,8 @@ private:
 					  bool show_circle,
 					  FullElementName const &name,
 					  uint16_t module_id,
-					  ElementCount::Indices idx) {
+					  ElementCount::Indices idx,
+					  lv_obj_t *alias_header = nullptr) {
 
 		std::string text = name.module_name;
 		if (!name.element_name.empty()) {
@@ -180,17 +183,48 @@ private:
 
 		lv_obj_set_user_data(row, CableEndpointUserData{module_id, idx});
 		lv_obj_add_event_cb(row, follow_jack_cb, LV_EVENT_CLICKED, this);
+
+		// When this row gains focus, also bring its alias header into view so the
+		// panel jack it belongs to stays on screen. Runs after the row's own
+		// scroll-on-focus.
+		if (alias_header)
+			lv_obj_add_event_cb(row, scroll_to_header_cb, LV_EVENT_FOCUSED, alias_header);
+
 		lv_group_add_obj(group, row);
+	}
+
+	// Pull the alias header on-screen when its jack row is focused. Only acts when
+	// the header is actually clipped: issuing a scroll when it's already visible
+	// would cancel the row's own scroll-into-view and leave the selection off
+	// screen. And only when the whole header..row span fits the viewport, so the
+	// selected row is never pushed off just to reveal the header.
+	static void scroll_to_header_cb(lv_event_t *event) {
+		auto header = static_cast<lv_obj_t *>(event->user_data);
+		auto row = event->target;
+		if (!header || !row || lv_obj_is_visible(header))
+			return;
+
+		if (!lv_obj_is_visible(row))
+			return;
+
+		auto cont = lv_obj_get_parent(row);
+		if (!cont)
+			return;
+
+		lv_coord_t span = lv_obj_get_y(row) + lv_obj_get_height(row) - lv_obj_get_y(header);
+		if (span <= lv_obj_get_content_height(cont))
+			lv_obj_scroll_to_view(header, LV_ANIM_ON);
 	}
 
 	// Show the panel jack's alias as a non-selectable header line. The circle+
 	// number sits on this line, and the (circle-less) jack rows below align
 	// under the alias text.
-	void add_alias_header(lv_obj_t *parent, MapButtonType type, unsigned panel_jack_id, const char *alias) {
+	lv_obj_t *add_alias_header(lv_obj_t *parent, MapButtonType type, unsigned panel_jack_id, const char *alias) {
 		auto header = create_mapping_circle_item(parent, type, panel_jack_id, alias);
 		auto label = lv_obj_get_child(header, 1);
-		lv_obj_set_style_text_color(label, Gui::orange_highlight, LV_PART_MAIN);
+		lv_obj_set_style_text_color(label, Gui::grey_highlight, LV_PART_MAIN);
 		lv_obj_clear_flag(header, LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_CLICKABLE);
+		return header;
 	}
 
 	// Make the panel jack circle invisible while keeping its layout footprint,

--- a/firmware/src/gui/pages/jackmaps.hh
+++ b/firmware/src/gui/pages/jackmaps.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include "gui/elements/element_name.hh"
 #include "gui/pages/base.hh"
+#include "gui/pages/helpers.hh"
 #include "gui/pages/page_list.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "gui/slsexport/ui_local.h"
@@ -26,39 +27,24 @@ struct JackMapViewPage : PageBase {
 		// lv_obj_add_event_cb(ui_PreviousKnobSet, prev_knobset_cb, LV_EVENT_CLICKED, this);
 	}
 
-	void onJackMapClick(unsigned idx, MapButtonType type) {
-		pr_trace("%s Jack: %d\n", type == MapButtonType::Input ? "Input" : "Output", idx);
+	// Clicking a jack-mapping row jumps to that jack's module in the Module View.
+	static void follow_jack_cb(lv_event_t *event) {
+		auto page = static_cast<JackMapViewPage *>(event->user_data);
+		if (!page || !event->target)
+			return;
 
-		if (type == MapButtonType::Input) {
-			const auto &i = patch->mapped_ins[idx];
-			if (!i.ins.size()) {
-				return;
-			}
-			args.module_id = i.ins[0].module_id;
-			args.element_indices = ElementCount::mark_unused_indices(
-				{.input_idx = static_cast<uint8_t>(i.ins[0].jack_id)}, {.num_inputs = 1});
-		} else {
-			const auto &o = patch->mapped_outs[idx];
-			args.module_id = o.out.module_id;
-			args.element_indices = ElementCount::mark_unused_indices(
-				{.output_idx = static_cast<uint8_t>(o.out.jack_id)}, {.num_outputs = 1});
-		}
+		auto userdata = lv_obj_get_user_data(event->target);
+		if (!userdata)
+			return;
 
-		args.detail_mode = true;
-		page_list.request_new_page(PageId::ModuleView, args);
-	}
-
-	template<MapButtonType type>
-	static void onJackMapClick(lv_event_t *event) {
-		if (const auto page = static_cast<JackMapViewPage *>(event->user_data); page) {
-			const auto idx = (uintptr_t)lv_obj_get_user_data(event->target);
-			page->onJackMapClick(idx, type);
-		}
+		auto endpoint = CableEndpointUserData{userdata};
+		page->args.module_id = endpoint.module_id;
+		page->args.element_indices = endpoint.idx;
+		page->args.detail_mode = true;
+		page->page_list.request_new_page(PageId::ModuleView, page->args);
 	}
 
 	void prepare_focus() override {
-		init_jack_items();
-
 		redraw();
 		lv_group_activate(group);
 
@@ -69,96 +55,63 @@ struct JackMapViewPage : PageBase {
 	void redraw() {
 		patch = patches.get_view_patch();
 
+		lv_obj_clean(ui_JackMapLeftItems);
+		lv_obj_clean(ui_JackMapRightItems);
 		lv_group_remove_all_objs(group);
 
-		// Clear old text
-		for (auto *in_cont : in_conts) {
-			if (!in_cont)
-				continue;
-			if (lv_obj_get_child_cnt(in_cont) > 1)
-				lv_label_set_text(lv_obj_get_child(in_cont, 1), "");
-			lv_obj_remove_event_cb(in_cont, NULL);
-		}
-		for (auto *out_cont : out_conts) {
-			if (!out_cont)
-				continue;
-			if (lv_obj_get_child_cnt(out_cont) > 1)
-				lv_label_set_text(lv_obj_get_child(out_cont, 1), "");
-			lv_obj_remove_event_cb(out_cont, NULL);
-		}
-
-		//Populate new text
-		for (auto [i, map] : enumerate(patch->mapped_ins)) {
-			for (auto &jack : map.ins) {
-				if (map.panel_jack_id < in_conts.size() && in_conts[map.panel_jack_id]) {
-					if (lv_obj_get_child_cnt(in_conts[map.panel_jack_id]) > 1) {
-						lv_obj_set_user_data(in_conts[map.panel_jack_id], (void *)((uintptr_t)i));
-						lv_obj_add_event_cb(
-							in_conts[map.panel_jack_id], onJackMapClick<MapButtonType::Input>, LV_EVENT_CLICKED, this);
-						auto label = lv_obj_get_child(in_conts[map.panel_jack_id], 1);
-						if (!map.alias_name.size()) {
-							auto name = get_full_element_name(jack.module_id, jack.jack_id, ElementType::Input, *patch);
-							lv_label_set_text_fmt(label, "%s %s", name.module_name.data(), name.element_name.data());
-						} else {
-							lv_label_set_text_fmt(label, "%s", map.alias_name.data());
-						}
-					}
-				}
-			}
-		}
-
-		for (auto [i, map] : enumerate(patch->mapped_outs)) {
-			if (map.panel_jack_id < out_conts.size() && out_conts[map.panel_jack_id]) {
-				if (lv_obj_get_child_cnt(out_conts[map.panel_jack_id]) > 1) {
-					lv_obj_set_user_data(out_conts[map.panel_jack_id], (void *)((uintptr_t)i));
-					lv_obj_add_event_cb(
-						out_conts[map.panel_jack_id], onJackMapClick<MapButtonType::Output>, LV_EVENT_CLICKED, this);
-					auto label = lv_obj_get_child(out_conts[map.panel_jack_id], 1);
-					if (!map.alias_name.size()) {
-						auto name =
-							get_full_element_name(map.out.module_id, map.out.jack_id, ElementType::Output, *patch);
-						lv_label_set_text_fmt(label, "%s %s", name.module_name.data(), name.element_name.data());
-					} else {
-						lv_label_set_text_fmt(label, "%s", map.alias_name.data());
-					}
-				}
-			}
-		}
-
-		// Add all populated items to group
-		for (auto *cont : in_conts) {
-			if (cont && lv_obj_get_child_cnt(cont) > 1) {
-				if (lv_label_get_text(lv_obj_get_child(cont, 1))[0] != '\0')
-					lv_group_add_obj(group, cont);
-			}
-		}
-		for (auto *cont : out_conts) {
-			if (cont && lv_obj_get_child_cnt(cont) > 1) {
-				if (lv_label_get_text(lv_obj_get_child(cont, 1))[0] != '\0')
-					lv_group_add_obj(group, cont);
-			}
-		}
-	}
-
-	void init_jack_items() {
-		// Calculate number of inputs and outputs to display
+		// Number of panel jacks to display (plus expander jacks if connected)
 		unsigned num_inputs = PanelDef::NumUserFacingInJacks;
 		unsigned num_outputs = PanelDef::NumUserFacingOutJacks;
-
-		// Show all expander jacks if an expander is connected
 		if (Expanders::get_connected().ext_audio_connected) {
 			num_inputs += AudioExpander::NumInJacks;
 			num_outputs += AudioExpander::NumOutJacks;
 		}
 
-		for (unsigned i = 0; i < num_inputs; i++) {
-			if (in_conts[i] == nullptr)
-				in_conts[i] = create_mapping_circle_item(ui_JackMapLeftItems, MapButtonType::Input, i, "");
+		// Inputs (left column). A panel input jack may be summed from several
+		// module input jacks: show one selectable row per jack, with the
+		// circle+number only on the first row and the following rows' text
+		// aligned beneath it.
+		for (unsigned pj = 0; pj < num_inputs; pj++) {
+			auto *mapped = patch->find_mapped_injack((uint16_t)pj);
+			if (!mapped || mapped->ins.empty()) {
+				create_mapping_circle_item(ui_JackMapLeftItems, MapButtonType::Input, pj, "");
+				continue;
+			}
+
+			for (auto [k, jack] : enumerate(mapped->ins)) {
+				auto name = get_full_element_name(jack.module_id, jack.jack_id, ElementType::Input, *patch);
+				add_jack_row(ui_JackMapLeftItems,
+							 MapButtonType::Input,
+							 pj,
+							 k == 0,
+							 name,
+							 (uint16_t)jack.module_id,
+							 ElementCount::mark_unused_indices({.input_idx = (uint8_t)jack.jack_id}, {.num_inputs = 1}));
+			}
 		}
 
-		for (unsigned i = 0; i < num_outputs; i++) {
-			if (out_conts[i] == nullptr)
-				out_conts[i] = create_mapping_circle_item(ui_JackMapRightItems, MapButtonType::Output, i, "");
+		// Outputs (right column). A panel output jack may be driven from several
+		// module output jacks (across map entries sharing a panel_jack_id).
+		for (unsigned pj = 0; pj < num_outputs; pj++) {
+			bool any = false;
+			for (auto &map : patch->mapped_outs) {
+				if (map.panel_jack_id != pj)
+					continue;
+
+				auto name = get_full_element_name(map.out.module_id, map.out.jack_id, ElementType::Output, *patch);
+				add_jack_row(
+					ui_JackMapRightItems,
+					MapButtonType::Output,
+					pj,
+					!any,
+					name,
+					(uint16_t)map.out.module_id,
+					ElementCount::mark_unused_indices({.output_idx = (uint8_t)map.out.jack_id}, {.num_outputs = 1}));
+				any = true;
+			}
+
+			if (!any)
+				create_mapping_circle_item(ui_JackMapRightItems, MapButtonType::Output, pj, "");
 		}
 	}
 
@@ -177,10 +130,49 @@ struct JackMapViewPage : PageBase {
 	}
 
 private:
+	// Create a selectable row for one module jack connected to a panel jack.
+	// `show_circle` draws the panel jack circle+number (first row of a panel
+	// jack); otherwise the circle's space is kept but hidden so the text lines
+	// up under the first row.
+	void add_jack_row(lv_obj_t *parent,
+					  MapButtonType type,
+					  unsigned panel_jack_id,
+					  bool show_circle,
+					  FullElementName const &name,
+					  uint16_t module_id,
+					  ElementCount::Indices idx) {
+
+		std::string text = name.module_name;
+		if (!name.element_name.empty()) {
+			if (!text.empty())
+				text += " ";
+			text += name.element_name;
+		}
+
+		auto row = create_mapping_circle_item(parent, type, panel_jack_id, text.c_str());
+
+		if (!show_circle)
+			hide_circle(row);
+
+		lv_obj_set_user_data(row, CableEndpointUserData{module_id, idx});
+		lv_obj_add_event_cb(row, follow_jack_cb, LV_EVENT_CLICKED, this);
+		lv_group_add_obj(group, row);
+	}
+
+	// Make the panel jack circle invisible while keeping its layout footprint,
+	// so a continuation row's text aligns with the first row's text.
+	static void hide_circle(lv_obj_t *row) {
+		if (lv_obj_get_child_cnt(row) == 0)
+			return;
+		auto circle = lv_obj_get_child(row, 0);
+		lv_obj_set_style_bg_opa(circle, LV_OPA_TRANSP, LV_PART_MAIN);
+		lv_obj_set_style_border_opa(circle, LV_OPA_TRANSP, LV_PART_MAIN);
+		if (lv_obj_get_child_cnt(circle) > 0)
+			lv_label_set_text(lv_obj_get_child(circle, 0), "");
+	}
+
 	lv_obj_t *base = nullptr;
 	PatchData *patch;
-	std::array<lv_obj_t *, PanelDef::NumUserFacingInJacks + AudioExpander::NumInJacks> in_conts{};
-	std::array<lv_obj_t *, PanelDef::NumUserFacingOutJacks + AudioExpander::NumOutJacks> out_conts{};
 	lv_group_t *group;
 };
 

--- a/firmware/src/gui/pages/jackmaps.hh
+++ b/firmware/src/gui/pages/jackmaps.hh
@@ -78,22 +78,49 @@ struct JackMapViewPage : PageBase {
 				continue;
 			}
 
+			// If the panel jack has an alias, show it as a header carrying the
+			// circle+number; the jack rows then align beneath the alias text.
+			bool has_alias = mapped->alias_name.size() > 0;
+			if (has_alias)
+				add_alias_header(ui_JackMapLeftItems, MapButtonType::Input, pj, mapped->alias_name.data());
+
 			for (auto [k, jack] : enumerate(mapped->ins)) {
 				auto name = get_full_element_name(jack.module_id, jack.jack_id, ElementType::Input, *patch);
-				add_jack_row(ui_JackMapLeftItems,
-							 MapButtonType::Input,
-							 pj,
-							 k == 0,
-							 name,
-							 (uint16_t)jack.module_id,
-							 ElementCount::mark_unused_indices({.input_idx = (uint8_t)jack.jack_id}, {.num_inputs = 1}));
+				add_jack_row(
+					ui_JackMapLeftItems,
+					MapButtonType::Input,
+					pj,
+					!has_alias && k == 0,
+					name,
+					(uint16_t)jack.module_id,
+					ElementCount::mark_unused_indices({.input_idx = (uint8_t)jack.jack_id}, {.num_inputs = 1}));
 			}
 		}
 
 		// Outputs (right column). A panel output jack may be driven from several
 		// module output jacks (across map entries sharing a panel_jack_id).
 		for (unsigned pj = 0; pj < num_outputs; pj++) {
+			// Entries sharing a panel_jack_id carry the same alias; find it and
+			// whether anything is mapped to this panel jack.
+			const char *alias = nullptr;
 			bool any = false;
+			for (auto &map : patch->mapped_outs) {
+				if (map.panel_jack_id != pj)
+					continue;
+				any = true;
+				if (map.alias_name.size())
+					alias = map.alias_name.data();
+			}
+
+			if (!any) {
+				create_mapping_circle_item(ui_JackMapRightItems, MapButtonType::Output, pj, "");
+				continue;
+			}
+
+			if (alias)
+				add_alias_header(ui_JackMapRightItems, MapButtonType::Output, pj, alias);
+
+			bool first = true;
 			for (auto &map : patch->mapped_outs) {
 				if (map.panel_jack_id != pj)
 					continue;
@@ -103,15 +130,12 @@ struct JackMapViewPage : PageBase {
 					ui_JackMapRightItems,
 					MapButtonType::Output,
 					pj,
-					!any,
+					!alias && first,
 					name,
 					(uint16_t)map.out.module_id,
 					ElementCount::mark_unused_indices({.output_idx = (uint8_t)map.out.jack_id}, {.num_outputs = 1}));
-				any = true;
+				first = false;
 			}
-
-			if (!any)
-				create_mapping_circle_item(ui_JackMapRightItems, MapButtonType::Output, pj, "");
 		}
 	}
 
@@ -157,6 +181,16 @@ private:
 		lv_obj_set_user_data(row, CableEndpointUserData{module_id, idx});
 		lv_obj_add_event_cb(row, follow_jack_cb, LV_EVENT_CLICKED, this);
 		lv_group_add_obj(group, row);
+	}
+
+	// Show the panel jack's alias as a non-selectable header line. The circle+
+	// number sits on this line, and the (circle-less) jack rows below align
+	// under the alias text.
+	void add_alias_header(lv_obj_t *parent, MapButtonType type, unsigned panel_jack_id, const char *alias) {
+		auto header = create_mapping_circle_item(parent, type, panel_jack_id, alias);
+		auto label = lv_obj_get_child(header, 1);
+		lv_obj_set_style_text_color(label, Gui::orange_highlight, LV_PART_MAIN);
+		lv_obj_clear_flag(header, LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_CLICKABLE);
 	}
 
 	// Make the panel jack circle invisible while keeping its layout footprint,

--- a/firmware/src/gui/pages/module_view/mapping_pane.hh
+++ b/firmware/src/gui/pages/module_view/mapping_pane.hh
@@ -327,29 +327,16 @@ private:
 		}
 	}
 
-	// List every panel input jack summed into `injack`, plus the other inputs sharing each one.
-	// Returns true if any were listed.
+	// List every panel input jack summed into `injack`
 	bool list_panel_in_cables(Jack injack) {
 		bool any = false;
 		for (auto &panel_jack : patch->mapped_ins) {
-			bool contains = false;
 			for (auto &in : panel_jack.ins) {
 				if (in == injack) {
-					contains = true;
+					auto obj = list.create_panel_in_item(panel_jack.panel_jack_id, ui_MapList, panel_jack.alias_name);
+					make_selectable_panel_jack_item(obj, &panel_jack);
+					any = true;
 					break;
-				}
-			}
-			if (!contains)
-				continue;
-
-			auto obj = list.create_panel_in_item(panel_jack.panel_jack_id, ui_MapList, panel_jack.alias_name);
-			make_selectable_panel_jack_item(obj, &panel_jack);
-			any = true;
-
-			for (auto &mappedin : panel_jack.ins) {
-				if (mappedin != injack) {
-					auto in_obj = list.create_cable_item(mappedin, ElementType::Input, *patch, ui_MapList);
-					make_selectable_injack_item(in_obj, mappedin);
 				}
 			}
 		}

--- a/firmware/src/gui/pages/module_view/mapping_pane.hh
+++ b/firmware/src/gui/pages/module_view/mapping_pane.hh
@@ -279,80 +279,94 @@ private:
 		bool has_connections = false;
 
 		lv_show(ui_CablePanelAddButton);
-		lv_show(ui_CableMidiAddButton, this_jack_type == ElementType::Input);
 
-		if (auto *cable = find_internal_cable(this_jack_type, this_jack)) {
-			has_connections = true;
-			list_cable_nodes(cable);
-
-		} else if (auto panel_jack_id = drawn_element->gui_element.mapped_panel_id) {
-			has_connections = true;
-
-			if (this_jack_type == ElementType::Input)
-				list_panel_in_cable(this_jack);
-			else if (auto panel_jack = patch->find_mapped_outjack(*panel_jack_id)) {
-				list_panel_out_cable(panel_jack);
+		if (this_jack_type == ElementType::Output) {
+			// Internal cable: this output drives one or more virtual input jacks
+			if (auto *cable = patch->find_internal_cable_with_outjack(this_jack)) {
+				list_cable_inputs(cable);
+				has_connections = true;
 			}
+			// This output may also drive one or more panel output jacks
+			if (list_panel_out_cables(this_jack))
+				has_connections = true;
+
+		} else {
+			// Find all connected internal cables: this input is driven by a virtual output jack
+			for (auto &cable : patch->int_cables) {
+				for (auto &in : cable.ins) {
+					if (in == this_jack) {
+						list_cable_output(cable);
+						has_connections = true;
+					}
+				}
+			}
+
+			// This input may also be summed from one or more panel input jacks
+			if (list_panel_in_cables(this_jack))
+				has_connections = true;
 		}
+
+		// MIDI can only be mapped to an input jack that has no other connections
+		lv_show(ui_CableMidiAddButton, this_jack_type == ElementType::Input && !has_connections);
 
 		this_jack_has_connections = has_connections;
 		prepare_jack_gui();
 	}
 
-	const InternalCable *find_internal_cable(ElementType dir, Jack jack) {
-		if (dir == ElementType::Output)
-			return patch->find_internal_cable_with_outjack(jack);
-		else
-			return patch->find_internal_cable_with_injack(jack);
+	// Viewing an input jack: list the driving output, and co-driven inputs.
+	void list_cable_output(InternalCable const &cable) {
+		auto obj = list.create_cable_item(cable.out, ElementType::Output, *patch, ui_MapList);
+		make_selectable_outjack_item(obj, cable.out);
 	}
 
-	void list_cable_nodes(InternalCable const *cable) {
-		lv_hide(ui_CableMidiAddButton);
-
-		// Each cable has an output:
-		if (!(cable->out == this_jack && this_jack_type == ElementType::Output)) {
-			auto obj = list.create_cable_item(cable->out, ElementType::Output, *patch, ui_MapList);
-			make_selectable_outjack_item(obj, cable->out);
-		}
-
-		// Output might be connected to the panel
-		if (auto panel_jack = patch->find_mapped_outjack(cable->out)) {
-			list_panel_out_cable(panel_jack);
-		}
-
-		// Each cable has 1 or more inputs:
+	// Viewing an output jack: list each virtual input it drives.
+	void list_cable_inputs(InternalCable const *cable) {
 		for (auto &injack : cable->ins) {
-			//draw it if NOT (it's this jack and this jack is an input)
-			if (!(injack == this_jack && this_jack_type == ElementType::Input)) {
-				auto obj = list.create_cable_item(injack, ElementType::Input, *patch, ui_MapList);
-				make_selectable_injack_item(obj, injack);
-			}
+			auto obj = list.create_cable_item(injack, ElementType::Input, *patch, ui_MapList);
+			make_selectable_injack_item(obj, injack);
 		}
 	}
 
-	void list_panel_in_cable(Jack injack) {
-		if (auto panel_jack = patch->find_mapped_injack(injack)) {
-			lv_hide(ui_CablePanelAddButton);
-			lv_hide(ui_CableMidiAddButton);
+	// List every panel input jack summed into `injack`, plus the other inputs sharing each one.
+	// Returns true if any were listed.
+	bool list_panel_in_cables(Jack injack) {
+		bool any = false;
+		for (auto &panel_jack : patch->mapped_ins) {
+			bool contains = false;
+			for (auto &in : panel_jack.ins) {
+				if (in == injack) {
+					contains = true;
+					break;
+				}
+			}
+			if (!contains)
+				continue;
 
-			auto obj = list.create_panel_in_item(panel_jack->panel_jack_id, ui_MapList, panel_jack->alias_name);
-			make_selectable_panel_jack_item(obj, panel_jack);
+			auto obj = list.create_panel_in_item(panel_jack.panel_jack_id, ui_MapList, panel_jack.alias_name);
+			make_selectable_panel_jack_item(obj, &panel_jack);
+			any = true;
 
-			for (auto &mappedin : panel_jack->ins) {
+			for (auto &mappedin : panel_jack.ins) {
 				if (mappedin != injack) {
-					auto obj = list.create_cable_item(mappedin, ElementType::Input, *patch, ui_MapList);
-					make_selectable_injack_item(obj, mappedin);
+					auto in_obj = list.create_cable_item(mappedin, ElementType::Input, *patch, ui_MapList);
+					make_selectable_injack_item(in_obj, mappedin);
 				}
 			}
 		}
+		return any;
 	}
 
-	void list_panel_out_cable(const MappedOutputJack *panel_jack) {
-		lv_hide(ui_CablePanelAddButton);
-		lv_hide(ui_CableMidiAddButton);
-
-		auto obj = list.create_panel_out_item(panel_jack->panel_jack_id, ui_MapList, panel_jack->alias_name);
-		make_selectable_panel_jack_item(obj, panel_jack);
+	// List every panel output jack driven by `outjack`. Returns true if any were listed.
+	bool list_panel_out_cables(Jack outjack) {
+		bool any = false;
+		for (auto &panel_jack : patch->mapped_outs) {
+			if (panel_jack.out == outjack) {
+				auto obj = list.create_panel_out_item(panel_jack.panel_jack_id, ui_MapList, panel_jack.alias_name);
+				make_selectable_panel_jack_item(obj, &panel_jack);
+				any = true;
+			}
+		}
+		return any;
 	}
 
 	void prepare_jack_gui() {

--- a/firmware/src/gui/pages/page_manager.hh
+++ b/firmware/src/gui/pages/page_manager.hh
@@ -110,6 +110,12 @@ public:
 		button_light.display_knobset(0);
 	}
 
+	// Request a specific page (used by the simulator to jump directly to a page
+	// for screenshots/testing, bypassing manual navigation).
+	void request_page(PageId id, PageArguments args = {}) {
+		page_list.request_initial_page(id, args);
+	}
+
 	void update_current_page() {
 
 		handle_knobset_change();

--- a/simulator/README-screenshots.md
+++ b/simulator/README-screenshots.md
@@ -1,0 +1,93 @@
+# Simulator screenshots & headless initial state
+
+The simulator can boot directly into a chosen page with a patch already loaded,
+render a few frames, dump the screen to an image file, and exit — all without
+manually driving the GUI. This is intended for visual verification of GUI
+changes (by a human or by automation/CI) without needing to navigate menus or
+worry about the SDL window being obscured by other windows.
+
+## Quick start
+
+Run from the `simulator/` directory (paths below are relative to it):
+
+```sh
+# Build the simulator (assets are produced by the firmware build)
+ninja -C build simulator
+
+# Load a patch, jump to the Jacks page, capture, and exit
+./build/simulator -p patches/ \
+    --patch /test-cable-disp.yml \
+    --page jackmap \
+    --screenshot /tmp/shot.bmp \
+    --screenshot-frames 20
+
+# Capture is written as BMP. Convert to PNG to view (macOS):
+sips -s format png /tmp/shot.bmp --out /tmp/shot.png
+# ...or cross-platform with ImageMagick:
+# convert /tmp/shot.bmp /tmp/shot.png
+```
+
+The screen is 320x240. The capture is taken from the last fully-rendered LVGL
+framebuffer, so it is unaffected by the SDL window being hidden, minimized, or
+covered by other windows.
+
+## Options
+
+These options are added on top of the simulator's normal options
+(`-z/--zoom`, `-p/--sdcarddir`, `-f/--flashdir`, `-s/--assets`, etc.):
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--patch <file>` | Patch file on the SD-card volume to load on startup, e.g. `/test-cable-disp.yml`. Path is relative to the SD-card root (`-p/--sdcarddir`, default `patches/`). | (none) |
+| `--page <name>` | Page to jump to on startup (see table below). | (none) |
+| `--screenshot <file>` | Capture the screen to this **BMP** file after rendering, then exit. If omitted, the simulator runs normally. | (none) |
+| `--screenshot-frames <N>` | Number of UI update cycles (~`N`×10 ms) to run before capturing. | `120` |
+
+`--patch` and `--page` also work without `--screenshot`: the simulator will load
+the patch / jump to the page and then run interactively as usual. This is handy
+for jumping straight to the screen you're working on.
+
+### Page names
+
+| `--page` value | Page |
+| --- | --- |
+| `mainmenu` | Main menu |
+| `patchsel` | Patch selector |
+| `patchview` | Patch view |
+| `moduleview` | Module view |
+| `modulelist` | Module list |
+| `jackmap` | Jack map (panel in/out mappings) |
+| `midimap` | MIDI map |
+
+(Unknown names print a warning and are ignored. All pages use the same jump
+mechanism, but some — e.g. `moduleview` and `knobmap` — need page arguments
+(a target module/param) to render anything useful when entered directly, which
+this tool does not currently supply. `jackmap` renders from just a loaded patch
+and is the verified target; `midimap`/`patchview` should behave similarly.)
+
+## Notes & caveats
+
+- **Choosing `--screenshot-frames`.** Labels that are too wide for their column
+  use `LV_LABEL_LONG_SCROLL` and start scrolling shortly after the page appears.
+  Use a small value (e.g. `20`) to capture text near its start; the default
+  `120` lets animations/notifications settle but long names will have scrolled.
+- **Output format.** Capture writes BMP (no extra image-library dependency).
+  Convert with `sips` (macOS) or ImageMagick `convert` as shown above. The
+  agent reading the image needs PNG/JPG, not BMP.
+- **Audio is skipped** in screenshot mode, so no audio device is required for a
+  capture.
+- The capture is the LVGL framebuffer, not the SDL window contents, so other
+  windows covering the simulator do not affect the result.
+
+## How it works (for maintainers)
+
+- `lv_port_disp_capture(const char *path)` in `lvgl_drv/lv_sdl_disp.c` saves the
+  most recently flushed framebuffer (the driver uses `full_refresh = 1`, so each
+  flush holds the whole screen) to a BMP via SDL. Declared in
+  `lvgl_drv/lv_port_disp.h`.
+- `Ui::load_patch()` and `Ui::goto_page()` (`src/ui.{hh,cc}`) load a patch
+  synchronously (the simulator's file storage services requests inline) and jump
+  to a page via `PageManager::request_page()` (a thin public wrapper added in the
+  firmware's `src/gui/pages/page_manager.hh`).
+- The startup/screenshot flow is wired in `src/main.cc`; option parsing is in
+  `src/settings.hh`.

--- a/simulator/README-screenshots.md
+++ b/simulator/README-screenshots.md
@@ -8,7 +8,10 @@ worry about the SDL window being obscured by other windows.
 
 ## Quick start
 
-Run from the `simulator/` directory (paths below are relative to it):
+The binary can be launched from any working directory — its default resource
+paths (`patches/`, `build/assets.uimg`, `../patches/default/`) are resolved
+relative to the executable's location when they aren't found relative to the
+cwd. The examples below are written as if run from `simulator/`:
 
 ```sh
 # Build the simulator (assets are produced by the firmware build)

--- a/simulator/README-screenshots.md
+++ b/simulator/README-screenshots.md
@@ -42,6 +42,7 @@ These options are added on top of the simulator's normal options
 | `--page <name>` | Page to jump to on startup (see table below). | (none) |
 | `--screenshot <file>` | Capture the screen to this **BMP** file after rendering, then exit. If omitted, the simulator runs normally. | (none) |
 | `--screenshot-frames <N>` | Number of UI update cycles (~`N`×10 ms) to run before capturing. | `120` |
+| `--input "<seq>"` | Ordered encoder actions to simulate on startup before capture (see below). | (none) |
 
 `--patch` and `--page` also work without `--screenshot`: the simulator will load
 the patch / jump to the page and then run interactively as usual. This is handy
@@ -64,6 +65,39 @@ mechanism, but some — e.g. `moduleview` and `knobmap` — need page arguments
 (a target module/param) to render anything useful when entered directly, which
 this tool does not currently supply. `jackmap` renders from just a loaded patch
 and is the verified target; `midimap`/`patchview` should behave similarly.)
+
+## Simulating encoder input
+
+`--input` drives the rotary encoder so you can navigate a list and activate an
+item, then screenshot the result. It takes a single ordered, space-separated
+sequence of tokens (one string, so order is preserved):
+
+| Token | Action |
+| --- | --- |
+| `cw` | Rotary turn clockwise (focus next item in the group) |
+| `ccw` | Rotary turn counter-clockwise (focus previous item) |
+| `click` | Rotary press+release (activate the focused item) |
+| `back` | Back/aux button press+release |
+
+Repeat a token with `token:N`, e.g. `cw:3`. Each action runs a few UI cycles
+before the next so LVGL processes it.
+
+```sh
+# Open the Jacks page, move focus down two items, click it, and capture the
+# page it navigates to:
+./build/simulator -p patches/ \
+    --patch /test-cable-disp.yml \
+    --page jackmap \
+    --input "cw cw click" \
+    --screenshot /tmp/shot.bmp \
+    --screenshot-frames 40
+```
+
+Focus starts on the first selectable item of the page, so `click` activates it,
+`cw click` the second, `cw cw click` the third, and so on. The synthesized
+events go through the real input driver, so this exercises the actual
+navigation/click code paths. (Key bindings come from `Ui::input_keys()`:
+cw=Right, ccw=Left, click=Down, back=Up.)
 
 ## Notes & caveats
 

--- a/simulator/lvgl_drv/lv_port_disp.h
+++ b/simulator/lvgl_drv/lv_port_disp.h
@@ -31,6 +31,7 @@ extern "C" {
  **********************/
 void lv_port_disp_init(int width, int height, int zoom);
 void lv_port_disp_deinit(void);
+int lv_port_disp_capture(const char *path);
 /**********************
  *      MACROS
  **********************/

--- a/simulator/lvgl_drv/lv_sdl_disp.c
+++ b/simulator/lvgl_drv/lv_sdl_disp.c
@@ -13,6 +13,8 @@ static lv_disp_drv_t disp_drv;
 static lv_disp_draw_buf_t draw_buf;
 static int DISPLAY_WIDTH;
 static int DISPLAY_HEIGHT;
+// Most recently flushed framebuffer (full_refresh=1, so it holds the whole screen)
+static lv_color_t *last_fb = NULL;
 #ifndef WINDOW_NAME
 #define WINDOW_NAME "MetaModule"
 #endif
@@ -26,7 +28,26 @@ static void disp_flush(lv_disp_drv_t *disp_drv, const lv_area_t *area, lv_color_
 	SDL_UpdateTexture(texture, &r, color_p, r.w * ((LV_COLOR_DEPTH + 7) / 8));
 	SDL_RenderCopy(renderer, texture, NULL, NULL);
 	SDL_RenderPresent(renderer);
+	last_fb = color_p;
 	lv_disp_flush_ready(disp_drv);
+}
+
+// Save the current screen contents to a BMP file. Returns 0 on success.
+int lv_port_disp_capture(const char *path) {
+	if (!last_fb)
+		return -1;
+
+	Uint32 fmt = (LV_COLOR_DEPTH == 32) ? SDL_PIXELFORMAT_ARGB8888 : SDL_PIXELFORMAT_RGB565;
+	int pitch = DISPLAY_WIDTH * ((LV_COLOR_DEPTH + 7) / 8);
+
+	SDL_Surface *surf = SDL_CreateRGBSurfaceWithFormatFrom(
+		last_fb, DISPLAY_WIDTH, DISPLAY_HEIGHT, LV_COLOR_DEPTH, pitch, fmt);
+	if (!surf)
+		return -1;
+
+	int ret = SDL_SaveBMP(surf, path);
+	SDL_FreeSurface(surf);
+	return ret;
 }
 
 void lv_port_disp_init(int width, int height, int zoom) {

--- a/simulator/patches/test-cable-disp.yml
+++ b/simulator/patches/test-cable-disp.yml
@@ -32,14 +32,26 @@ PatchData:
         - module_id: 4
           jack_id: 1
   mapped_outs:
-    - panel_jack_id: 0
+    - panel_jack_id: 2
       out:
         module_id: 1
         jack_id: 1
-    - panel_jack_id: 0
+      alias_name: Clock
+    - panel_jack_id: 2
       out:
         module_id: 3
         jack_id: 3
+      alias_name: Clock
+    - panel_jack_id: 7
+      out:
+        module_id: 1
+        jack_id: 2
+      alias_name: Clock
+    - panel_jack_id: 7
+      out:
+        module_id: 3
+        jack_id: 2
+      alias_name: Clock
   static_knobs:
     - module_id: 1
       param_id: 0
@@ -141,27 +153,12 @@ PatchData:
       param_id: 1
       value: 1
   mapped_knobs:
-    - name: ''
-      set: []
-    - name: ''
-      set: []
-    - name: ''
-      set: []
-    - name: ''
-      set: []
-    - name: ''
-      set: []
-    - name: ''
-      set: []
-    - name: ''
-      set: []
-    - name: ''
+    - name: Knob Set 1
       set: []
   midi_maps:
     name: ''
     set: []
-  midi_poly_num: 1
-  midi_poly_num_setting: 0
+  midi_poly_num: 0
   midi_poly_mode: 0
   midi_pitchwheel_range: -1
   mapped_lights: []

--- a/simulator/patches/test-cable-disp.yml
+++ b/simulator/patches/test-cable-disp.yml
@@ -1,0 +1,175 @@
+PatchData:
+  patch_name: 'test-cable-disp'
+  description: Patch Description
+  module_slugs:
+    0: '4msCompany:HubMedium'
+    1: '4msCompany:MPEG'
+    2: '4msCompany:Seq8'
+    3: '4msCompany:BWAVP'
+    4: '4msCompany:Atvert2'
+  int_cables:
+    - out:
+        module_id: 1
+        jack_id: 1
+      ins:
+        - module_id: 2
+          jack_id: 0
+        - module_id: 3
+          jack_id: 0
+      color: 64934
+    - out:
+        module_id: 4
+        jack_id: 0
+      ins:
+        - module_id: 3
+          jack_id: 0
+      color: 61865
+  mapped_ins:
+    - panel_jack_id: 6
+      ins:
+        - module_id: 3
+          jack_id: 0
+        - module_id: 4
+          jack_id: 1
+  mapped_outs:
+    - panel_jack_id: 0
+      out:
+        module_id: 1
+        jack_id: 1
+    - panel_jack_id: 0
+      out:
+        module_id: 3
+        jack_id: 3
+  static_knobs:
+    - module_id: 1
+      param_id: 0
+      value: 0.5
+    - module_id: 1
+      param_id: 1
+      value: 0.5
+    - module_id: 1
+      param_id: 2
+      value: 1
+    - module_id: 1
+      param_id: 3
+      value: 1
+    - module_id: 1
+      param_id: 4
+      value: 0
+    - module_id: 1
+      param_id: 5
+      value: 0
+    - module_id: 1
+      param_id: 6
+      value: 0
+    - module_id: 1
+      param_id: 7
+      value: 0.5
+    - module_id: 1
+      param_id: 8
+      value: 1
+    - module_id: 1
+      param_id: 9
+      value: 0
+    - module_id: 1
+      param_id: 10
+      value: 0
+    - module_id: 1
+      param_id: 11
+      value: 0.333333
+    - module_id: 1
+      param_id: 12
+      value: 0
+    - module_id: 1
+      param_id: 13
+      value: 0
+    - module_id: 2
+      param_id: 0
+      value: 0.25
+    - module_id: 2
+      param_id: 1
+      value: 0.5
+    - module_id: 2
+      param_id: 2
+      value: 0.875
+    - module_id: 2
+      param_id: 3
+      value: 0.25
+    - module_id: 2
+      param_id: 4
+      value: 0.5
+    - module_id: 2
+      param_id: 5
+      value: 0.875
+    - module_id: 2
+      param_id: 6
+      value: 1
+    - module_id: 2
+      param_id: 7
+      value: 0.25
+    - module_id: 3
+      param_id: 0
+      value: 0
+    - module_id: 3
+      param_id: 1
+      value: 0
+    - module_id: 3
+      param_id: 2
+      value: 0
+    - module_id: 3
+      param_id: 3
+      value: 0.101562
+    - module_id: 3
+      param_id: 4
+      value: 0.25
+    - module_id: 3
+      param_id: 5
+      value: 0.272727
+    - module_id: 3
+      param_id: 6
+      value: 0
+    - module_id: 3
+      param_id: 7
+      value: 0
+    - module_id: 3
+      param_id: 8
+      value: 0
+    - module_id: 4
+      param_id: 0
+      value: 0.50412
+    - module_id: 4
+      param_id: 1
+      value: 1
+  mapped_knobs:
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+    - name: ''
+      set: []
+  midi_maps:
+    name: ''
+    set: []
+  midi_poly_num: 1
+  midi_poly_num_setting: 0
+  midi_poly_mode: 0
+  midi_pitchwheel_range: -1
+  mapped_lights: []
+  vcvModuleStates:
+    - module_id: 1
+      data: |-
+        XuzTPgGowwE=
+  suggested_samplerate: 0
+  suggested_blocksize: 0
+  bypassed_modules: []
+  module_aliases: []

--- a/simulator/src/host_file_io.hh
+++ b/simulator/src/host_file_io.hh
@@ -22,7 +22,12 @@ struct HostFileIO {
 
 		std::cout << "Scanning " << _root_dir << " for " << extension << " files...\n";
 
-		fs::current_path(_root_dir);
+		std::error_code cp_ec;
+		fs::current_path(_root_dir, cp_ec);
+		if (cp_ec) {
+			std::cout << "Error: cannot access " << _root_dir << ": " << cp_ec.message() << "\n";
+			return false;
+		}
 
 		fs::path full_path{"."};
 

--- a/simulator/src/main.cc
+++ b/simulator/src/main.cc
@@ -8,8 +8,72 @@
 #include <chrono>
 #include <iostream>
 #include <optional>
+#include <sstream>
+#include <string>
 #include <string_view>
 #include <thread>
+
+static void run_cycles(MetaModule::Ui &ui, unsigned n) {
+	for (unsigned i = 0; i < n; i++) {
+		ui.update();
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+}
+
+static void push_key(SDL_Keycode keycode, bool down) {
+	SDL_Event e{};
+	e.type = down ? SDL_KEYDOWN : SDL_KEYUP;
+	e.key.state = down ? SDL_PRESSED : SDL_RELEASED;
+	e.key.repeat = 0;
+	e.key.keysym.sym = keycode;
+	SDL_PushEvent(&e);
+}
+
+// Simulate a sequence of encoder actions (e.g. "cw cw click") by synthesizing
+// the same SDL key events the input driver reads, running UI cycles in between
+// so LVGL processes each one.
+static void simulate_input(MetaModule::Ui &ui, const std::string &seq) {
+	auto const &keys = ui.input_keys();
+
+	run_cycles(ui, 12); // let the starting page settle before sending input
+
+	std::istringstream iss(seq);
+	std::string tok;
+	while (iss >> tok) {
+		unsigned count = 1;
+		std::string name = tok;
+		if (auto colon = tok.find(':'); colon != std::string::npos) {
+			name = tok.substr(0, colon);
+			count = (unsigned)std::stoul(tok.substr(colon + 1));
+		}
+
+		for (unsigned c = 0; c < count; c++) {
+			if (name == "cw") {
+				push_key(keys.turn_cw, true);
+				run_cycles(ui, 4);
+				push_key(keys.turn_cw, false);
+				run_cycles(ui, 2);
+			} else if (name == "ccw") {
+				push_key(keys.turn_ccw, true);
+				run_cycles(ui, 4);
+				push_key(keys.turn_ccw, false);
+				run_cycles(ui, 2);
+			} else if (name == "click") {
+				push_key(keys.click, true);
+				run_cycles(ui, 4);
+				push_key(keys.click, false);
+				run_cycles(ui, 6);
+			} else if (name == "back") {
+				push_key(keys.aux_button, true);
+				run_cycles(ui, 4);
+				push_key(keys.aux_button, false);
+				run_cycles(ui, 4);
+			} else {
+				std::cout << "Unknown --input token '" << name << "'\n";
+			}
+		}
+	}
+}
 
 static std::optional<MetaModule::PageId> resolve_page(std::string_view name) {
 	using MetaModule::PageId;
@@ -67,6 +131,10 @@ int main(int argc, char *argv[]) {
 
 	if (auto page = resolve_page(settings.start_page))
 		ui.goto_page(*page);
+
+	// Simulate encoder input (e.g. navigate to and click a list item) before capture
+	if (!settings.input_sequence.empty())
+		simulate_input(ui, settings.input_sequence);
 
 	// Headless screenshot mode: render a few frames so the page settles, then
 	// dump the screen to a BMP file and exit without starting audio.

--- a/simulator/src/main.cc
+++ b/simulator/src/main.cc
@@ -6,6 +6,7 @@
 #include "settings.hh"
 #include "ui.hh"
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <optional>
 #include <sstream>
@@ -107,11 +108,39 @@ int main(int argc, char *argv[]) {
 
 	SDLAudio<Frame> audio_out{settings.audioout_dev};
 
-	auto sdcard_path = std::filesystem::absolute(settings.sdcard_path);
+	// The default resource paths (patches/, build/assets.uimg, ../patches/default/)
+	// are relative to the simulator/ directory. So the binary can be launched from
+	// any working directory, fall back to resolving them relative to the executable
+	// (which lives in simulator/build/) when they aren't found relative to the cwd.
+	namespace fs = std::filesystem;
+	fs::path sim_dir;
+	if (argc > 0 && std::string_view(argv[0]).find('/') != std::string_view::npos) {
+		std::error_code ec;
+		auto exe = fs::weakly_canonical(fs::absolute(argv[0], ec), ec);
+		if (!ec)
+			sim_dir = exe.parent_path().parent_path(); // simulator/build/simulator -> simulator/
+	}
 
-	auto flash_path = std::filesystem::absolute(settings.flash_path);
+	auto resolve_resource = [&](const std::string &p) -> fs::path {
+		std::error_code ec;
+		auto cwd_rel = fs::absolute(p, ec);
+		if (!ec && fs::exists(cwd_rel, ec))
+			return cwd_rel;
+		if (!sim_dir.empty()) {
+			auto sim_rel = sim_dir / p;
+			if (fs::exists(sim_rel, ec))
+				return sim_rel;
+		}
+		return cwd_rel; // not found anywhere; reported by the file layer (no longer aborts)
+	};
 
-	auto asset_tar_path = std::filesystem::absolute(settings.asset_file);
+	auto sdcard_path = resolve_resource(settings.sdcard_path);
+	auto flash_path = resolve_resource(settings.flash_path);
+	auto asset_tar_path = resolve_resource(settings.asset_file);
+
+	if (std::error_code ec; !fs::exists(sdcard_path, ec))
+		std::cout << "Warning: SD-card patch dir not found: " << sdcard_path
+				  << " (pass -p <dir> or run from the simulator/ directory)\n";
 
 	MetaModule::Ui ui{sdcard_path.string(), flash_path.string(), asset_tar_path.string(), audio_out.get_block_size()};
 

--- a/simulator/src/main.cc
+++ b/simulator/src/main.cc
@@ -5,7 +5,33 @@
 #include "sdl_audio.hh"
 #include "settings.hh"
 #include "ui.hh"
+#include <chrono>
+#include <iostream>
+#include <optional>
 #include <string_view>
+#include <thread>
+
+static std::optional<MetaModule::PageId> resolve_page(std::string_view name) {
+	using MetaModule::PageId;
+	if (name.empty())
+		return std::nullopt;
+	if (name == "mainmenu")
+		return PageId::MainMenu;
+	if (name == "patchsel")
+		return PageId::PatchSel;
+	if (name == "patchview")
+		return PageId::PatchView;
+	if (name == "moduleview")
+		return PageId::ModuleView;
+	if (name == "modulelist")
+		return PageId::ModuleList;
+	if (name == "jackmap")
+		return PageId::JackMapView;
+	if (name == "midimap")
+		return PageId::MidiMapView;
+	std::cout << "Unknown --page '" << name << "'\n";
+	return std::nullopt;
+}
 
 int main(int argc, char *argv[]) {
 	MetaModuleSim::Settings settings;
@@ -34,6 +60,34 @@ int main(int argc, char *argv[]) {
 	}
 
 	ui.set_audio_fullscale(settings.fullscale_volts);
+
+	// Optional headless startup state for screenshots/testing
+	if (!settings.startup_patch.empty())
+		ui.load_patch(settings.startup_patch, MetaModule::Volume::SDCard);
+
+	if (auto page = resolve_page(settings.start_page))
+		ui.goto_page(*page);
+
+	// Headless screenshot mode: render a few frames so the page settles, then
+	// dump the screen to a BMP file and exit without starting audio.
+	if (!settings.screenshot_path.empty()) {
+		for (unsigned i = 0; i < settings.screenshot_frames; i++) {
+			ui.update();
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		}
+
+		int rc = lv_port_disp_capture(settings.screenshot_path.c_str());
+		if (rc == 0)
+			std::cout << "Saved screenshot to " << settings.screenshot_path << "\n";
+		else
+			std::cout << "Screenshot capture failed (rc=" << rc << ")\n";
+
+		MetaModule::kill_module_threads();
+		lv_port_disp_deinit();
+		lv_deinit();
+		return rc;
+	}
+
 	audio_out.set_callback([&ui](auto playback_buffer) { ui.play_patch(playback_buffer); });
 	audio_out.unpause();
 

--- a/simulator/src/settings.hh
+++ b/simulator/src/settings.hh
@@ -21,6 +21,7 @@ struct Settings {
 	std::string start_page = "";	// page to jump to on startup, e.g. "jackmap"
 	std::string screenshot_path = ""; // if set, capture to this BMP path then exit
 	unsigned screenshot_frames = 120; // UI update cycles to run before capturing
+	std::string input_sequence = ""; // ordered encoder actions to simulate, e.g. "cw cw click"
 
 	void parse(int argc, char *argv[]) {
 
@@ -68,6 +69,11 @@ struct Settings {
 								  "UI update cycles to run before capturing a screenshot",
 								  cxxopts::value<unsigned>()->default_value("120"));
 
+			options.add_options()("input",
+								  "Ordered encoder actions to simulate on startup, e.g. \"cw cw click\" "
+								  "(tokens: cw, ccw, click, back; repeat with cw:3)",
+								  cxxopts::value<std::string>()->default_value(""));
+
 			options.add_options()("h,help", "Print help");
 
 			auto args = options.parse(argc, argv);
@@ -83,6 +89,9 @@ struct Settings {
 
 			if (args.count("screenshot-frames") > 0)
 				screenshot_frames = args["screenshot-frames"].as<unsigned>();
+
+			if (args.count("input") > 0)
+				input_sequence = args["input"].as<std::string>();
 
 			if (args.count("zoom") > 0)
 				zoom = std::clamp(args["zoom"].as<unsigned>(), 25U, 800U);

--- a/simulator/src/settings.hh
+++ b/simulator/src/settings.hh
@@ -15,6 +15,13 @@ struct Settings {
 	std::string test_brand = "";
 	float fullscale_volts = 5;
 
+	// Headless screenshot support: load a patch, jump to a page, render some
+	// frames, then dump the screen to a BMP file and exit.
+	std::string startup_patch = ""; // patch filename on the SD card, e.g. "/test-cable-disp.yml"
+	std::string start_page = "";	// page to jump to on startup, e.g. "jackmap"
+	std::string screenshot_path = ""; // if set, capture to this BMP path then exit
+	unsigned screenshot_frames = 120; // UI update cycles to run before capturing
+
 	void parse(int argc, char *argv[]) {
 
 		try {
@@ -46,9 +53,36 @@ struct Settings {
 								  "Volts (peak) which corresponds to full-scale signal sent to sound card",
 								  cxxopts::value<float>()->default_value("5"));
 
+			options.add_options()("patch",
+								  "Patch file on the SD card to load on startup (e.g. /test-cable-disp.yml)",
+								  cxxopts::value<std::string>()->default_value(""));
+
+			options.add_options()(
+				"page", "Page to jump to on startup (e.g. jackmap, midimap)", cxxopts::value<std::string>()->default_value(""));
+
+			options.add_options()("screenshot",
+								  "Capture the screen to this BMP file after rendering, then exit",
+								  cxxopts::value<std::string>()->default_value(""));
+
+			options.add_options()("screenshot-frames",
+								  "UI update cycles to run before capturing a screenshot",
+								  cxxopts::value<unsigned>()->default_value("120"));
+
 			options.add_options()("h,help", "Print help");
 
 			auto args = options.parse(argc, argv);
+
+			if (args.count("patch") > 0)
+				startup_patch = args["patch"].as<std::string>();
+
+			if (args.count("page") > 0)
+				start_page = args["page"].as<std::string>();
+
+			if (args.count("screenshot") > 0)
+				screenshot_path = args["screenshot"].as<std::string>();
+
+			if (args.count("screenshot-frames") > 0)
+				screenshot_frames = args["screenshot-frames"].as<unsigned>();
 
 			if (args.count("zoom") > 0)
 				zoom = std::clamp(args["zoom"].as<unsigned>(), 25U, 800U);

--- a/simulator/src/ui.cc
+++ b/simulator/src/ui.cc
@@ -108,6 +108,14 @@ void Ui::set_audio_fullscale(float volts_peak) {
 	audio_stream.volts_peak = volts_peak;
 }
 
+void Ui::load_patch(std::string_view patch_name, Volume vol) {
+	patch_playloader.load_initial_patch(patch_name, vol);
+}
+
+void Ui::goto_page(PageId page_id) {
+	page_manager.request_page(page_id);
+}
+
 void Ui::play_patch(std::span<Frame> soundcard_out) {
 
 	// assert(soundcard_out.size() == out_buffer.size());

--- a/simulator/src/ui.hh
+++ b/simulator/src/ui.hh
@@ -37,6 +37,11 @@ public:
 	void play_patch(std::span<Frame> buffer);
 	void set_audio_fullscale(float volts_peak);
 
+	// Load a patch and start viewing/playing it (used for headless screenshots).
+	void load_patch(std::string_view patch_name, Volume vol);
+	// Jump directly to a page by id (used for headless screenshots).
+	void goto_page(PageId page_id);
+
 private:
 	PatchDirList patch_dir_list;
 

--- a/simulator/src/ui.hh
+++ b/simulator/src/ui.hh
@@ -41,6 +41,10 @@ public:
 	void load_patch(std::string_view patch_name, Volume vol);
 	// Jump directly to a page by id (used for headless screenshots).
 	void goto_page(PageId page_id);
+	// Encoder key bindings, so headless tooling can synthesize matching SDL events.
+	const RotaryEncoderKeys &input_keys() const {
+		return keys;
+	}
 
 private:
 	PatchDirList patch_dir_list;


### PR DESCRIPTION
The list of "Connected to:" jack and the Jack Maps page were not showing the whole picture, and sometimes showed indirectly-connected jacks (omitting directly connected ones). This PR cleans up all cases so that the list shows only what's directly connected:
- Inputs display all the outputs that are summed to drive this input, including panel mappings. Other inputs that are also driven by a common output are not shown.
- Outputs display all inputs that are being driven by this output, including panel mappings. Other outputs that sum to drive a common input are not shown.
- On the Jack Maps page, panel jacks that map to multiple module jacks show all the mappings, and clicking on any jack navigates to that jack on the module page.
- Aliases are displayed as a header above the multiple jack names (iff there's an alias and >1 jack mappings)