### PR TITLE
Improve param z-order

### DIFF
--- a/firmware/src/gui/elements/redraw.hh
+++ b/firmware/src/gui/elements/redraw.hh
@@ -7,6 +7,7 @@
 #include "patch/patch_data.hh"
 #include "pr_dbg.hh"
 #include <cmath>
+#include <span>
 
 namespace MetaModule
 {
@@ -180,6 +181,28 @@ inline bool redraw_element(const BaseElement &, const GuiElement &, float) {
 	return false;
 }
 
+// Raise all params mapped in the active knob set above the un-mapped ones
+// so that stacked controls (e.g. concentric knobs) show the ones in use.
+// Note: controls are drawn at their zero position, and redrawing a control moves it to the
+// foreground, so this must be called after all params have been drawn at their current value.
+inline void raise_mapped_params(std::span<DrawnElement> drawn_elements) {
+	for (auto &drawn_el : drawn_elements) {
+		auto &gui_el = drawn_el.gui_element;
+
+		if (gui_el.count.num_params == 0 || !gui_el.obj)
+			continue;
+
+		if (!gui_el.mapped_panel_id.has_value())
+			continue;
+
+		lv_obj_move_foreground(gui_el.obj);
+
+		// Keep the map ring above its own control, as when it was drawn
+		if (gui_el.map_ring)
+			lv_obj_move_foreground(gui_el.map_ring);
+	}
+}
+
 inline bool redraw_param(DrawnElement &drawn_el, float value) {
 	bool was_redrawn = false;
 
@@ -194,6 +217,17 @@ inline bool redraw_param(DrawnElement &drawn_el, float value) {
 			drawn_el.element);
 	}
 	return was_redrawn;
+}
+
+// Draws every param at its current value: used just after drawing a module, so that the
+// first regular redraw pass doesn't move controls to the foreground in param order.
+template<typename GetParamValue>
+inline void redraw_all_params(std::span<DrawnElement> drawn_elements, GetParamValue &&get_value) {
+	for (auto &drawn_el : drawn_elements) {
+		auto &gui_el = drawn_el.gui_element;
+		if (gui_el.count.num_params > 0 && gui_el.obj)
+			redraw_param(drawn_el, get_value(gui_el.module_idx, gui_el.idx.param_idx));
+	}
 }
 
 } // namespace MetaModule

--- a/firmware/src/gui/pages/module_view/draw_module.cc
+++ b/firmware/src/gui/pages/module_view/draw_module.cc
@@ -3,6 +3,8 @@
 #include "gui/elements/redraw_display.hh"
 #include "gui/elements/redraw_light.hh"
 #include "gui/pages/module_view/module_view.hh"
+#include "util/countzip.hh"
+#include <algorithm>
 
 namespace MetaModule
 {
@@ -33,6 +35,8 @@ unsigned ModuleViewPage::resize_module_image(unsigned max) {
 }
 
 void ModuleViewPage::redraw_module() {
+	save_element_stacking_order();
+
 	reset_module_page();
 
 	size_t num_elements = moduleinfo.elements.size();
@@ -59,7 +63,11 @@ void ModuleViewPage::redraw_module() {
 		});
 	}
 
+	restore_element_stacking_order();
+
 	raise_mapped_params(drawn_elements);
+
+	stack_order_module_id = this_module_id;
 
 	// Populate Roller and highlighter buttons
 	populate_element_objects();
