### PR TITLE
Support sliders in Module menu (context menu for modules)

### DIFF
--- a/firmware/src/gui/helpers/roller_hover_text.hh
+++ b/firmware/src/gui/helpers/roller_hover_text.hh
@@ -23,11 +23,11 @@ public:
 			pr_err("RollerHoverText requires a Roller, which must have a label child\n");
 		}
 
-		lv_obj_set_align(label_cont, LV_ALIGN_CENTER);
+		lv_obj_set_align(label_cont, LV_ALIGN_LEFT_MID);
 		// default: center on roller and no offset
 		lv_obj_set_y(label_cont, lv_obj_get_y(roller) / 2 + 0);
 		lv_obj_set_x(label_cont, 0);
-		lv_obj_set_width(label_cont, lv_pct(109));
+		lv_obj_set_width(label_cont, lv_pct(100));
 		lv_obj_set_height(label_cont, 19);
 		lv_obj_set_style_pad_all(label_cont, 0, LV_PART_MAIN);
 		lv_obj_set_style_radius(label_cont, 0, LV_PART_MAIN);
@@ -56,7 +56,7 @@ public:
 		lv_obj_set_style_pad_top(label, 0, LV_PART_MAIN);
 		lv_obj_set_style_pad_bottom(label, 0, LV_PART_MAIN);
 		lv_obj_set_style_pad_left(label, 15, LV_PART_MAIN);
-		lv_obj_set_style_pad_right(label, 6, LV_PART_MAIN);
+		lv_obj_set_style_pad_right(label, 10, LV_PART_MAIN);
 		lv_obj_set_style_radius(label, 0, LV_PART_MAIN);
 		lv_label_set_recolor(label, true);
 		lv_hide(label);

