### PR TITLE
Fix time_convert using wrong format for std::tm

### DIFF
--- a/firmware/src/fs/time_convert.cc
+++ b/firmware/src/fs/time_convert.cc
@@ -7,13 +7,16 @@
 // std::tm: (36 bytes) date and time, minimum 1970, resolution 1 second. Intermediate value
 // time_t: (8 bytes) seconds since 1970
 
+// std::tm conventions: tm_mon is 0-based (0 = January), tm_year is years since 1900.
+// default_poweron_tm represents 2000-01-01 01:00:00, and must stay in a range that
+// mktime()/localtime() can represent on every host (e.g. simulator on Windows, macOS, Linux...)
 static std::tm default_poweron_tm = {
 	.tm_sec = 0,
 	.tm_min = 0,
 	.tm_hour = 1,
 	.tm_mday = 1,
-	.tm_mon = 1,
-	.tm_year = 2000,
+	.tm_mon = 0,
+	.tm_year = 2000 - 1900,
 	.tm_isdst = 0,
 };
 
@@ -43,19 +46,20 @@ FatTime make_fattime(unsigned year, unsigned month, unsigned day, unsigned hour,
 }
 
 FatTime tm_to_fattime(std::tm &t) {
-	return make_fattime(t.tm_year, t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
+	// std::tm -> human-readable: year is since 1900, month is 0-based.
+	return make_fattime(t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
 }
 
 std::tm fattime_to_tm(FatTime fattime) {
 	uint16_t fdate = fattime.date;
 	uint16_t ftime = fattime.time;
 	std::tm t;
-	t.tm_year = static_cast<uint8_t>(fdate >> 9) + 1980;  //top 7 bits are year-1980 1980..2107
-	t.tm_mon = static_cast<uint8_t>((fdate >> 5) & 0x0F); //middle 4 bits are month 1..12
-	t.tm_mday = static_cast<uint8_t>(fdate & 0x1F);		  //bottom 5 bits are day 1..31
-	t.tm_hour = static_cast<uint8_t>(ftime >> 11);		  //top 5 bits are hour 0..23
-	t.tm_min = static_cast<uint8_t>((ftime >> 5) & 0x3F); //middle 6 bits are minute 0..59
-	t.tm_sec = static_cast<uint8_t>((ftime & 0x1F) * 2);  //bottom 5 bits are seconds/2 0..29
+	t.tm_year = static_cast<uint8_t>(fdate >> 9) + 1980 - 1900; //top 7 bits are year-1980; tm_year is since 1900
+	t.tm_mon = static_cast<uint8_t>((fdate >> 5) & 0x0F) - 1;	//middle 4 bits are month 1..12; tm_mon is 0-based
+	t.tm_mday = static_cast<uint8_t>(fdate & 0x1F);				//bottom 5 bits are day 1..31
+	t.tm_hour = static_cast<uint8_t>(ftime >> 11);				//top 5 bits are hour 0..23
+	t.tm_min = static_cast<uint8_t>((ftime >> 5) & 0x3F);		//middle 6 bits are minute 0..59
+	t.tm_sec = static_cast<uint8_t>((ftime & 0x1F) * 2);		//bottom 5 bits are seconds/2 0..29
 	t.tm_isdst = 0;
 	return t;
 }
@@ -74,8 +78,11 @@ uint64_t fattime_to_ticks(FatTime fattime) {
 FatTime ticks_to_fattime(uint32_t ticks) {
 	time_t secs = (time_t)(ticks / 1000) + poweron_sec_since_epoch;
 	std::tm *t = std::localtime(&secs);
+	if (!t) //localtime can fail (e.g. out-of-range time_t on Windows); don't crash
+		return make_fattime(1980, 1, 1, 0, 0, 0);
 
-	return make_fattime(t->tm_year, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+	// localtime -> human-readable: year is since 1900, month is 0-based.
+	return make_fattime(t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
 }
 
 #if TIME_PRINT_TESTS_ENABLE
@@ -106,8 +113,8 @@ void time_tests() {
 		.tm_min = 40,
 		.tm_hour = 9,
 		.tm_mday = 21,
-		.tm_mon = 11,
-		.tm_year = 2022,
+		.tm_mon = 11,			//December (0-based)
+		.tm_year = 2022 - 1900, //years since 1900
 	};
 	time_t poweron_time = mktime(&poweron_tm);
 	printf_("poweron_time: secs since epoch = %llu", poweron_time);

--- a/firmware/src/fs/time_convert.hh
+++ b/firmware/src/fs/time_convert.hh
@@ -10,8 +10,8 @@ struct FatTime {
 	operator uint32_t() const {
 		return ((uint32_t)date << 16) | (uint32_t)time;
 	}
-	uint8_t year() {
-		return static_cast<uint8_t>(date >> 9) + 1980; //top 7 bits are year-1980 1980..2107
+	uint16_t year() {
+		return (date >> 9) + 1980; //top 7 bits are year-1980 1980..2107
 	}
 	uint8_t month() {
 		return static_cast<uint8_t>((date >> 5) & 0x0F); //middle 4 bits are month 1..12

--- a/firmware/tests/time_convert_tests.cc
+++ b/firmware/tests/time_convert_tests.cc
@@ -11,12 +11,22 @@ TEST_CASE("fatetime->tm") {
 	unsigned second = 52;
 	FatTime ft = make_fattime(year, month, day, hour, minute, second);
 	std::tm t = fattime_to_tm(ft);
-	CHECK(t.tm_year == year);
-	CHECK(t.tm_mon == month);
+	CHECK(t.tm_year == year - 1900); //std::tm: years since 1900
+	CHECK(t.tm_mon == month - 1);	 //std::tm: 0-based month
 	CHECK(t.tm_mday == day);
 	CHECK(t.tm_hour == hour);
 	CHECK(t.tm_min == minute);
 	CHECK(t.tm_sec == second);
+}
+
+TEST_CASE("FatTime field accessors") {
+	FatTime ft = make_fattime(2000, 12, 31, 23, 59, 58);
+	CHECK(ft.year() == 2000); //year() must not truncate to uint8_t (2000 & 0xFF == 208)
+	CHECK(ft.month() == 12);
+	CHECK(ft.day() == 31);
+	CHECK(ft.hour() == 23);
+	CHECK(ft.minute() == 59);
+	CHECK(ft.second() == 58);
 }
 
 void print_tm(std::tm t) {
@@ -36,8 +46,8 @@ TEST_CASE("fattime<->ticks") {
 		.tm_min = 0,
 		.tm_hour = 1,
 		.tm_mday = 1,
-		.tm_mon = 2,
-		.tm_year = 2000,
+		.tm_mon = 1,			//February (0-based)
+		.tm_year = 2000 - 1900, //years since 1900
 	};
 	set_time_now(poweron_tm, 0); //0 ticks since power-on
 
@@ -62,4 +72,32 @@ TEST_CASE("tick -> ft -> tick") {
 	ticks_ms /= 2000;
 	ticks_ms *= 2000;
 	CHECK(ticks_ms == ticks_ms2);
+}
+
+TEST_CASE("default power-on time is a valid absolute time") {
+	// Rebuild the default power-on reference (2000-01-01 01:00:00) and drive conversions off it.
+	std::tm poweron_tm{
+		.tm_sec = 0,
+		.tm_min = 0,
+		.tm_hour = 1,
+		.tm_mday = 1,
+		.tm_mon = 0,			//January (0-based)
+		.tm_year = 2000 - 1900, //years since 1900
+	};
+	set_time_now(poweron_tm, 0);
+
+	time_t poweron = get_poweron_time();
+	CHECK(poweron != (time_t)-1); //mktime succeeded
+
+	std::tm *back = std::localtime(&poweron);
+	REQUIRE(back != nullptr); //localtime succeeded (this is what crashed before)
+	CHECK(back->tm_year + 1900 == 2000);
+	CHECK(back->tm_mon + 1 == 1);
+
+	// 0 ticks since power-on must round-trip back to the power-on date, not year 3900.
+	FatTime ft = ticks_to_fattime(0);
+	std::tm t = fattime_to_tm(ft);
+	CHECK(t.tm_year + 1900 == 2000);
+	CHECK(t.tm_mon + 1 == 1);
+	CHECK(t.tm_mday == 1);
 }


### PR DESCRIPTION
std::tm is 0-based for the month, and year 0 is 1900. Also FatTime::year() was returning the year incorrectly (nothing called this, so not yet reported as a bug)

Brought to light via #600 