@@ -82,6 +90,43 @@ void ModuleViewPage::redraw_module() {
 
 	dynamic_elements_prepared = false;
 	update_graphic_throttle_setting();
+}
+
+// Records the stacking order of the currently drawn elements, so it can be re-applied
+// after re-drawing the module. Otherwise overlapping controls (e.g. concentric knobs)
+// would jump back to param order every time the module is re-drawn.
+void ModuleViewPage::save_element_stacking_order() {
+	element_stack_order.clear();
+
+	// Elements are for a different module: nothing to preserve
+	if (stack_order_module_id != this_module_id)
+		return;
+
+	for (auto [idx, drawn_el] : enumerate(drawn_elements)) {
+		if (drawn_el.gui_element.obj)
+			element_stack_order.push_back(idx);
+	}
+
+	std::ranges::stable_sort(element_stack_order, {}, [this](uint16_t idx) {
+		return lv_obj_get_index(drawn_elements[idx].gui_element.obj);
+	});
+}
+
+void ModuleViewPage::restore_element_stacking_order() {
+	for (auto idx : element_stack_order) {
+		if (idx >= drawn_elements.size())
+			continue;
+
+		auto &gui_el = drawn_elements[idx].gui_element;
+		if (!gui_el.obj)
+			continue;
+
+		lv_obj_move_foreground(gui_el.obj);
+
+		// Keep the map ring above its own control, as when it was drawn
+		if (gui_el.map_ring)
+			lv_obj_move_foreground(gui_el.map_ring);
+	}
 }
 
 void ModuleViewPage::watch_element(DrawnElement const &drawn_element) {

--- a/firmware/src/gui/pages/module_view/draw_module.cc
+++ b/firmware/src/gui/pages/module_view/draw_module.cc
@@ -53,6 +53,14 @@ void ModuleViewPage::redraw_module() {
 
 	lv_obj_update_layout(canvas);
 
+	if (is_patch_playloaded) {
+		redraw_all_params(drawn_elements, [this](uint16_t module_idx, uint16_t param_idx) {
+			return patch_playloader.param_value(module_idx, param_idx);
+		});
+	}
+
+	raise_mapped_params(drawn_elements);
+
 	// Populate Roller and highlighter buttons
 	populate_element_objects();
 	populate_roller();

--- a/firmware/src/gui/pages/module_view/module_view.hh
+++ b/firmware/src/gui/pages/module_view/module_view.hh
@@ -267,6 +267,8 @@ struct ModuleViewPage : PageBase {
 			patch = patches.get_view_patch();
 			auto ok = read_slug();
 			if (!ok || prev_slug != slug) {
+				// A different module is at this module_id now: its stacking order does not apply
+				stack_order_module_id.reset();
 				page_list.request_new_page(PageId::PatchView, args);
 			} else {
 				if (gui_state.force_redraw_patch)
@@ -472,6 +474,8 @@ private:
 	void prepare_dynamic_elements();
 	unsigned resize_module_image(unsigned max);
 	void redraw_module();
+	void save_element_stacking_order();
+	void restore_element_stacking_order();
 	void watch_element(DrawnElement const &drawn_element);
 	void redraw_elements();
 	void update_map_ring_style();
@@ -511,6 +515,12 @@ private:
 
 	std::vector<lv_obj_t *> element_highlights;
 	std::vector<DrawnElement> drawn_elements;
+
+	// Drawn element indices, ordered back to front: used to keep the stacking order of
+	// overlapping controls (e.g. concentric knobs) when the module is re-drawn
+	std::vector<uint16_t> element_stack_order;
+	std::optional<uint16_t> stack_order_module_id;
+
 	std::vector<int> roller_drawn_el_idx;
 
 	lv_obj_t *canvas = nullptr;

--- a/firmware/src/gui/pages/module_view/quick_assign.cc
+++ b/firmware/src/gui/pages/module_view/quick_assign.cc
@@ -31,6 +31,11 @@ void ModuleViewPage::handle_quick_assign() {
 				cc.changed = false;
 			params.last_midi_note.changed = false;
 		}
+
+		// Clear all events
+		for (auto &knob : params.knobs) {
+			knob.changed = false;
+		}
 	}
 
 	if (quickmap_rotary_button.is_pressed()) {

--- a/firmware/src/gui/pages/patch_view.hh
+++ b/firmware/src/gui/pages/patch_view.hh
@@ -266,6 +266,14 @@ struct PatchViewPage : PageBase {
 			}
 		}
 
+		if (is_patch_playloaded) {
+			redraw_all_params(drawn_elements, [this](uint16_t module_idx, uint16_t param_idx) {
+				return patch_playloader.param_value(module_idx, param_idx);
+			});
+		}
+
+		raise_mapped_params(drawn_elements);
+
 		if (modules_skipped_for_size) {
 			std::string msg = "Not displaying: " + modules_skipped_slugs + "because graphics buffer is full";
 			notify_queue.put({msg, Notification::Priority::Info, 4000});
@@ -299,6 +307,9 @@ struct PatchViewPage : PageBase {
 			ModuleDrawer{modules_cont, page_settings.view_height_px}.draw_mapped_ring(
 				*patch, module_id, knobset, canvas, drawn_el);
 		}
+
+		raise_mapped_params(drawn_elements);
+
 		update_map_ring_style();
 	}
 


### PR DESCRIPTION
Handles the z-order issue of stacking knobs on top of each other a little better. The rules:
- Moving a knob draws it on top (via a mapping or manual adjustment)
- Selecting a knob in the element roller draws it on top
- Changing knobsets saves the current z-order and restores it after redrawing the module, and then moves all knobs that are mapped in the current knobset to the foreground.
