### PR TITLE
Simulator: Fix crash in get_fattime on Windows, use host time for file timestamps

### DIFF
--- a/simulator/stubs/fattime.cc
+++ b/simulator/stubs/fattime.cc
@@ -1,5 +1,14 @@
 #include "fs/time_convert.hh"
+#include <ctime>
 
+// Timestamp files with the host's current local time.
+// std::localtime can return nullptr (e.g. on Windows for out-of-range values),
+// so fall back to the FAT epoch rather than crash.
 extern "C" uint32_t get_fattime() {
-	return (uint32_t)ticks_to_fattime(0);
+	std::time_t now = std::time(nullptr);
+	std::tm *t = std::localtime(&now);
+	if (!t)
+		return (uint32_t)make_fattime(1980, 1, 1, 0, 0, 0);
+
+	return (uint32_t)make_fattime(t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
 }


### PR DESCRIPTION
The simulator crashes at startup on Windows (MinGW/MSYS2) with a null-pointer dereference in `ticks_to_fattime()`, called from the `get_fattime()` stub while `InternalPluginManager` formats the plugin ramdisk.

Cause: `default_poweron_tm` in `firmware/src/fs/time_convert.cc` is populated with human-readable units (`tm_year = 2000`), but `mktime()` interprets `tm_year` as years since 1900, so it is asked for the year 3900. glibc handles this (and the offsets cancel out later, which is why this works on Linux), but Windows `mktime()` returns -1 for out-of-range years, and `localtime(-1)` then returns `nullptr`, which `ticks_to_fattime()` dereferences.

Rather than touching the firmware time code, this changes the simulator stub to timestamp files with the host clock directly (guarding against `localtime()` returning `nullptr`). Side benefit: files written by the simulator now get real timestamps instead of the simulated year-2000 power-on time.

Found while working on #599; with this fix the simulator builds and runs on Windows (MSYS2 ucrt64, gcc 14.1), modulo two smaller issues I can file separately: `SDL2main` is not linked (WinMain undefined at link) and the `uimg_header.py` asset step invokes the script without a python interpreter.