--- a/firmware/src/gui/module_menu/base_plugin_menu.hh
+++ b/firmware/src/gui/module_menu/base_plugin_menu.hh
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -6,11 +7,30 @@ namespace MetaModule
 {
 
 struct BasePluginModuleMenu {
+	// Returned by click_item() when the clicked row is a continuously-adjustable value
+	// (e.g. a Slider) instead of an action/submenu.
+	struct SliderEdit {
+		std::string label;
+		float scaled_value = 0.f; // 0..1
+	};
+
 	virtual ~BasePluginModuleMenu() = default;
 
 	virtual std::vector<std::string> get_items() = 0;
 	virtual void back_event() = 0;
-	virtual void click_item(unsigned idx) = 0;
+
+	// Returns a SliderEdit if idx refers to a slider row, so the caller can show a
+	// value-editing widget. Otherwise the click is handled internally (e.g. submenu
+	// navigation or an action), and std::nullopt is returned.
+	virtual std::optional<SliderEdit> click_item(unsigned idx) = 0;
+
+	// Called continuously while the caller's value-editing widget is being adjusted.
+	// Returns an updated display string for the value, or "" if there is none.
+	virtual std::string set_slider_value(float scaled_value) = 0;
+
+	// Called when the caller's value-editing widget is closed.
+	virtual void end_slider_edit() = 0;
+
 	virtual bool is_done() = 0;
 	virtual void close() = 0;
 };

--- a/firmware/src/gui/module_menu/native_plugin_menu.hh
+++ b/firmware/src/gui/module_menu/native_plugin_menu.hh
@@ -21,7 +21,15 @@ struct NativeModuleMenu : BasePluginModuleMenu {
 	void back_event() override {
 	}
 
-	void click_item(unsigned idx) override {
+	std::optional<SliderEdit> click_item(unsigned idx) override {
+		return std::nullopt;
+	}
+
+	std::string set_slider_value(float scaled_value) override {
+		return {};
+	}
+
+	void end_slider_edit() override {
 	}
 
 	bool is_done() override {

--- a/firmware/src/gui/module_menu/plugin_module_menu.hh
+++ b/firmware/src/gui/module_menu/plugin_module_menu.hh
@@ -5,6 +5,7 @@
 #include "gui/module_menu/base_plugin_menu.hh"
 #include "gui/module_menu/native_plugin_menu.hh"
 #include "gui/module_menu/vcv_plugin_menu.hh"
+#include "gui/pages/slider_popup.hh"
 #include "gui/slsexport/meta5/ui.h"
 #include "lvgl.h"
 #include "patch_play/patch_playloader.hh"
@@ -93,6 +94,12 @@ struct PluginModuleMenu {
 	}
 
 	void back_event() {
+		if (slider_popup.is_visible()) {
+			slider_popup.hide();
+			close_slider_popup();
+			return;
+		}
+
 		if (visible) {
 			plugin_menu->back_event();
 
@@ -115,13 +122,27 @@ struct PluginModuleMenu {
 		// First item is "< Back"
 		if (idx == 0) {
 			back_event();
+			return;
+		}
+
+		if (auto slider_edit = plugin_menu->click_item(idx - 1)) {
+			slider_popup.show(
+				[this](float scaled_value) { slider_popup.update_label(plugin_menu->set_slider_value(scaled_value)); },
+				[this]() { close_slider_popup(); },
+				slider_edit->label,
+				slider_edit->scaled_value,
+				static_cast<lv_group_t *>(lv_obj_get_group(roller)));
 		} else {
-			plugin_menu->click_item(idx - 1);
 			refresh_menu_items();
 		}
 	}
 
 private:
+	void close_slider_popup() {
+		plugin_menu->end_slider_edit();
+		refresh_menu_items();
+	}
+
 	unsigned populate_menu_items() {
 		std::string opts = LV_SYMBOL_LEFT + std::string(" Back\n");
 
@@ -179,6 +200,7 @@ private:
 	lv_obj_t *const roller = ui_ModuleViewExtraMenuRoller;
 
 	RollerHoverText roller_hover;
+	SliderPopup slider_popup;
 	PatchPlayLoader &patch_playloader;
 
 	bool visible = false;

--- a/firmware/src/gui/module_menu/plugin_module_menu.hh
+++ b/firmware/src/gui/module_menu/plugin_module_menu.hh
@@ -31,14 +31,17 @@ struct PluginModuleMenu {
 		lv_obj_set_style_text_font(roller, &ui_font_MuseoSansRounded70014, LV_PART_MAIN);
 		lv_obj_set_style_text_font(roller, &ui_font_MuseoSansRounded70014, LV_PART_SELECTED);
 
-		lv_obj_set_style_text_color(roller, lv_color_hex(0xCCCCCC), LV_STATE_DEFAULT);
+		lv_obj_set_style_text_color(roller, lv_color_hex(0xFFFFFF), LV_STATE_DEFAULT);
 		lv_obj_set_style_text_opa(roller, 255, LV_STATE_DEFAULT);
 
 		auto hover_label = lv_obj_get_child(roller_hover.get_cont(), 0);
 		lv_obj_set_style_text_font(hover_label, &ui_font_MuseoSansRounded70014, LV_PART_MAIN);
+		lv_obj_set_style_text_color(hover_label, lv_color_hex(0xFFFFFF), LV_STATE_DEFAULT);
 
-		lv_obj_set_x(roller_hover.get_cont(), 8);
-		lv_obj_set_style_pad_left(hover_label, 14, 0);
+		lv_obj_set_x(roller_hover.get_cont(), 6);
+		lv_obj_set_width(roller_hover.get_cont(), lv_pct(100));
+		lv_obj_set_style_pad_left(hover_label, 10, 0);
+		lv_obj_set_style_pad_right(hover_label, 10, 0);
 	}
 
 	bool create_options_menu(unsigned this_module_id) {
@@ -95,7 +98,7 @@ struct PluginModuleMenu {
 
 	void back_event() {
 		if (slider_popup.is_visible()) {
-			slider_popup.hide();
+			slider_popup.back();
 			close_slider_popup();
 			return;
 		}
@@ -111,7 +114,11 @@ struct PluginModuleMenu {
 	}
 
 	void update() {
-		roller_hover.update();
+		if (!slider_popup.is_visible()) {
+			roller_hover.update();
+		} else {
+			roller_hover.hide();
+		}
 	}
 
 	bool wants_to_close() {
@@ -126,9 +133,13 @@ struct PluginModuleMenu {
 		}
 
 		if (auto slider_edit = plugin_menu->click_item(idx - 1)) {
+			roller_hover.hide();
 			slider_popup.show(
 				[this](float scaled_value) { slider_popup.update_label(plugin_menu->set_slider_value(scaled_value)); },
-				[this]() { close_slider_popup(); },
+				[this]() {
+					close_slider_popup();
+					roller_hover.force_redraw();
+				},
 				slider_edit->label,
 				slider_edit->scaled_value,
 				static_cast<lv_group_t *>(lv_obj_get_group(roller)));
@@ -187,7 +198,7 @@ private:
 		lv_event_send(page->roller, LV_EVENT_PRESSED, nullptr);
 
 		// index might be the same, but content probably changed
-		page->roller_hover.force_redraw();
+		// page->roller_hover.force_redraw();
 	}
 
 	static void roller_scrolled_cb(lv_event_t *event) {

--- a/firmware/src/gui/module_menu/vcv_plugin_menu.hh
+++ b/firmware/src/gui/module_menu/vcv_plugin_menu.hh
@@ -52,15 +52,15 @@ struct RackModuleMenu : BasePluginModuleMenu {
 		return exited;
 	}
 
-	void click_item(unsigned idx) override {
+	std::optional<SliderEdit> click_item(unsigned idx) override {
 		if (!current_menu) {
 			pr_err("VCV module menu not initialized\n");
-			return;
+			return std::nullopt;
 		}
 
 		if (idx > current_menu->children.size()) {
 			pr_err("Clicked vcv module menu out of range\n");
-			return;
+			return std::nullopt;
 		}
 
 		//find the child that was clicked
@@ -74,7 +74,29 @@ struct RackModuleMenu : BasePluginModuleMenu {
 					refresh_menu(mw);
 				}
 			}
+		} else if (auto slider = dynamic_cast<rack::ui::Slider *>(*child)) {
+			if (slider->quantity) {
+				active_slider = slider;
+				return SliderEdit{
+					.label = slider->quantity->getString(),
+					.scaled_value = slider->quantity->getScaledValue(),
+				};
+			}
 		}
+
+		return std::nullopt;
+	}
+
+	std::string set_slider_value(float scaled_value) override {
+		if (active_slider && active_slider->quantity) {
+			active_slider->quantity->setScaledValue(scaled_value);
+			return active_slider->quantity->getString();
+		}
+		return {};
+	}
+
+	void end_slider_edit() override {
+		active_slider = nullptr;
 	}
 
 	void close() override {
@@ -187,6 +209,7 @@ private:
 	std::unique_ptr<rack::widget::Widget> menu_owner;
 
 	rack::ui::Menu *current_menu{}; //can't use smart pointer because must point to a raw pointer in rack API
+	rack::ui::Slider *active_slider{}; //the slider currently being adjusted via a SliderPopup, if any
 
 	bool exited = false;
 };

--- a/firmware/src/gui/module_menu/vcv_plugin_menu.hh
+++ b/firmware/src/gui/module_menu/vcv_plugin_menu.hh
@@ -171,7 +171,7 @@ private:
 					if (rack_item->rightText.ends_with(CHECKMARK_STRING))
 						item = Gui::yellow_text(CHECKMARK_STRING);
 
-					item += rack_item->text;
+					item += Gui::lt_grey_text(rack_item->text);
 
 					if (rack_item->rightText.length() && !rack_item->rightText.ends_with(CHECKMARK_STRING))
 						item += " " + Gui::yellow_text(rack_item->rightText);
@@ -187,7 +187,7 @@ private:
 				{
 					rack_item->step();
 					if (rack_item->quantity)
-						menu.emplace_back(Gui::grey_text(rack_item->quantity->getString()));
+						menu.emplace_back(Gui::lt_grey_text(rack_item->quantity->getString()));
 				}
 
 				else if (auto rack_item = dynamic_cast<rack::ui::MenuSeparator *>(child))
@@ -208,7 +208,7 @@ private:
 	std::weak_ptr<rack::app::ModuleWidget> module_widget{};
 	std::unique_ptr<rack::widget::Widget> menu_owner;
 
-	rack::ui::Menu *current_menu{}; //can't use smart pointer because must point to a raw pointer in rack API
+	rack::ui::Menu *current_menu{};	   //can't use smart pointer because must point to a raw pointer in rack API
 	rack::ui::Slider *active_slider{}; //the slider currently being adjusted via a SliderPopup, if any
 
 	bool exited = false;

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -89,8 +89,9 @@ struct ModuleViewPage : PageBase {
 		lv_obj_set_y(load_meter, -2);
 		lv_hide(load_meter);
 
-		lv_obj_set_x(roller_hover.get_cont(), 8);
-		lv_obj_set_style_pad_left(lv_obj_get_child(roller_hover.get_cont(), 0), 14, 0);
+		// lv_obj_set_x(roller_hover.get_cont(), 8);
+		lv_obj_set_style_pad_left(lv_obj_get_child(roller_hover.get_cont(), 0), 15, 0);
+		lv_obj_set_style_pad_right(lv_obj_get_child(roller_hover.get_cont(), 0), 10, 0);
 	}
 
 	void prepare_focus() override {

--- a/firmware/src/gui/pages/slider_popup.hh
+++ b/firmware/src/gui/pages/slider_popup.hh
@@ -18,8 +18,14 @@ struct SliderPopup {
 		, group(lv_group_create()) {
 		lv_hide(popup);
 
-		lv_obj_set_width(slider, 200);
+		lv_obj_set_width(popup, 200);
+		lv_obj_set_height(popup, LV_SIZE_CONTENT);
+
+		lv_obj_set_width(slider, LV_PCT(75));
 		lv_slider_set_range(slider, 0, Resolution);
+
+		lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded50012, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_width(label, LV_PCT(75));
 
 		lv_obj_add_event_cb(slider, value_changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(slider, click_cb, LV_EVENT_CLICKED, this);

--- a/firmware/src/gui/pages/slider_popup.hh
+++ b/firmware/src/gui/pages/slider_popup.hh
@@ -1,0 +1,95 @@
+#pragma once
+#include "gui/helpers/lv_helpers.hh"
+#include "gui/slsexport/ui_local.h"
+#include <cmath>
+#include <functional>
+
+namespace MetaModule
+{
+
+// A popup showing a single lv_slider, focused on its own lv_group so the rotary
+// encoder adjusts its value directly. Clicking (or calling hide()) restores focus
+// to whatever group was active before show() was called.
+struct SliderPopup {
+	SliderPopup()
+		: popup{create_lv_labeled_popup(lv_layer_sys(), "")}
+		, label{lv_obj_get_child(popup, 0)}
+		, slider{lv_slider_create(popup)}
+		, group(lv_group_create()) {
+		lv_hide(popup);
+
+		lv_obj_set_width(slider, 200);
+		lv_slider_set_range(slider, 0, Resolution);
+
+		lv_obj_add_event_cb(slider, value_changed_cb, LV_EVENT_VALUE_CHANGED, this);
+		lv_obj_add_event_cb(slider, click_cb, LV_EVENT_CLICKED, this);
+		lv_group_add_obj(group, slider);
+	}
+
+	void show(std::function<void(float)> changed_cb,
+			  std::function<void()> done_cb,
+			  std::string_view title,
+			  float scaled_value,
+			  lv_group_t *cur_group) {
+		on_changed = std::move(changed_cb);
+		on_done = std::move(done_cb);
+		orig_group = cur_group;
+
+		lv_label_set_text(label, title.data());
+		lv_slider_set_value(slider, std::round(scaled_value * Resolution), LV_ANIM_OFF);
+
+		lv_show(popup);
+
+		lv_indev_set_group(lv_indev_get_next(nullptr), group);
+		lv_group_focus_obj(slider);
+		lv_group_set_editing(group, true);
+
+		visible = true;
+	}
+
+	void update_label(std::string_view text) {
+		if (text.length())
+			lv_label_set_text(label, text.data());
+	}
+
+	void hide() {
+		lv_hide(popup);
+		if (orig_group)
+			lv_indev_set_group(lv_indev_get_next(nullptr), orig_group);
+		visible = false;
+	}
+
+	bool is_visible() const {
+		return visible;
+	}
+
+	static constexpr int32_t Resolution = 1000;
+
+private:
+	static void value_changed_cb(lv_event_t *event) {
+		auto page = static_cast<SliderPopup *>(event->user_data);
+		auto val = lv_slider_get_value(page->slider);
+		if (page->on_changed)
+			page->on_changed((float)val / Resolution);
+	}
+
+	static void click_cb(lv_event_t *event) {
+		auto page = static_cast<SliderPopup *>(event->user_data);
+		page->hide();
+		if (page->on_done)
+			page->on_done();
+	}
+
+	lv_obj_t *popup;
+	lv_obj_t *label;
+	lv_obj_t *slider;
+	lv_group_t *group;
+	lv_group_t *orig_group = nullptr;
+
+	bool visible = false;
+
+	std::function<void(float)> on_changed;
+	std::function<void()> on_done;
+};
+
+} // namespace MetaModule

--- a/firmware/src/gui/pages/slider_popup.hh
+++ b/firmware/src/gui/pages/slider_popup.hh
@@ -12,23 +12,15 @@ namespace MetaModule
 // to whatever group was active before show() was called.
 struct SliderPopup {
 	SliderPopup()
-		: popup{create_lv_labeled_popup(lv_layer_sys(), "")}
-		, label{lv_obj_get_child(popup, 0)}
-		, slider{lv_slider_create(popup)}
-		, group(lv_group_create()) {
+		: group(lv_group_create()) {
+
+		create_objects(ui_ElementRollerPanel);
+
 		lv_hide(popup);
-
-		lv_obj_set_width(popup, 200);
-		lv_obj_set_height(popup, LV_SIZE_CONTENT);
-
-		lv_obj_set_width(slider, LV_PCT(75));
-		lv_slider_set_range(slider, 0, Resolution);
-
-		lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded50012, LV_PART_MAIN | LV_STATE_DEFAULT);
-		lv_obj_set_width(label, LV_PCT(75));
 
 		lv_obj_add_event_cb(slider, value_changed_cb, LV_EVENT_VALUE_CHANGED, this);
 		lv_obj_add_event_cb(slider, click_cb, LV_EVENT_CLICKED, this);
+		lv_obj_add_event_cb(slider, click_release_cb, LV_EVENT_RELEASED, this);
 		lv_group_add_obj(group, slider);
 	}
 
@@ -42,11 +34,12 @@ struct SliderPopup {
 		orig_group = cur_group;
 
 		lv_label_set_text(label, title.data());
-		lv_slider_set_value(slider, std::round(scaled_value * Resolution), LV_ANIM_OFF);
+		lv_slider_set_range(slider, 0, arc_range_value[arc_range_idx]);
+		lv_slider_set_value(slider, std::round(scaled_value * arc_range_value[arc_range_idx]), LV_ANIM_OFF);
 
 		lv_show(popup);
 
-		lv_indev_set_group(lv_indev_get_next(nullptr), group);
+		lv_group_activate(group);
 		lv_group_focus_obj(slider);
 		lv_group_set_editing(group, true);
 
@@ -58,39 +51,172 @@ struct SliderPopup {
 			lv_label_set_text(label, text.data());
 	}
 
-	void hide() {
+	void back() {
 		lv_hide(popup);
 		if (orig_group)
-			lv_indev_set_group(lv_indev_get_next(nullptr), orig_group);
+			lv_group_activate(orig_group);
 		visible = false;
+
+		if (on_done)
+			on_done();
 	}
 
 	bool is_visible() const {
 		return visible;
 	}
 
-	static constexpr int32_t Resolution = 1000;
-
 private:
 	static void value_changed_cb(lv_event_t *event) {
 		auto page = static_cast<SliderPopup *>(event->user_data);
 		auto val = lv_slider_get_value(page->slider);
 		if (page->on_changed)
-			page->on_changed((float)val / Resolution);
+			page->on_changed((float)val / page->arc_range_value[page->arc_range_idx]);
 	}
 
 	static void click_cb(lv_event_t *event) {
 		auto page = static_cast<SliderPopup *>(event->user_data);
-		page->hide();
-		if (page->on_done)
-			page->on_done();
+
+		float cur_value = lv_slider_get_value(page->slider);
+		auto cur_arc_range = lv_slider_get_max_value(page->slider);
+		page->arc_range_idx = (page->arc_range_idx + 1) % page->arc_range_value.size();
+
+		lv_slider_set_range(page->slider, 0, page->arc_range_value[page->arc_range_idx]);
+		lv_label_set_text(page->click_label, "Click to change:");
+		lv_label_set_text(page->res_label, page->arc_range_text[page->arc_range_idx].data());
+
+		auto new_arc_range = lv_slider_get_max_value(page->slider);
+		lv_slider_set_value(
+			page->slider, std::round(cur_value / (float)cur_arc_range * (float)new_arc_range), LV_ANIM_OFF);
+	}
+
+	static void click_release_cb(lv_event_t *event) {
+		auto page = static_cast<SliderPopup *>(event->user_data);
+		lv_group_focus_obj(page->slider);
+		lv_group_set_editing(page->group, true);
+	}
+
+	void create_objects(lv_obj_t *parent) {
+		popup = lv_obj_create(parent);
+		lv_obj_set_width(popup, lv_pct(100));
+		lv_obj_set_height(popup, LV_SIZE_CONTENT); /// 1
+		lv_obj_set_x(popup, 0);
+		lv_obj_set_y(popup, -10);
+		lv_obj_set_align(popup, LV_ALIGN_BOTTOM_MID);
+		lv_obj_set_flex_flow(popup, LV_FLEX_FLOW_COLUMN);
+		lv_obj_set_flex_align(popup, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+		lv_obj_add_flag(popup, LV_OBJ_FLAG_FLOATING); /// Flags
+		lv_obj_clear_flag(popup,
+						  LV_OBJ_FLAG_PRESS_LOCK | LV_OBJ_FLAG_CLICK_FOCUSABLE | LV_OBJ_FLAG_GESTURE_BUBBLE |
+							  LV_OBJ_FLAG_SNAPPABLE | LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_SCROLL_ELASTIC |
+							  LV_OBJ_FLAG_SCROLL_MOMENTUM | LV_OBJ_FLAG_SCROLL_CHAIN); /// Flags
+		lv_obj_set_style_radius(popup, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_color(popup, lv_color_hex(0x777777), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(popup, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_border_color(popup, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_border_opa(popup, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_border_width(popup, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_color(popup, lv_color_hex(0xFD8B18), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_opa(popup, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_width(popup, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_pad(popup, 1, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_left(popup, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(popup, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(popup, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(popup, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_color(popup, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_opa(popup, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_align(popup, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+		lv_obj_set_style_pad_left(popup, -4, LV_PART_SCROLLBAR | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(popup, -4, LV_PART_SCROLLBAR | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(popup, 0, LV_PART_SCROLLBAR | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(popup, 0, LV_PART_SCROLLBAR | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_row(popup, 0, LV_PART_SCROLLBAR | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_column(popup, 0, LV_PART_SCROLLBAR | LV_STATE_DEFAULT);
+
+		slider = lv_slider_create(popup);
+		lv_obj_set_width(slider, 0);
+		lv_obj_set_height(slider, 0);
+		lv_obj_set_align(slider, LV_ALIGN_CENTER);
+		lv_obj_add_flag(slider, LV_OBJ_FLAG_IGNORE_LAYOUT);
+		lv_arc_set_value(slider, 0);
+
+		lv_obj_set_style_bg_color(slider, lv_color_hex(0xFFFFFF), LV_PART_KNOB | LV_STATE_DEFAULT);
+
+		lv_obj_set_style_bg_opa(slider, 0, LV_PART_KNOB | LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(slider, 0, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(slider, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(slider, 0, LV_PART_SELECTED | LV_STATE_DEFAULT);
+		lv_obj_set_style_bg_opa(slider, 0, LV_PART_ITEMS | LV_STATE_DEFAULT);
+
+		lv_obj_set_style_border_opa(slider, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_outline_opa(slider, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_border_opa(slider, 0, LV_PART_MAIN | LV_STATE_FOCUSED);
+		lv_obj_set_style_outline_opa(slider, 0, LV_PART_MAIN | LV_STATE_FOCUSED);
+		lv_obj_set_style_border_opa(slider, 0, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+		lv_obj_set_style_outline_opa(slider, 0, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+
+		label = lv_label_create(popup);
+		lv_obj_set_width(label, lv_pct(100));
+		lv_obj_set_height(label, LV_SIZE_CONTENT);
+		lv_obj_set_align(label, LV_ALIGN_TOP_MID);
+		lv_label_set_text(label, "Turn rotary to adjust");
+		lv_obj_set_style_text_color(label, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_opa(label, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_font(label, &ui_font_MuseoSansRounded70016, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_left(label, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(label, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(label, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(label, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+		auto res_cont = lv_obj_create(popup);
+		lv_obj_remove_style_all(res_cont);
+		lv_obj_set_width(res_cont, lv_pct(100));
+		lv_obj_set_height(res_cont, LV_SIZE_CONTENT); /// 50
+		lv_obj_set_align(res_cont, LV_ALIGN_CENTER);
+		lv_obj_set_flex_flow(res_cont, LV_FLEX_FLOW_COLUMN);
+		lv_obj_set_flex_align(res_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+		lv_obj_clear_flag(res_cont, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE); /// Flags
+
+		click_label = lv_label_create(res_cont);
+		lv_obj_set_width(click_label, lv_pct(100));
+		lv_obj_set_height(click_label, LV_SIZE_CONTENT); /// 1
+		lv_obj_set_align(click_label, LV_ALIGN_BOTTOM_MID);
+		lv_label_set_text(click_label, "Click to change:");
+		lv_obj_set_style_text_color(click_label, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_opa(click_label, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_font(click_label, &ui_font_MuseoSansRounded50014, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_left(click_label, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(click_label, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(click_label, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(click_label, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+		res_label = lv_label_create(res_cont);
+		lv_obj_set_width(res_label, lv_pct(100));
+		lv_obj_set_height(res_label, LV_SIZE_CONTENT); /// 1
+		lv_obj_set_align(res_label, LV_ALIGN_BOTTOM_MID);
+		lv_label_set_text(res_label, "Coarse");
+		lv_obj_set_style_text_color(res_label, lv_color_hex(0x000000), LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_opa(res_label, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_text_font(res_label, &ui_font_MuseoSansRounded70014, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_left(res_label, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_right(res_label, 4, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_top(res_label, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+		lv_obj_set_style_pad_bottom(res_label, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 	}
 
 	lv_obj_t *popup;
 	lv_obj_t *label;
 	lv_obj_t *slider;
+	lv_obj_t *res_label;
+	lv_obj_t *click_label;
+
 	lv_group_t *group;
 	lv_group_t *orig_group = nullptr;
+
+	unsigned arc_range_idx = 0;
+	std::array<unsigned, 3> arc_range_value{100, 1000, 10000};
+	std::array<std::string_view, 3> arc_range_text{"Coarse", "Fine", "Ultra-fine"};
 
 	bool visible = false;
 

--- a/firmware/src/gui/styles.hh
+++ b/firmware/src/gui/styles.hh
@@ -98,7 +98,7 @@ struct Gui {
 	}
 
 	static std::string lt_grey_text(std::string_view txt) {
-		return color_text(txt, "^cccccc ");
+		return color_text(txt, "^dddddd ");
 	}
 
 	static inline std::string_view grey_color_html = "^aaaaaa ";


### PR DESCRIPTION
Adds support for `rack::ui::slider` widgets in the context menu when running on hardware. Clicking on such an item brings up a pop-up similar to the Adjust Param pop-up. Clicking cycles through Coarse->Fine->Ultra-Fine settings. Pressing back exits with the current value.
