### PR TITLE
Simulator extplugin quality-of-life improvements

### DIFF
--- a/docs/simulator-ext-plugins.md
+++ b/docs/simulator-ext-plugins.md
@@ -16,29 +16,16 @@ Within the plugin, there must be an `init()` function (or `init(rack::Plugin
 
 ### Building
 
-You must make a few changes to the code to make this hack work:
+No source-code changes to the plugin are needed. The simulator prelinks each
+external plugin and keeps its symbols private, the same isolation it has when
+dynamically loaded on hardware: the plugin's `init()` is automatically renamed
+to `init_BrandName`, its `pluginInstance` global stays private to the plugin,
+and its other symbols cannot collide with the firmware's built-in brands or
+other external plugins. (Plugins that were previously modified for the
+simulator — `#ifdef`'ing `init()` to `init_BrandName()` and making
+`pluginInstance` extern — still work unchanged.)
 
-1. In your plugin, find the `init()` function and change it to `init_PluginSlug()`, 
-   where PluginSlug is the brand slug of your plugin (check your plugin.json file to 
-   find your brand slug). This is needed because we can't have multiple
-   functions with the name `init()`.
-
-2. If you have a global variable in your plugin called `pluginInstance`, you need
-   to make it `extern`. So find this:
-
-```c++
-   Plugin* pluginInstance;
-```
-
-   and change it to this:
-```c++
-   extern Plugin* pluginInstance;
-```
-
-   This is needed because there already is a global variable called pluginInstance, and 
-   we can't have two.
-
-3. In your plugin's CMakeLists.txt file, make sure something like this is at the top:
+1. In your plugin's CMakeLists.txt file, make sure something like this is at the top:
 
 ```cmake
 if(NOT "${METAMODULE_SDK_DIR}" STREQUAL "")
@@ -72,7 +59,7 @@ simulator's fake SDK. Something is wrong with the block of cmake code above, or
 else METAMODULE_SDK_DIR is not being set properly.
 
 
-4. Finally, in the simulator project, open the file `simulator/ext-plugins.cmake`
+2. Next, in the simulator project, open the file `simulator/ext-plugins.cmake`
    and add these two lines at the top:
 
 ```cmake
@@ -98,7 +85,7 @@ or plugin-mm.json file. If the slug is the same as the CMake library name, then 
 
 If you have more than one external plugin, then you need to specify the slug for all of them, or for none of them.
 
-5. Now, you can build the simulator from within the simulator directory (not the firmware dir!) and your plugin should show up as a built-in brand.
+3. Now, you can build the simulator from within the simulator directory (not the firmware dir!) and your plugin should show up as a built-in brand.
 
 ```bash
 cd metamodule/simulator
@@ -126,29 +113,24 @@ Since this is a bit of a hack, there are some limitations:
   MetaModule, there might be other things broken when trying to access files on
   the host computer.
 
-- The global variable `pluginInstance` will not be properly set to your plugin's
+- Legacy-style plugins that declare `extern Plugin* pluginInstance;` for the
+  simulator (instead of defining their own) share one `pluginInstance` global
+  with all the internal brands, so it will not be properly set to your plugin's
   plugin instance during runtime (that is, outside of the init() function). This
   usually shows up as a font or image that's supposed to be loaded during runtime,
-  cannot be found. To work around this, temporarily change
-  `rack::asset::plugin(pluginInstance, "res/path/to/file.svg")` to a hard-coded
-  path like `"MyPluginSlug/path/to/file.png"`. See
-  `firmware/vcv_plugin/export/src/asset.cc` to understand how
-  `rack::asset::plugin` transforms the path.
+  cannot be found. To fix this, remove the `#ifdef METAMODULE_BUILTIN` boilerplate
+  so the plugin defines its own `Plugin* pluginInstance;` like it does when built
+  for hardware — the simulator keeps it private to the plugin automatically.
 
 If you are experiencing an issue along these lines with an external plugin on
 the simulator, testing on actual hardware is the best way to determine if an
 issue is due to one of these limitations or is an actual bug.
 
