### PR TITLE
Simulator: Support multiple key bindings per action, add Enter and Backspace

### DIFF
--- a/docs/simulator-usage.md
+++ b/docs/simulator-usage.md
@@ -9,8 +9,8 @@ The simulator simulates the hardware's rotary encoder, button, knobs, and jacks
 
 - `Left Arrow`: Turn encoder counter-clockwise
 - `Right Arrow`: Turn encoder clockwise
-- `Down Arrow`: Press the encoder
-- `Up Arrow`: Press the button (typically goes to the previous page)
+- `Down Arrow` or `Enter`: Press the encoder
+- `Up Arrow` or `Backspace`: Press the button (typically goes to the previous page)
 
 ### Knobs
 

--- a/simulator/lvgl_drv/lv_port_indev.h
+++ b/simulator/lvgl_drv/lv_port_indev.h
@@ -3,6 +3,7 @@
 #include "lvgl.h"
 #include <SDL2/SDL.h>
 #include <array>
+#include <vector>
 
 enum QuitEvent {
 	LV_QUIT_NONE,
@@ -12,17 +13,18 @@ enum QuitEvent {
 	LV_QUIT_OTHER,
 };
 
+// Each action can be bound to multiple keys: any key in the list triggers the action.
 struct RotaryEncoderKeys {
-	SDL_Keycode turn_cw;
-	SDL_Keycode turn_ccw;
-	SDL_Keycode click;
-	SDL_Keycode aux_button;
-	SDL_Keycode quit;
-	SDL_Keycode param_inc;
-	SDL_Keycode param_dec;
-	SDL_Keycode param_fine_toggle;
-	SDL_Keycode prev_knobset;
-	SDL_Keycode next_knobset;
+	std::vector<SDL_Keycode> turn_cw;
+	std::vector<SDL_Keycode> turn_ccw;
+	std::vector<SDL_Keycode> click;
+	std::vector<SDL_Keycode> aux_button;
+	std::vector<SDL_Keycode> quit;
+	std::vector<SDL_Keycode> param_inc;
+	std::vector<SDL_Keycode> param_dec;
+	std::vector<SDL_Keycode> param_fine_toggle;
+	std::vector<SDL_Keycode> prev_knobset;
+	std::vector<SDL_Keycode> next_knobset;
 };
 
 enum class ButtonEvent { None, Pressed, Released };

--- a/simulator/lvgl_drv/lv_port_indev_encoder.cc
+++ b/simulator/lvgl_drv/lv_port_indev_encoder.cc
@@ -3,6 +3,11 @@
 #include "lv_port_indev.h"
 #include "lvgl.h"
 #include <SDL2/SDL.h>
+#include <algorithm>
+
+static bool matches(std::vector<SDL_Keycode> const &binding, SDL_Keycode key) {
+	return std::ranges::find(binding, key) != binding.end();
+}
 
 LvglEncoderSimulatorDriver::LvglEncoderSimulatorDriver(RotaryEncoderKeys &keys)
 	: keys{keys} {
@@ -98,15 +103,15 @@ void LvglEncoderSimulatorDriver::keyboard_rotary_read_cb(lv_indev_drv_t *, lv_in
 		}
 
 		if (e.type == SDL_KEYDOWN && e.key.state == SDL_PRESSED) {
-			if (e.key.keysym.sym == keys.click && e.key.repeat == 0) {
+			if (matches(keys.click, e.key.keysym.sym) && e.key.repeat == 0) {
 				rotary_pressed = ButtonEvent::Pressed;
 			}
 
-			if (e.key.keysym.sym == keys.aux_button) {
+			if (matches(keys.aux_button, e.key.keysym.sym)) {
 				aux_pressed = ButtonEvent::Pressed;
 			}
 
-			if (e.key.keysym.sym == keys.turn_cw) {
+			if (matches(keys.turn_cw, e.key.keysym.sym)) {
 				if (rotary_pressed == ButtonEvent::Pressed)
 					rotary_push_turn++;
 				else {
@@ -115,7 +120,7 @@ void LvglEncoderSimulatorDriver::keyboard_rotary_read_cb(lv_indev_drv_t *, lv_in
 				}
 			}
 
-			if (e.key.keysym.sym == keys.turn_ccw) {
+			if (matches(keys.turn_ccw, e.key.keysym.sym)) {
 				if (rotary_pressed == ButtonEvent::Pressed)
 					rotary_push_turn--;
 				else {
@@ -142,35 +147,35 @@ void LvglEncoderSimulatorDriver::keyboard_rotary_read_cb(lv_indev_drv_t *, lv_in
 }
 
 void LvglEncoderSimulatorDriver::handle_key_up(SDL_Keycode key, lv_indev_data_t *data) {
-	if (key == keys.quit) {
+	if (matches(keys.quit, key)) {
 		_instance->set_quit(LV_QUIT);
 	}
 
-	if (key == keys.aux_button) {
+	if (matches(keys.aux_button, key)) {
 		aux_pressed = ButtonEvent::Released;
 	}
 
-	if (key == keys.click) {
+	if (matches(keys.click, key)) {
 		rotary_pressed = ButtonEvent::Released;
 	}
 
-	if (key == keys.param_inc) {
+	if (matches(keys.param_inc, key)) {
 		_instance->param_inc_pressed = true;
 	}
 
-	if (key == keys.param_fine_toggle) {
+	if (matches(keys.param_fine_toggle, key)) {
 		_instance->param_fine_mode = !_instance->param_fine_mode;
 	}
 
-	if (key == keys.param_dec) {
+	if (matches(keys.param_dec, key)) {
 		_instance->param_dec_pressed = true;
 	}
 
-	if (key == keys.next_knobset) {
+	if (matches(keys.next_knobset, key)) {
 		_instance->knobset_change++;
 	}
 
-	if (key == keys.prev_knobset) {
+	if (matches(keys.prev_knobset, key)) {
 		_instance->knobset_change--;
 	}
 

--- a/simulator/src/main.cc
+++ b/simulator/src/main.cc
@@ -1,4 +1,4 @@
-#include "../firmware/src/load_test/test_modules.hh"
+﻿#include "../firmware/src/load_test/test_modules.hh"
 #include "frame.hh"
 #include "lv_port_disp.h"
 #include "lvgl.h"
@@ -51,24 +51,24 @@ static void simulate_input(MetaModule::Ui &ui, const std::string &seq) {
 
 		for (unsigned c = 0; c < count; c++) {
 			if (name == "cw") {
-				push_key(keys.turn_cw, true);
+				push_key(keys.turn_cw.front(), true);
 				run_cycles(ui, 4);
-				push_key(keys.turn_cw, false);
+				push_key(keys.turn_cw.front(), false);
 				run_cycles(ui, 2);
 			} else if (name == "ccw") {
-				push_key(keys.turn_ccw, true);
+				push_key(keys.turn_ccw.front(), true);
 				run_cycles(ui, 4);
-				push_key(keys.turn_ccw, false);
+				push_key(keys.turn_ccw.front(), false);
 				run_cycles(ui, 2);
 			} else if (name == "click") {
-				push_key(keys.click, true);
+				push_key(keys.click.front(), true);
 				run_cycles(ui, 4);
-				push_key(keys.click, false);
+				push_key(keys.click.front(), false);
 				run_cycles(ui, 6);
 			} else if (name == "back") {
-				push_key(keys.aux_button, true);
+				push_key(keys.aux_button.front(), true);
 				run_cycles(ui, 4);
-				push_key(keys.aux_button, false);
+				push_key(keys.aux_button.front(), false);
 				run_cycles(ui, 4);
 			} else {
 				std::cout << "Unknown --input token '" << name << "'\n";

--- a/simulator/src/ui.hh
+++ b/simulator/src/ui.hh
@@ -18,16 +18,16 @@ namespace MetaModule
 class Ui {
 
 	RotaryEncoderKeys keys{
-		.turn_cw = SDLK_RIGHT,
-		.turn_ccw = SDLK_LEFT,
-		.click = SDLK_DOWN,
-		.aux_button = SDLK_UP,
-		.quit = SDLK_ESCAPE,
-		.param_inc = ']',
-		.param_dec = '[',
-		.param_fine_toggle = '\\',
-		.prev_knobset = ',',
-		.next_knobset = '.',
+		.turn_cw = {SDLK_RIGHT},
+		.turn_ccw = {SDLK_LEFT},
+		.click = {SDLK_DOWN, SDLK_RETURN, SDLK_KP_ENTER},
+		.aux_button = {SDLK_UP, SDLK_BACKSPACE},
+		.quit = {SDLK_ESCAPE},
+		.param_inc = {']'},
+		.param_dec = {'['},
+		.param_fine_toggle = {'\\'},
+		.prev_knobset = {','},
+		.next_knobset = {'.'},
 	};
 
 public:


### PR DESCRIPTION
Closes #196

Each `RotaryEncoderKeys` action is now a list of SDL keycodes searched on every event, as suggested in the issue, so alternate bindings can be added without dropping the existing ones.

New default bindings:
- `Enter` / keypad `Enter` also press the encoder (same as `Down Arrow`)
- `Backspace` also presses the back button (same as `Up Arrow`)

Design notes:
- `Esc` stays bound to quit, so I did not add it as a back binding to avoid changing behavior for existing users. Quitting is also possible by closing the window. Happy to move `Esc` to back if you prefer the layout from the issue.
- `Up`/`Down` cannot also mean encoder turns since they are already used for click/back.
- Headless `--input` synthesizes events using the first binding of each action, so screenshot tooling behavior is unchanged.

Tested with the headless screenshot mode: the same input sequence executed via `Enter`/`Backspace` and via the arrow keys produces byte-identical screenshots. Docs updated in `docs/simulator-usage.md`.