### PR TITLE
CPU load tests: test plugins one at a time

### DIFF
--- a/firmware/src/dynload/plugin_manager.hh
+++ b/firmware/src/dynload/plugin_manager.hh
@@ -30,6 +30,20 @@ public:
 	void unload_plugin(std::string_view name) {
 		for (unsigned i = 0; auto const &plugin : loaded_plugin_list) {
 			if (plugin.fileinfo.plugin_name == name) {
+				// Unregister the brand *first*, while the plugin code is still loaded.
+				// This destroys each module's CreateModuleFunc std::function, whose
+				// type-erasure manager (for a plugin's lambda) lives in the plugin's
+				// code. If we did this after erasing/poisoning the code, that manager
+				// call would jump into freed/poisoned memory (an 0xEAFFFFFE "bl ." spin)
+				// and hang -- which is native-plugin-only, since VCV plugins tear down
+				// their create-funcs earlier in ~Plugin. See commit 167e30f74.
+				// (For VCV plugins ~Plugin's per-module unregister then finds the brand
+				// already gone and logs a harmless "failed to remove module" warning.)
+				if (ModuleFactory::unregisterBrand(name) > 0)
+					pr_dbg("Unregistered brand %s\n", name.data());
+				else
+					pr_dbg("Failed to unregister brand %s\n", name.data());
+
 				// Cleanup files we copied to the ramdisk
 				for (auto const &file : plugin.loaded_files) {
 					if (file.ends_with(".bin")) {
@@ -54,11 +68,6 @@ public:
 				for (auto &x : code) {
 					x = 0xEAFFFFFE; //bl .
 				}
-
-				if (ModuleFactory::unregisterBrand(name) > 0)
-					pr_dbg("Unregistered brand %s\n", name.data());
-				else
-					pr_dbg("Failed to unregistered brand %s\n", name.data());
 
 				break;
 			}

--- a/firmware/src/dynload/plugin_manager.hh
+++ b/firmware/src/dynload/plugin_manager.hh
@@ -30,8 +30,6 @@ public:
 	void unload_plugin(std::string_view name) {
 		for (unsigned i = 0; auto const &plugin : loaded_plugin_list) {
 			if (plugin.fileinfo.plugin_name == name) {
-				ModuleFactory::unregisterBrand(name);
-
 				// Cleanup files we copied to the ramdisk
 				for (auto const &file : plugin.loaded_files) {
 					if (file.ends_with(".bin")) {
@@ -56,6 +54,11 @@ public:
 				for (auto &x : code) {
 					x = 0xEAFFFFFE; //bl .
 				}
+
+				if (ModuleFactory::unregisterBrand(name) > 0)
+					pr_dbg("Unregistered brand %s\n", name.data());
+				else
+					pr_dbg("Failed to unregistered brand %s\n", name.data());
 
 				break;
 			}

--- a/firmware/src/load_test/test_manager.hh
+++ b/firmware/src/load_test/test_manager.hh
@@ -6,6 +6,7 @@
 #include "test_modules.hh"
 #include "test_modules_memory.hh"
 #include "test_patches.hh"
+#include <algorithm>
 #include <cstdlib>
 
 namespace MetaModule
@@ -42,14 +43,44 @@ struct CpuLoadTest {
 	static void run_hil_tests(FileStorageProxy &file_storage_proxy, Ui &ui, PluginManager &plugin_manager) {
 		pr_info("Running HIL CPU load tests\n");
 
-		if (!preload_all_plugins(plugin_manager)) {
-			pr_err("Failed preloading plugins for HIL CPU load tests\n");
+		hil_message("*loadtesting\n");
+
+		// clear previous results files
+		FS::write_file(file_storage_proxy, std::string("In progress"), {"cpu_test.csv", Volume::USB});
+		FS::write_file(file_storage_proxy, std::string("\n"), {"cpu_test_in_progress.csv", Volume::USB});
+
+		std::string results;
+		results.reserve(1024 * 1024); // reserve 1MB to reduce memory fragmentation
+
+		auto append_file = [&file_storage_proxy, &ui, &results](std::string_view csv_line) {
+			results += csv_line;
+			FS::append_file(file_storage_proxy, csv_line, {"cpu_test_in_progress.csv", Volume::USB});
+			ui.update_screen();
+		};
+
+		lv_show(ui_MainMenuNowPlayingPanel);
+		lv_show(ui_MainMenuNowPlaying);
+
+		append_file(LoadTest::csv_header());
+
+		PatchPlayer player;
+
+		// Test built-in brands first (registered before any plugin is loaded)
+		for (auto brand : ModuleFactory::getAllBrands())
+			LoadTest::test_brand(brand, player, append_file);
+
+		// Then load one plugin at a time, test its module(s), and unload it.
+		// Loading all plugins at once exhausts memory, so we keep only one resident.
+		if (!test_plugins_one_at_a_time(plugin_manager, player, append_file)) {
+			pr_err("Failed getting plugin list for HIL CPU load tests\n");
 			hil_message("*failure\n");
 			return;
 		}
-		hil_message("*loadtesting\n");
 
-		run_module_tests(file_storage_proxy, ui);
+		lv_label_set_text(ui_MainMenuNowPlaying, "Finished load tests");
+
+		FS::write_file(file_storage_proxy, results, {"cpu_test.csv", Volume::USB});
+		hil_message("*success\n");
 	}
 
 	static void run_module_tests(FileStorageProxy &file_storage_proxy, Ui &ui) {
@@ -148,43 +179,53 @@ struct CpuLoadTest {
 		hil_message("*success\n");
 	}
 
-	static bool preload_all_plugins(PluginManager &plugin_manager) {
+	// Loads each plugin one at a time, running the CPU load test on the module(s)
+	// it registers, then unloads it before moving on — so only a single plugin is
+	// ever resident. The brand(s) a plugin contributes are found by diffing
+	// ModuleFactory::getAllBrands() before/after loading it (same approach as
+	// ModuleImageGen). Returns false only if the plugin list couldn't be read; a
+	// plugin that fails to load is skipped.
+	static bool test_plugins_one_at_a_time(PluginManager &plugin_manager, PatchPlayer &player, auto append_file) {
 		plugin_manager.start_loading_plugin_list();
 
 		while (true) {
 			auto result = plugin_manager.process_loading();
-
-			if (result.state == PluginFileLoader::State::GotList) {
+			if (result.state == PluginFileLoader::State::GotList)
 				break;
-			}
-
-			if (result.state == PluginFileLoader::State::Error) {
+			if (result.state == PluginFileLoader::State::Error)
 				return false;
-			}
 		}
 
 		auto list = plugin_manager.found_plugin_list();
 
 		for (auto i = 0u; i < list->size(); ++i) {
-			printf("Loading plugin: '%s'\n", plugin_manager.plugin_name(i).c_str());
+			auto plugin_file_name = plugin_manager.plugin_name(i);
+			printf("Loading plugin: '%s'\n", plugin_file_name.c_str());
+
+			auto brands_before = ModuleFactory::getAllBrands();
 
 			plugin_manager.load_plugin(i);
-			auto load = true;
-			while (load) {
-				switch (plugin_manager.process_loading().state) {
-					using enum PluginFileLoader::State;
-					case Success:
-						load = false;
-						break;
-
-					case RamDiskFull:
-					case InvalidPlugin:
-					case Error:
-						return false;
-
-					default:
-						continue;
+			bool loaded_ok = true;
+			while (true) {
+				using enum PluginFileLoader::State;
+				auto state = plugin_manager.process_loading().state;
+				if (state == Success)
+					break;
+				if (state == RamDiskFull || state == InvalidPlugin || state == Error) {
+					pr_warn("Failed to load plugin '%s' for CPU load test, skipping\n", plugin_file_name.c_str());
+					loaded_ok = false;
+					break;
 				}
+			}
+
+			if (loaded_ok) {
+				for (auto brand : ModuleFactory::getAllBrands()) {
+					if (std::ranges::find(brands_before, brand) != brands_before.end())
+						continue; // pre-existing brand, not from this plugin
+					LoadTest::test_brand(brand, player, append_file);
+				}
+
+				plugin_manager.unload_plugin(plugin_file_name);
 			}
 		}
 

--- a/firmware/src/load_test/test_manager.hh
+++ b/firmware/src/load_test/test_manager.hh
@@ -225,6 +225,12 @@ struct CpuLoadTest {
 					LoadTest::test_brand(brand, player, append_file);
 				}
 
+				// Never free the plugin's code while the player still holds one of its
+				// modules: unloading the plugin invalidates the module's vtable, and the
+				// next load_patch() would deinit the dangling module and crash.
+				if (player.is_loaded)
+					player.unload_patch();
+
 				plugin_manager.unload_plugin(plugin_file_name);
 			}
 		}

--- a/firmware/src/load_test/test_modules.hh
+++ b/firmware/src/load_test/test_modules.hh
@@ -37,6 +37,93 @@ inline void send_heartbeat() {
 	hil_message("*ok\n");
 }
 
+// Runs the CPU load test on every module of a single (already-registered) brand,
+// emitting one CSV row per module via append_file.
+inline void test_brand(std::string_view brand, PatchPlayer &player, auto append_file) {
+	auto slugs = ModuleFactory::getAllModuleSlugs(brand);
+	for (auto slug : slugs) {
+		ModuleEntry entry;
+		entry.slug = std::string(brand) + ":" + std::string(slug);
+
+		if (entry.slug == "AmalgamatedHarmonics:Arp32") {
+			pr_info("Skipping %s\n", entry.slug.c_str());
+			continue;
+		}
+
+		printf("Testing %s\n", entry.slug.c_str());
+		lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.slug.c_str());
+
+#ifndef SIMULATOR
+		struct mallinfo mem_start = mallinfo();
+#endif
+#ifdef MM_LOADTEST_MEASURE_MEMORY
+		auto mem_tester = ModuleMemoryTester{entry.slug};
+		pr_info("Running memory test\n");
+		entry.mem_usage = mem_tester.run_test(ModuleMemoryTester::TestType::FirstRun);
+#endif
+
+		for (auto i = 0u; auto blocksize : ModuleEntry::blocksizes) {
+			ModuleLoadTester tester(player, entry.slug);
+
+			pr_trace("Block size %u\n", blocksize);
+
+			send_heartbeat();
+
+			pr_trace("Timing module construction\n");
+			entry.load_time = tester.measure_construction_time();
+
+			send_heartbeat();
+
+			pr_trace("Running all unpatched test\n");
+			entry.isolated[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::NonePatched);
+
+			send_heartbeat();
+
+			pr_trace("Running Zero'ed inputs test\n");
+			entry.patched[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsZero);
+
+			send_heartbeat();
+
+			pr_trace("Running LFO test\n");
+			entry.cv_modulated[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsLFO);
+
+			send_heartbeat();
+
+			pr_trace("Running audio-rate test\n");
+			entry.audio_modulated[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsAudio);
+
+			send_heartbeat();
+
+			pr_trace("Running poly audio-rate test\n");
+			entry.poly_audio_modulated[i] =
+				tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsPolyAudio);
+
+			send_heartbeat();
+
+			i++;
+		}
+
+#ifndef SIMULATOR
+		struct mallinfo mem_end = mallinfo();
+
+		entry.raw_mem_used = (int32_t)mem_end.uordblks - (int32_t)mem_start.uordblks;
+		pr_info("Mem used: %d\n", entry.raw_mem_used);
+
+		// pr_info("    arena    %zu (total space allocated so far via sbrk)\n", mem_end.arena);
+		// pr_info("    ordblks  %zu (number of non-inuse chunks)\n", mem_end.ordblks);
+		// pr_info("    hblks    %zu (number of mmapped regions)\n", mem_end.hblks);
+		// pr_info("    hblkhd   %zu (total space in mmapped regions)\n", mem_end.hblkhd);
+		// pr_info("    uordblks %zu (total allocated space)\n", mem_end.uordblks);
+		// pr_info("    fordblks %zu (total non-inuse space)\n", mem_end.fordblks);
+		// pr_info("    keepcost %zu (top-most, releasable via malloc_trim space)\n", mem_end.keepcost);
+#endif
+
+		append_file(entry_to_csv(entry));
+	}
+}
+
+// Runs the CPU load test on every registered brand (or a single brand if
+// only_brand names one). Assumes all plugins are already loaded.
 inline void test_module_brand(std::string_view only_brand, auto append_file) {
 	lv_show(ui_MainMenuNowPlayingPanel);
 	lv_show(ui_MainMenuNowPlaying);
@@ -45,93 +132,10 @@ inline void test_module_brand(std::string_view only_brand, auto append_file) {
 
 	PatchPlayer player;
 
-	auto brands = ModuleFactory::getAllBrands();
-	for (auto brand : brands) {
-
+	for (auto brand : ModuleFactory::getAllBrands()) {
 		if (only_brand != "all" && only_brand != "" && only_brand != brand)
 			continue;
-
-		auto slugs = ModuleFactory::getAllModuleSlugs(brand);
-		for (auto slug : slugs) {
-			ModuleEntry entry;
-			entry.slug = std::string(brand) + ":" + std::string(slug);
-
-			if (entry.slug == "AmalgamatedHarmonics:Arp32") {
-				pr_info("Skipping %s\n", entry.slug.c_str());
-				continue;
-			}
-
-			printf("Testing %s\n", entry.slug.c_str());
-			lv_label_set_text_fmt(ui_MainMenuNowPlaying, "Testing %s", entry.slug.c_str());
-
-#ifndef SIMULATOR
-			struct mallinfo mem_start = mallinfo();
-#endif
-#ifdef MM_LOADTEST_MEASURE_MEMORY
-			auto mem_tester = ModuleMemoryTester{entry.slug};
-			pr_info("Running memory test\n");
-			entry.mem_usage = mem_tester.run_test(ModuleMemoryTester::TestType::FirstRun);
-#endif
-
-			for (auto i = 0u; auto blocksize : ModuleEntry::blocksizes) {
-				ModuleLoadTester tester(player, entry.slug);
-
-				pr_trace("Block size %u\n", blocksize);
-
-				send_heartbeat();
-
-				pr_trace("Timing module construction\n");
-				entry.load_time = tester.measure_construction_time();
-
-				send_heartbeat();
-
-				pr_trace("Running all unpatched test\n");
-				entry.isolated[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::NonePatched);
-
-				send_heartbeat();
-
-				pr_trace("Running Zero'ed inputs test\n");
-				entry.patched[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsZero);
-
-				send_heartbeat();
-
-				pr_trace("Running LFO test\n");
-				entry.cv_modulated[i] = tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsLFO);
-
-				send_heartbeat();
-
-				pr_trace("Running audio-rate test\n");
-				entry.audio_modulated[i] =
-					tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsAudio);
-
-				send_heartbeat();
-
-				pr_trace("Running poly audio-rate test\n");
-				entry.poly_audio_modulated[i] =
-					tester.run_test(blocksize, KnobTestType::AllStill, JackTestType::AllInputsPolyAudio);
-
-				send_heartbeat();
-
-				i++;
-			}
-
-#ifndef SIMULATOR
-			struct mallinfo mem_end = mallinfo();
-
-			entry.raw_mem_used = (int32_t)mem_end.uordblks - (int32_t)mem_start.uordblks;
-			pr_info("Mem used: %d\n", entry.raw_mem_used);
-
-			// pr_info("    arena    %zu (total space allocated so far via sbrk)\n", mem_end.arena);
-			// pr_info("    ordblks  %zu (number of non-inuse chunks)\n", mem_end.ordblks);
-			// pr_info("    hblks    %zu (number of mmapped regions)\n", mem_end.hblks);
-			// pr_info("    hblkhd   %zu (total space in mmapped regions)\n", mem_end.hblkhd);
-			// pr_info("    uordblks %zu (total allocated space)\n", mem_end.uordblks);
-			// pr_info("    fordblks %zu (total non-inuse space)\n", mem_end.fordblks);
-			// pr_info("    keepcost %zu (top-most, releasable via malloc_trim space)\n", mem_end.keepcost);
-#endif
-
-			append_file(entry_to_csv(entry));
-		}
+		test_brand(brand, player, append_file);
 	}
 
 	lv_label_set_text(ui_MainMenuNowPlaying, "Finished load tests");

--- a/firmware/src/load_test/tester.hh
+++ b/firmware/src/load_test/tester.hh
@@ -135,26 +135,24 @@ struct ModuleLoadTester {
 				for (uint16_t in = 0; in < counts.num_inputs; in++)
 					in_bufs[in] = plugin_module_get_poly_input_buffer(player.modules[module_id], in);
 
-				if (!is_poly_capable(player.modules[module_id])) {
-					return {};
-				}
-				result = run_patch(
-					[&, this] {
-						for (uint16_t in = 0; in < counts.num_inputs; in++) {
-							auto &buf = in_bufs[in];
-							if (buf.voltages && buf.channels) {
-								// Poly input: drive all channels
-								for (unsigned ch = 0; ch < chans; ch++)
-									buf.voltages[ch] = oscs[in * chans + ch].process_float() * 10.f - 5.f;
-								*buf.channels = chans;
-							} else {
-								// Mono input: drive channel 0 only
-								auto audio = oscs[in * chans].process_float() * 10.f - 5.f;
-								player.modules[module_id]->set_input(in, audio);
+				if (is_poly_capable(player.modules[module_id]))
+					result = run_patch(
+						[&, this] {
+							for (uint16_t in = 0; in < counts.num_inputs; in++) {
+								auto &buf = in_bufs[in];
+								if (buf.voltages && buf.channels) {
+									// Poly input: drive all channels
+									for (unsigned ch = 0; ch < chans; ch++)
+										buf.voltages[ch] = oscs[in * chans + ch].process_float() * 10.f - 5.f;
+									*buf.channels = chans;
+								} else {
+									// Mono input: drive channel 0 only
+									auto audio = oscs[in * chans].process_float() * 10.f - 5.f;
+									player.modules[module_id]->set_input(in, audio);
+								}
 							}
-						}
-					},
-					block_size);
+						},
+						block_size);
 			}
 		}
 

--- a/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
@@ -89,7 +89,7 @@ Plugin::~Plugin() {
 
 		auto removed_ok = MetaModule::ModuleFactory::unregisterModule(slug, model->slug);
 		if (!removed_ok) {
-			pr_warn("Failed to remove module '%s' in brand '%s'\n", model->slug.c_str(), slug.c_str());
+			pr_warn("Failed to remove VCV module '%s' in brand '%s'\n", model->slug.c_str(), slug.c_str());
 		}
 		delete model;
 	}


### PR DESCRIPTION
Load each plugin, test all its modules, then unload it. This prevents out-of-memory errors since loading all available plugins consumes > 50% of RAM