-- Variable names, function names, and macros (`#define`) might collide. Since
-  the plugin is being built and linked with the simulator code and all the
-  normal built-in modules (Befaco, HetrickCV, 4ms, etc) there's a chance some
-  function or global variable name your plugin uses will already be in use.
-  Hopefully this will cause a compiler error, but in the worst case it could
-  cause a runtime crash (especially with macros). Unfortunately there's not an
-  easy way around this besides renaming your functions/variables, using
-  namespacing, and/or avoiding macros. Searching the metamodule repo for the
-  offending text should tell you if this is happening, or you can try building
-  the plugin normally and see if you get the same error.
+- Macros (`#define`) in the interface headers might collide with names in your
+  plugin, since the plugin is compiled against the simulator's copy of the
+  rack interface headers. (Link-time symbol collisions with the firmware's
+  built-in brands or other external plugins are not an issue: each external
+  plugin's symbols are kept private to that plugin.)
 
 - The `plugin` target that the real SDK's `create_plugin()` defines (which
   plugins sometimes attach `add_custom_command(TARGET plugin POST_BUILD ...)`

--- a/simulator/ext-plugins.cmake
+++ b/simulator/ext-plugins.cmake
@@ -16,6 +16,10 @@
 # 
 # See docs/simulator-ext-plugins.md for instructions
 
+list(APPEND ext_builtin_brand_paths "${CMAKE_CURRENT_LIST_DIR}/../../metamodule-plugin-examples/CVfunk/metamodule")
+list(APPEND ext_builtin_brand_libname "CVfunk")
+# list(APPEND ext_builtin_brand_paths "${CMAKE_CURRENT_LIST_DIR}/../../metamodule-plugin-examples/Bogaudio")
+# list(APPEND ext_builtin_brand_libname "BogaudioModules")
 
 #
 # Asset dir
@@ -62,7 +66,45 @@ foreach(branddir brand slug IN ZIP_LISTS ext_builtin_brand_paths ext_builtin_bra
 	target_link_libraries(${brand} PRIVATE cpputil::cpputil)
 	target_compile_definitions(${brand} PRIVATE METAMODULE METAMODULE_BUILTIN)
 
-	target_link_libraries(_vcv_ports_internal PUBLIC ${brand})
+	# Prelink the brand's static lib into a single relocatable object and localize all
+	# symbols except its entry point (init_${brand}). This keeps each plugin's internal
+	# symbols private, the same as when it's dynamically loaded on hardware. Otherwise,
+	# same-named classes in two statically-linked plugins (e.g. a global-namespace
+	# `DigitalDisplay` in both Valley and CVfunk) get merged by the linker, and one
+	# plugin's vtable/methods silently operate on the other's incompatible object layout.
+	set(brand_localized_obj ${CMAKE_CURRENT_BINARY_DIR}/builtins/${brand}_localized.o)
+
+	if (APPLE)
+		set(brand_exports_file ${CMAKE_CURRENT_BINARY_DIR}/builtins/${brand}_exports.txt)
+		file(WRITE ${brand_exports_file} "*init_${brand}*\n")
+		# -mmacosx-version-min: stamp a floor version so the final link never sees the
+		# prelinked object as "newer" than its target. -Wl,-w: silence the resulting
+		# version-mismatch warnings within this (purely mechanical) prelink step.
+		add_custom_command(
+			OUTPUT ${brand_localized_obj}
+			COMMAND ${CMAKE_CXX_COMPILER} -r -nostdlib -mmacosx-version-min=11.0 -Wl,-w
+					-Wl,-force_load,$<TARGET_FILE:${brand}>
+					-Wl,-exported_symbols_list,${brand_exports_file}
+					-o ${brand_localized_obj}
+			DEPENDS ${brand} ${brand_exports_file}
+			COMMENT "Prelinking ${brand} and localizing all symbols except init_${brand}"
+			VERBATIM
+		)
+	else()
+		add_custom_command(
+			OUTPUT ${brand_localized_obj}
+			COMMAND ${CMAKE_LINKER} -r --whole-archive $<TARGET_FILE:${brand}> --no-whole-archive -o ${brand_localized_obj}.partial.o
+			COMMAND ${CMAKE_OBJCOPY} -w --keep-global-symbol=*init_${brand}* ${brand_localized_obj}.partial.o ${brand_localized_obj}
+			DEPENDS ${brand}
+			COMMENT "Prelinking ${brand} and localizing all symbols except init_${brand}"
+			VERBATIM
+		)
+	endif()
+
+	add_custom_target(${brand}-localized DEPENDS ${brand_localized_obj})
+	add_dependencies(_vcv_ports_internal ${brand}-localized)
+
+	target_link_libraries(_vcv_ports_internal PUBLIC ${brand_localized_obj})
 	add_dependencies(asset-image ${brand}-assets)
 
 	string(APPEND EXT_PLUGIN_INIT_CALLS "\textern void init_${brand}(rack::plugin::Plugin *);\n\tinit_${brand}(&internal_plugins.emplace_back(\"${slug}\"));")

--- a/simulator/ext-plugins.cmake
+++ b/simulator/ext-plugins.cmake
@@ -12,8 +12,11 @@
 #
 # If you have more than one external plugin, then you have to specify the slug for ALL of them or NONE of them.
 #
-# Don't forget to change init() => init_BrandSlug(), and add `extern` to the pluginInstance!
-# 
+# No source changes are needed in the plugin: its init() is automatically renamed to
+# init_BrandName and all its other symbols (including pluginInstance) are kept private.
+# (Legacy plugins that #ifdef'd init() => init_BrandName() and made pluginInstance
+# `extern` for the simulator still work, too.)
+#
 # See docs/simulator-ext-plugins.md for instructions
 
 list(APPEND ext_builtin_brand_paths "${CMAKE_CURRENT_LIST_DIR}/../../metamodule-plugin-examples/CVfunk/metamodule")
@@ -66,40 +69,77 @@ foreach(branddir brand slug IN ZIP_LISTS ext_builtin_brand_paths ext_builtin_bra
 	target_link_libraries(${brand} PRIVATE cpputil::cpputil)
 	target_compile_definitions(${brand} PRIVATE METAMODULE METAMODULE_BUILTIN)
 
-	# Prelink the brand's static lib into a single relocatable object and localize all
-	# symbols except its entry point (init_${brand}). This keeps each plugin's internal
-	# symbols private, the same as when it's dynamically loaded on hardware. Otherwise,
-	# same-named classes in two statically-linked plugins (e.g. a global-namespace
-	# `DigitalDisplay` in both Valley and CVfunk) get merged by the linker, and one
-	# plugin's vtable/methods silently operate on the other's incompatible object layout.
+	# Prelink the brand's static lib into a single relocatable object, rename its
+	# init() entry point to init_${brand}, and localize all other symbols. This keeps
+	# each plugin's internal symbols (including its `pluginInstance`) private, the same
+	# as when it's dynamically loaded on hardware. Otherwise, same-named symbols in two
+    # statically-linked plugins get merged by the linker, and one plugin's code
+    # silently operates on another plugin's incompatible objects. See
+    # localize-ext-plugin.cmake for details.
 	set(brand_localized_obj ${CMAKE_CURRENT_BINARY_DIR}/builtins/${brand}_localized.o)
 
-	if (APPLE)
-		set(brand_exports_file ${CMAKE_CURRENT_BINARY_DIR}/builtins/${brand}_exports.txt)
-		file(WRITE ${brand_exports_file} "*init_${brand}*\n")
-		# -mmacosx-version-min: stamp a floor version so the final link never sees the
-		# prelinked object as "newer" than its target. -Wl,-w: silence the resulting
-		# version-mismatch warnings within this (purely mechanical) prelink step.
-		add_custom_command(
-			OUTPUT ${brand_localized_obj}
-			COMMAND ${CMAKE_CXX_COMPILER} -r -nostdlib -mmacosx-version-min=11.0 -Wl,-w
-					-Wl,-force_load,$<TARGET_FILE:${brand}>
-					-Wl,-exported_symbols_list,${brand_exports_file}
-					-o ${brand_localized_obj}
-			DEPENDS ${brand} ${brand_exports_file}
-			COMMENT "Prelinking ${brand} and localizing all symbols except init_${brand}"
-			VERBATIM
-		)
-	else()
-		add_custom_command(
-			OUTPUT ${brand_localized_obj}
-			COMMAND ${CMAKE_LINKER} -r --whole-archive $<TARGET_FILE:${brand}> --no-whole-archive -o ${brand_localized_obj}.partial.o
-			COMMAND ${CMAKE_OBJCOPY} -w --keep-global-symbol=*init_${brand}* ${brand_localized_obj}.partial.o ${brand_localized_obj}
-			DEPENDS ${brand}
-			COMMENT "Prelinking ${brand} and localizing all symbols except init_${brand}"
-			VERBATIM
-		)
-	endif()
+	# Collect the brand's own static-library dependencies (transitively), so
+	# multi-library plugins (e.g. Airwindows' airwin-registry) get prelinked and
+	# localized completely. Host-provided targets are excluded: references to them
+	# stay undefined in the prelinked object and resolve against the host at the
+	# final link (same as when the plugin is dynamically loaded on hardware).
+	set(host_provided_targets
+		metamodule::vcv-plugin-interface vcv-plugin-interface
+		cpputil::cpputil cpputil
+		metamodule::CMSISDSP CMSISDSP
+	)
+	set(brand_dep_archives "")
+	set(brand_dep_targets "")
+	set(_pending ${brand})
+	set(_visited "")
+	while(_pending)
+		list(POP_FRONT _pending _dep)
+		if (_dep IN_LIST _visited)
+			continue()
+		endif()
+		list(APPEND _visited ${_dep})
+		if (_dep IN_LIST host_provided_targets)
+			continue()
+		endif()
+		if (NOT TARGET ${_dep})
+			# A raw path to a prebuilt static lib is prelinked in, too
+			if (EXISTS ${_dep} AND _dep MATCHES "\\.a$")
+				list(APPEND brand_dep_archives ${_dep})
+			endif()
+			continue()
+		endif()
+		get_target_property(_dep_type ${_dep} TYPE)
+		if (NOT _dep STREQUAL brand AND _dep_type STREQUAL "STATIC_LIBRARY")
+			list(APPEND brand_dep_archives $<TARGET_FILE:${_dep}>)
+			list(APPEND brand_dep_targets ${_dep})
+		endif()
+		if (_dep_type STREQUAL "INTERFACE_LIBRARY")
+			get_target_property(_dep_deps ${_dep} INTERFACE_LINK_LIBRARIES)
+		else()
+			get_target_property(_dep_deps ${_dep} LINK_LIBRARIES)
+		endif()
+		if (_dep_deps)
+			list(APPEND _pending ${_dep_deps})
+		endif()
+	endwhile()
+	list(JOIN brand_dep_archives "|" brand_dep_archives_joined)
+
+	add_custom_command(
+		OUTPUT ${brand_localized_obj}
+		COMMAND ${CMAKE_COMMAND}
+				-DARCHIVE=$<TARGET_FILE:${brand}>
+				"-DDEP_ARCHIVES=${brand_dep_archives_joined}"
+				-DBRAND=${brand}
+				-DOUTPUT=${brand_localized_obj}
+				-DHOST_APPLE=${APPLE}
+				-DCXX=${CMAKE_CXX_COMPILER}
+				-DLINKER=${CMAKE_LINKER}
+				-DOBJCOPY=${CMAKE_OBJCOPY}
+				-P ${CMAKE_CURRENT_LIST_DIR}/localize-ext-plugin.cmake
+		DEPENDS ${brand} ${brand_dep_targets} ${CMAKE_CURRENT_LIST_DIR}/localize-ext-plugin.cmake
+		COMMENT "Prelinking ${brand}: renaming init() => init_${brand} and localizing internal symbols"
+		VERBATIM
+	)
 
 	add_custom_target(${brand}-localized DEPENDS ${brand_localized_obj})
 	add_dependencies(_vcv_ports_internal ${brand}-localized)
@@ -107,7 +147,7 @@ foreach(branddir brand slug IN ZIP_LISTS ext_builtin_brand_paths ext_builtin_bra
 	target_link_libraries(_vcv_ports_internal PUBLIC ${brand_localized_obj})
 	add_dependencies(asset-image ${brand}-assets)
 
-	string(APPEND EXT_PLUGIN_INIT_CALLS "\textern void init_${brand}(rack::plugin::Plugin *);\n\tinit_${brand}(&internal_plugins.emplace_back(\"${slug}\"));")
+	string(APPEND EXT_PLUGIN_INIT_CALLS "\textern void init_${brand}(rack::plugin::Plugin *);\n\tpluginInstance = &internal_plugins.emplace_back(\"${slug}\");\n\tinit_${brand}(pluginInstance);\n")
 endforeach()
 
 configure_file(src/ext_plugin_builtin.hh.in ${CMAKE_CURRENT_BINARY_DIR}/ext_plugin/ext_plugin_builtin.hh)

--- a/simulator/localize-ext-plugin.cmake
+++ b/simulator/localize-ext-plugin.cmake
@@ -1,0 +1,99 @@
+# Build-time script (cmake -P) that prelinks an ext-builtin plugin brand's
+# static library into a single relocatable object, renames the plugin's init()
+# entry point to init_<BRAND>, and localizes all other symbols.
+#
+# Why: ext-builtin plugins are statically linked into the simulator alongside
+# the firmware's built-in brands. Without this step, same-named global symbols
+# in two plugins  get merged by the linker, and one plugin's code/vtables
+# silently operate on another plugin's incompatible objects. Localizing each
+# brand's symbols gives it the same isolation it has when dynamically loaded on
+# hardware, with no source changes needed in the plugin.
+#
+# The plugin may define its entry point in any of the ways the hardware dynamic
+# loader accepts:
+#   - extern "C" void init(rack::plugin::Plugin *)
+#   - void init(rack::plugin::Plugin *)            (C++ linkage)
+#   - void init_<BRAND>(rack::plugin::Plugin *)    (legacy simulator style)
+# The first two are renamed to the mangled name of init_<BRAND> that the generated
+# ext_plugin_builtin.hh declares. Only init_<BRAND> is left exported.
+#
+# Inputs:
+#   ARCHIVE      - path to the brand's static library (libBrand.a)
+#   DEP_ARCHIVES - "|"-separated paths of the brand's own static-lib dependencies
+#                  (loaded lazily: only members the plugin references are pulled in)
+#   BRAND        - brand library name (init entry point becomes init_<BRAND>)
+#   OUTPUT       - path of the localized relocatable object to produce
+#   HOST_APPLE   - TRUE when building on macOS
+#   CXX          - C++ compiler driver (macOS: used to drive `ld -r`)
+#   LINKER       - ld (Linux only)
+#   OBJCOPY      - objcopy (Linux only)
+
+if (DEP_ARCHIVES)
+	string(REPLACE "|" ";" dep_archives "${DEP_ARCHIVES}")
+else()
+	set(dep_archives "")
+endif()
+
+# Mangled name of `void init_<BRAND>(rack::plugin::Plugin *)`, which is how the
+# generated ext_plugin_builtin.hh declares each brand's entry point:
+string(LENGTH "init_${BRAND}" init_name_len)
+set(entry_sym "_Z${init_name_len}init_${BRAND}PN4rack6plugin6PluginE")
+
+# Find which init symbol (if any) the plugin defines. Legacy-style plugins that
+# already define init_<BRAND>() need no rename.
+execute_process(COMMAND nm -g ${ARCHIVE} OUTPUT_VARIABLE archive_syms COMMAND_ERROR_IS_FATAL ANY)
+
+if (HOST_APPLE)
+	# macOS symbol names have a leading underscore
+	set(alias_args "")
+	if (archive_syms MATCHES "T __Z4initPN4rack6plugin6PluginE")
+		set(alias_args -Wl,-alias,__Z4initPN4rack6plugin6PluginE,_${entry_sym})
+	elseif (archive_syms MATCHES "T _init([\r\n]|$)")
+		set(alias_args -Wl,-alias,_init,_${entry_sym})
+	endif()
+
+	file(WRITE ${OUTPUT}.exports "*init_${BRAND}*\n")
+
+	# -r: partial (relocatable) link; unexported symbols become local.
+	# -mmacosx-version-min: stamp a floor version so the final link never sees the
+	# prelinked object as "newer" than its target. -Wl,-w: silence the resulting
+	# version-mismatch warnings within this (purely mechanical) prelink step.
+	execute_process(
+		COMMAND ${CXX} -r -nostdlib -mmacosx-version-min=11.0 -Wl,-w
+				-Wl,-force_load,${ARCHIVE}
+				${dep_archives}
+				${alias_args}
+				-Wl,-exported_symbols_list,${OUTPUT}.exports
+				-o ${OUTPUT}
+		COMMAND_ERROR_IS_FATAL ANY
+	)
+else()
+	set(rename_args "")
+	if (archive_syms MATCHES "T _Z4initPN4rack6plugin6PluginE")
+		set(rename_args --redefine-sym _Z4initPN4rack6plugin6PluginE=${entry_sym})
+	elseif (archive_syms MATCHES "T init([\r\n]|$)")
+		set(rename_args --redefine-sym init=${entry_sym})
+	endif()
+
+	execute_process(
+		COMMAND ${LINKER} -r --whole-archive ${ARCHIVE} --no-whole-archive ${dep_archives} -o ${OUTPUT}.partial.o
+		COMMAND_ERROR_IS_FATAL ANY
+	)
+	execute_process(
+		COMMAND ${OBJCOPY} ${rename_args} -w --keep-global-symbol=*init_${BRAND}* ${OUTPUT}.partial.o ${OUTPUT}
+		COMMAND_ERROR_IS_FATAL ANY
+	)
+endif()
+
+# Sanity check: the result must export the entry point, or the final simulator link
+# will fail with a much more confusing undefined-symbol error.
+execute_process(COMMAND nm -g ${OUTPUT} OUTPUT_VARIABLE output_syms COMMAND_ERROR_IS_FATAL ANY)
+string(FIND "${output_syms}" "${entry_sym}" entry_found)
+if (entry_found EQUAL -1)
+	message(FATAL_ERROR
+		"Plugin brand '${BRAND}' does not define an init() entry point.\n"
+		"Expected the plugin to define `void init(rack::plugin::Plugin *)` "
+		"(with C or C++ linkage), or `void init_${BRAND}(rack::plugin::Plugin *)`.\n"
+		"Symbols searched in: ${ARCHIVE}"
+	)
+endif()

--- a/simulator/src/ext_plugin_builtin.hh.in
+++ b/simulator/src/ext_plugin_builtin.hh.in
@@ -1,3 +1,13 @@
+namespace rack::plugin
+{
+struct Plugin;
+}
+
+// The shared "current plugin" global (defined in vcv_ports/glue/plugin_instance.cc).
+// Mirroring the hardware dynamic loader, it must point at the brand's Plugin while that
+// brand's init() runs, since host code (e.g. Plugin::addModel) reads it.
+extern rack::plugin::Plugin *pluginInstance;
+
 inline void load_ext_builtin_plugins(auto &internal_plugins) {
 ${EXT_PLUGIN_INIT_CALLS}
 }


### PR DESCRIPTION
This lets the simulator build external plugins without needing to change the `init()` function to `init_BRAND()`, and needing to `extern` the `pluginInstance` pointer. Now, you can just build an ext plugin as-is.

It also builds the plugins in a separate library and only exports the `init()` symbol, so this fixes the problem where a plugin having a symbol with the same name as one in firmware would cause strange issues, or if you're lucky it just failed to compile.