### PR TITLE
Usb console

### DIFF
--- a/firmware/flashing/flash-t32.py
+++ b/firmware/flashing/flash-t32.py
@@ -73,7 +73,12 @@ def main():
     # so the poll below can't see a stale value from the last boot.
     write_long(dbg, TAMP_BKP6R, 0)
     print("Resetting board (MPSYSRST)...")
-    write_long(dbg, RCC_MP_GRSTCSETR, 1)
+    try:
+        write_long(dbg, RCC_MP_GRSTCSETR, 1)
+    except Exception:
+        # TRACE32 often reports "target reset detected" on this write -- that
+        # IS the reset we asked for, so carry on to polling for the bootloader
+        pass
 
     print("Waiting for mp1-boot to be ready for an image...")
     deadline = time.time() + 20

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -2,7 +2,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/common.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/arch_mp15xa7.cmake)
 
 option(CPU_TEST_ALL_MODULES     "Perform CPU tests at boot on all modules (built-in and preloaded plugins)" ON)
-option(CONSOLE_USE_USB          "Send printf() to USB if connected" OFF)
 option(SUPPRESS_HIL_MESSAGES    "Suppress HIL messages" OFF)
 
 
@@ -276,11 +275,6 @@ if (CPU_TEST_ALL_MODULES)
 endif()
 if (SUPPRESS_HIL_MESSAGES)
   target_compile_definitions(main.elf PRIVATE SUPPRESS_HIL_MESSAGES=1)
-endif()
-
-if (CONSOLE_USE_USB)
-  message("USB serial device enabled for console logging")
-  target_compile_definitions(main.elf PRIVATE CONSOLE_USE_USB=1)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../vcv_ports/brands.cmake)

--- a/firmware/src/console/concurrent_buffer.hh
+++ b/firmware/src/console/concurrent_buffer.hh
@@ -26,13 +26,13 @@ struct ConcurrentBuffer {
 		// inner-shareable i.e. not the M4).
 		asm volatile("dmb sy" ::: "memory");
 #else
-		// Host builds (tests/simulator): ordinary threads on one OS
+		// Host builds (tests/simulator)
 		std::atomic_thread_fence(std::memory_order_seq_cst);
 #endif
 	}
 
 	// Copy data into the ring at pos without publishing it. Re-entrant: callers
-	// writing to disjoint [pos, pos+size) regions can safely interrupt each other.
+	// writing to non-overlapping regions can safely interrupt each other.
 	void copy_in(std::span<const uint8_t> data, uint32_t pos) {
 		buffer.write(data, pos);
 	}

--- a/firmware/src/console/concurrent_buffer.hh
+++ b/firmware/src/console/concurrent_buffer.hh
@@ -2,21 +2,48 @@
 
 #include "util/circular_buffer_block.hh"
 #include <atomic>
+#include <cstdint>
 #include <span>
 
+// Per-core console log buffer, living in shared, non-cached memory (.consolebuf).
+// Written by the core that owns it, read by the M4 which writes to UART or USB CDC.
+//
+// Note: no read-modify-write atomics (LDREX/STREX) in this struct. On the A7,
+// exclusives to non-cacheable memory need a global exclusive monitor in the
+// interconnect, which the STM32MP15 does not have and the M4 does not go through the MMU.
+// Plain aligned 32-bit loads/stores are single-copy atomic on both cores,
+// so SPSC + explicit barriers is enough.
 struct ConcurrentBuffer {
-	CircularBufferBlock<uint8_t, 256 * 1024> buffer{};
-	int writer_ref_count{0};
-	int current_write_pos{0};
-	bool use_color = false;
+	static constexpr uint32_t Size = 256 * 1024;
 
-	void write(std::span<const uint8_t> data) {
-		auto start = current_write_pos;
-		current_write_pos += data.size();
-		buffer.write(data, start);
+	CircularBufferBlock<uint8_t, Size> buffer{};
+	std::atomic<uint32_t> write_pos{0};
+	std::atomic<uint32_t> read_pos{0};
+
+	static void barrier() {
+#if defined(CORE_CA7) || defined(CORE_CM4)
+		// Full-system barrier ("dmb sy") is required (not "dmb ish" which is only for
+		// inner-shareable i.e. not the M4).
+		asm volatile("dmb sy" ::: "memory");
+#else
+		// Host builds (tests/simulator): ordinary threads on one OS
+		std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
 	}
 
-	void write(std::span<const char> data) {
-		write({(uint8_t *)data.data(), data.size()});
+	// Copy data into the ring at pos without publishing it. Re-entrant: callers
+	// writing to disjoint [pos, pos+size) regions can safely interrupt each other.
+	void copy_in(std::span<const uint8_t> data, uint32_t pos) {
+		buffer.write(data, pos);
+	}
+
+	void copy_in(std::span<const char> data, uint32_t pos) {
+		copy_in({reinterpret_cast<const uint8_t *>(data.data()), data.size()}, pos);
+	}
+
+	// Make everything up to pos visible to the reader
+	void publish(uint32_t pos) {
+		barrier(); // data must be visible before the new write_pos is
+		write_pos = pos;
 	}
 };

--- a/firmware/src/console/console_buffer_reader.hh
+++ b/firmware/src/console/console_buffer_reader.hh
@@ -1,0 +1,132 @@
+#pragma once
+#include "console/concurrent_buffer.hh"
+#include "util/term_codes.hh"
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <span>
+#include <string_view>
+
+namespace MetaModule
+{
+
+// Keeps a read position per buffer and copies out contiguous chunks, optionally
+// wrapping each chunk in a per-core terminal color. Only one reader may be actively
+// draining the buffers at a time: the UART drain by default, or the USB CDC console
+// while a host is connected (see console_routing.hh).
+class ConsoleBufferReader {
+public:
+	static constexpr size_t NumBuffers = 3;
+
+	ConsoleBufferReader(std::array<ConcurrentBuffer *, NumBuffers> buffers)
+		: buffers{buffers} {
+	}
+
+	// Drop any pending backlog: continue from each buffer's current position.
+	// Call when taking over as the active drain (the previously active drain
+	// already output the earlier data).
+	void resync() {
+		for (auto i = 0u; i < NumBuffers; i++) {
+			read_pos[i] = buffers[i]->write_pos;
+			buffers[i]->read_pos = read_pos[i];
+		}
+	}
+
+	void set_color(bool enabled) {
+		use_color = enabled;
+	}
+
+	// Copy the next pending chunk from one of the buffers into `out` (wrapped in
+	// color codes if enabled). Returns the number of bytes written to `out`, or 0
+	// if no buffer has pending data. Scans the buffers round-robin for fairness.
+	size_t next_chunk(std::span<uint8_t> out) {
+		for (auto scan = 0u; scan < NumBuffers; scan++) {
+			auto i = next_idx;
+			next_idx = (next_idx + 1) % NumBuffers;
+
+			auto payload = out;
+			size_t prefix_len = 0, suffix_len = 0;
+			if (use_color) {
+				prefix_len = strlen(core_colors[i]);
+				suffix_len = strlen(Term::Normal);
+				if (out.size() <= prefix_len + suffix_len)
+					return 0;
+				payload = out.subspan(prefix_len, out.size() - prefix_len - suffix_len);
+			}
+
+			auto len = read_from(i, payload);
+			if (len == 0)
+				continue;
+
+			if (use_color) {
+				memcpy(out.data(), core_colors[i], prefix_len);
+				memcpy(out.data() + prefix_len + len, Term::Normal, suffix_len);
+				return prefix_len + len + suffix_len;
+			}
+			return len;
+		}
+		return 0;
+	}
+
+private:
+	// Copy pending bytes from buffer i into `out`, returning the count (0 = no data)
+	size_t read_from(unsigned i, std::span<uint8_t> out) {
+		auto &buf = *buffers[i];
+		const uint32_t start = read_pos[i];
+
+		const uint32_t wpos = buf.write_pos;
+		ConcurrentBuffer::barrier(); // load write_pos before loading the data it covers
+
+		const uint32_t avail = wpos - start;
+		if (avail == 0)
+			return 0;
+
+		if (avail > ConcurrentBuffer::Size) {
+			// Writer lapped us (we stalled, or output came way too fast): the
+			// backlog is partly overwritten, so drop it all and say so
+			read_pos[i] = wpos;
+			buf.read_pos = wpos;
+			constexpr std::string_view msg = "\n<console overrun>\n";
+			auto n = std::min(msg.size(), out.size());
+			memcpy(out.data(), msg.data(), n);
+			return n;
+		}
+
+		const uint32_t offset = start & (ConcurrentBuffer::Size - 1);
+		auto n = std::min<uint32_t>({avail, (uint32_t)out.size(), ConcurrentBuffer::Size - offset});
+		memcpy(out.data(), &buf.buffer.data[offset], n);
+
+		ConcurrentBuffer::barrier(); // finish copying before re-checking write_pos
+		if (buf.write_pos - start > ConcurrentBuffer::Size) {
+			// Writer wrapped into the region while we were copying: data is torn
+			read_pos[i] = buf.write_pos;
+			buf.read_pos = read_pos[i];
+			return 0;
+		}
+
+		// Prefer ending a chunk at a line boundary, so that when chunks from
+		// different cores interleave, they don't splice mid-line. If the chunk
+		// has no newline at all (a partial or extra-long line), emit it as-is.
+		if (out[n - 1] != '\n') {
+			auto k = n;
+			while (k > 0 && out[k - 1] != '\n')
+				k--;
+			if (k > 0)
+				n = k;
+		}
+
+		read_pos[i] = start + n;
+		buf.read_pos = read_pos[i]; // let writers see our progress (backpressure)
+		return n;
+	}
+
+	std::array<ConcurrentBuffer *, NumBuffers> buffers;
+	std::array<uint32_t, NumBuffers> read_pos{};
+	unsigned next_idx = 0;
+	bool use_color = false;
+
+	// Buffer index -> color: A7 core 0, A7 core 1, M4
+	static constexpr std::array<const char *, NumBuffers> core_colors{Term::Blue, Term::Green, Term::Yellow};
+};
+
+} // namespace MetaModule

--- a/firmware/src/console/console_buffer_reader.hh
+++ b/firmware/src/console/console_buffer_reader.hh
@@ -23,8 +23,7 @@ public:
 	}
 
 	// Drop any pending backlog: continue from each buffer's current position.
-	// Call when taking over as the active drain (the previously active drain
-	// already output the earlier data).
+	// Call when switching UART<->USB CDC
 	void resync() {
 		for (auto i = 0u; i < NumBuffers; i++) {
 			read_pos[i] = buffers[i]->write_pos;
@@ -36,9 +35,8 @@ public:
 		use_color = enabled;
 	}
 
-	// Copy the next pending chunk from one of the buffers into `out` (wrapped in
-	// color codes if enabled). Returns the number of bytes written to `out`, or 0
-	// if no buffer has pending data. Scans the buffers round-robin for fairness.
+	// Copy the next pending chunk from one of the buffers into `out`
+	// Returns the number of bytes written.
 	size_t next_chunk(std::span<uint8_t> out) {
 		for (auto scan = 0u; scan < NumBuffers; scan++) {
 			auto i = next_idx;

--- a/firmware/src/console/console_routing.hh
+++ b/firmware/src/console/console_routing.hh
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace MetaModule::ConsoleRouting
+{
+
+// Included in main_m4.cc and usb_serial_device.cc
+// TODO: share this in a different way, can main_m4 get it from usb_serial_device?
+inline bool usb_console_active = false;
+
+} // namespace MetaModule::ConsoleRouting

--- a/firmware/src/console/uart_console_drain.hh
+++ b/firmware/src/console/uart_console_drain.hh
@@ -1,0 +1,94 @@
+#pragma once
+#include "conf/hsem_conf.hh"
+#include "console/console_buffer_reader.hh"
+#include "console/console_routing.hh"
+#include "console/uart_log.hh"
+#include "drivers/hsem.hh"
+
+namespace MetaModule
+{
+
+// Write the console buffers to the UART, as needed. Runs on the M4 in the main
+// context.
+//
+// Typing 'c' into the console enables per-core colored output; 'm' disables it
+//
+// Future UART-DMA upgrade: everything up to the FIFO top-up is TX-agnostic.
+// When idle, start a DMA transfer of bounce[tx_pos..tx_len) instead of writing
+// TDR here, and poll DMA completion (or use its interrupt) instead of checking
+// TXE_TXFNF. (DMA1/2 stream + DMAMUX request for UART7_TX, mem-to-periph,
+// byte-wise; the bounce buffer is already DMA-friendly M4-local RAM.)
+class UartConsoleDrain {
+public:
+	UartConsoleDrain(std::array<ConcurrentBuffer *, ConsoleBufferReader::NumBuffers> buffers)
+		: reader{buffers} {
+		UartLog::init();
+	}
+
+	void set_color(bool enabled) {
+		reader.set_color(enabled);
+	}
+
+	void process() {
+		if (ConsoleRouting::usb_console_active) {
+			usb_was_active = true;
+			return;
+		}
+		if (usb_was_active) {
+			usb_was_active = false;
+			// The USB console already displayed everything up to this point
+			reader.resync();
+		}
+
+		auto uart = UartLog::uart_regs();
+
+		poll_rx(uart);
+
+		while (true) {
+			if (tx_pos >= tx_len) {
+				tx_pos = 0;
+				tx_len = reader.next_chunk(bounce);
+				if (tx_len == 0)
+					return;
+			}
+
+			// Don't interleave with a core doing direct (unbuffered) UART writes.
+			// Those only happen during early boot, so contention is rare: just
+			// try again on the next process() call.
+			if (mdrivlib::HWSemaphore<UartLock>::lock(M4LockId) != mdrivlib::HWSemaphoreFlag::LockedOk)
+				return;
+
+			while (tx_pos < tx_len && (uart->ISR & USART_ISR_TXE_TXFNF))
+				uart->TDR = bounce[tx_pos++];
+
+			mdrivlib::HWSemaphore<UartLock>::unlock(M4LockId);
+
+			if (tx_pos < tx_len)
+				return; // TX FIFO full: continue on the next call
+		}
+	}
+
+private:
+	void poll_rx(USART_TypeDef *uart) {
+		if (uart->ISR & USART_ISR_ORE)
+			uart->ICR = USART_ICR_ORECF;
+
+		while (uart->ISR & USART_ISR_RXNE_RXFNE) {
+			char c = uart->RDR;
+			if (c == 'c')
+				reader.set_color(true);
+			else if (c == 'm')
+				reader.set_color(false);
+		}
+	}
+
+	static constexpr uint32_t M4LockId = 2; // same process id UartLog's direct writes use on the M4
+
+	ConsoleBufferReader reader;
+	std::array<uint8_t, 256> bounce;
+	size_t tx_pos = 0;
+	size_t tx_len = 0;
+	bool usb_was_active = false;
+};
+
+} // namespace MetaModule

--- a/firmware/src/console/uart_console_drain.hh
+++ b/firmware/src/console/uart_console_drain.hh
@@ -4,6 +4,8 @@
 #include "console/console_routing.hh"
 #include "console/uart_log.hh"
 #include "drivers/hsem.hh"
+#include "drivers/rcc.hh"
+#include <cstdio>
 
 namespace MetaModule
 {
@@ -11,18 +13,19 @@ namespace MetaModule
 // Write the console buffers to the UART, as needed. Runs on the M4 in the main
 // context.
 //
-// Typing 'c' into the console enables per-core colored output; 'm' disables it
+// TX uses DMA: process() assembles a chunk into the bounce buffer and starts a
+// DMA transfer (DMA1 Stream1, DMAMUX1 request UART7_TX), and later calls just poll
+// for completion -- the M4 spends no cycles feeding the UART. If the DMA ever
+// reports a transfer error, we permanently fall back to topping up the UART TX
+// FIFO directly (still non-blocking).
 //
-// Future UART-DMA upgrade: everything up to the FIFO top-up is TX-agnostic.
-// When idle, start a DMA transfer of bounce[tx_pos..tx_len) instead of writing
-// TDR here, and poll DMA completion (or use its interrupt) instead of checking
-// TXE_TXFNF. (DMA1/2 stream + DMAMUX request for UART7_TX, mem-to-periph,
-// byte-wise; the bounce buffer is already DMA-friendly M4-local RAM.)
+// Typing 'c' into the console enables per-core colored output; 'm' disables it
 class UartConsoleDrain {
 public:
 	UartConsoleDrain(std::array<ConcurrentBuffer *, ConsoleBufferReader::NumBuffers> buffers)
 		: reader{buffers} {
 		UartLog::init();
+		init_dma();
 	}
 
 	void set_color(bool enabled) {
@@ -44,27 +47,50 @@ public:
 
 		poll_rx(uart);
 
-		while (true) {
-			if (tx_pos >= tx_len) {
-				tx_pos = 0;
-				tx_len = reader.next_chunk(bounce);
-				if (tx_len == 0)
-					return;
+		if (dma_running) {
+			if (DMA1->LISR & DMA_LISR_TEIF1) {
+				// Bus error reading the bounce buffer or writing TDR: give up
+				// on DMA for good, drain via the TX FIFO from now on
+				auto flags = DMA1->LISR;
+				clear_dma_flags();
+				dma_running = false;
+				dma_ok = false;
+				unlock();
+				// Report through the very console we drain: this lands in the
+				// M4's buffer and comes out via the FIFO fallback path below.
+				// Deliberately not pr_err(): must be visible at any log level.
+				printf("<console: UART TX DMA error (LISR=0x%08x), using FIFO fallback>\n", (unsigned)flags);
+			} else if (DMA1->LISR & DMA_LISR_TCIF1) {
+				clear_dma_flags();
+				dma_running = false;
+				tx_pos = tx_len = 0;
+				unlock();
+			} else {
+				return; // still transferring
 			}
+		}
 
-			// Don't interleave with a core doing direct (unbuffered) UART writes.
-			// Those only happen during early boot, so contention is rare: just
-			// try again on the next process() call.
-			if (mdrivlib::HWSemaphore<UartLock>::lock(M4LockId) != mdrivlib::HWSemaphoreFlag::LockedOk)
+		// Fetch the next chunk if none is pending
+		if (tx_pos >= tx_len) {
+			tx_pos = 0;
+			tx_len = reader.next_chunk(bounce);
+			if (tx_len == 0)
 				return;
+		}
 
+		// Exclude cores doing direct (unbuffered) UART writes while we transmit.
+		// Those only happen during early boot, so contention is rare: just try
+		// again on the next process() call.
+		if (mdrivlib::HWSemaphore<UartLock>::lock(M4LockId) != mdrivlib::HWSemaphoreFlag::LockedOk)
+			return;
+
+		if (dma_ok) {
+			start_dma(&bounce[tx_pos], tx_len - tx_pos);
+			// hold the lock until the transfer completes
+		} else {
 			while (tx_pos < tx_len && (uart->ISR & USART_ISR_TXE_TXFNF))
 				uart->TDR = bounce[tx_pos++];
-
-			mdrivlib::HWSemaphore<UartLock>::unlock(M4LockId);
-
-			if (tx_pos < tx_len)
-				return; // TX FIFO full: continue on the next call
+			unlock();
 		}
 	}
 
@@ -82,6 +108,54 @@ private:
 		}
 	}
 
+	void init_dma() {
+		mdrivlib::core_m4::RCC_Enable::DMA1_::set();
+		mdrivlib::core_m4::RCC_Enable::DMAMUX_::set();
+
+		// DMAMUX1 channels 0..7 feed DMA1 streams 0..7
+		DMAMUX1_Channel1->CCR = DMA_REQUEST_UART7_TX;
+
+		DMA1_Stream1->CR = 0;
+		while (DMA1_Stream1->CR & DMA_SxCR_EN)
+			;
+		clear_dma_flags();
+
+		DMA1_Stream1->PAR = reinterpret_cast<uint32_t>(&UartLog::uart_regs()->TDR);
+		// Byte-wise, memory-increment, memory-to-peripheral, direct mode
+		DMA1_Stream1->CR = DMA_SxCR_MINC | DMA_SxCR_DIR_0;
+		DMA1_Stream1->FCR = 0;
+
+		// UART7 raises a DMA request whenever its TX FIFO has room. Harmless
+		// for direct (CPU putchar) writes while the stream is disabled.
+		UartLog::uart_regs()->CR3 |= USART_CR3_DMAT;
+	}
+
+	void start_dma(const uint8_t *ptr, size_t len) {
+		DMA1_Stream1->M0AR = dma_address(ptr);
+		DMA1_Stream1->NDTR = len;
+		clear_dma_flags();
+		DMA1_Stream1->CR |= DMA_SxCR_EN;
+		dma_running = true;
+	}
+
+	static void clear_dma_flags() {
+		DMA1->LIFCR = DMA_LIFCR_CTCIF1 | DMA_LIFCR_CHTIF1 | DMA_LIFCR_CTEIF1 | DMA_LIFCR_CDMEIF1 | DMA_LIFCR_CFEIF1;
+	}
+
+	// The M4 sees MCU SRAM (code/stack, where this object lives) at the
+	// 0x10000000 alias, but the other bus masters -- including DMA1 -- address
+	// the same RAM at 0x30000000. Translate for the DMA.
+	static uint32_t dma_address(const void *p) {
+		auto addr = reinterpret_cast<uint32_t>(p);
+		if (addr >= 0x1000'0000 && addr < 0x1006'0000)
+			return addr + 0x2000'0000;
+		return addr;
+	}
+
+	static void unlock() {
+		mdrivlib::HWSemaphore<UartLock>::unlock(M4LockId);
+	}
+
 	static constexpr uint32_t M4LockId = 2; // same process id UartLog's direct writes use on the M4
 
 	ConsoleBufferReader reader;
@@ -89,6 +163,8 @@ private:
 	size_t tx_pos = 0;
 	size_t tx_len = 0;
 	bool usb_was_active = false;
+	bool dma_running = false;
+	bool dma_ok = true;
 };
 
 } // namespace MetaModule

--- a/firmware/src/console/uart_console_drain.hh
+++ b/firmware/src/console/uart_console_drain.hh
@@ -14,10 +14,9 @@ namespace MetaModule
 // context.
 //
 // TX uses DMA: process() assembles a chunk into the bounce buffer and starts a
-// DMA transfer (DMA1 Stream1, DMAMUX1 request UART7_TX), and later calls just poll
-// for completion -- the M4 spends no cycles feeding the UART. If the DMA ever
-// reports a transfer error, we permanently fall back to topping up the UART TX
-// FIFO directly (still non-blocking).
+// DMA transfer.
+// If the DMA reports a transfer error, we permanently fall back feeding UART->TDR
+// fifo directly.
 //
 // Typing 'c' into the console enables per-core colored output; 'm' disables it
 class UartConsoleDrain {
@@ -56,9 +55,7 @@ public:
 				dma_running = false;
 				dma_ok = false;
 				unlock();
-				// Report through the very console we drain: this lands in the
-				// M4's buffer and comes out via the FIFO fallback path below.
-				// Deliberately not pr_err(): must be visible at any log level.
+				// Report through the same UART we drain, using printf so it's always visible
 				printf("<console: UART TX DMA error (LISR=0x%08x), using FIFO fallback>\n", (unsigned)flags);
 			} else if (DMA1->LISR & DMA_LISR_TCIF1) {
 				clear_dma_flags();
@@ -78,9 +75,8 @@ public:
 				return;
 		}
 
-		// Exclude cores doing direct (unbuffered) UART writes while we transmit.
-		// Those only happen during early boot, so contention is rare: just try
-		// again on the next process() call.
+		// Exclude cores doing direct UART writes while we transmit.
+		// Those only happen during early boot
 		if (mdrivlib::HWSemaphore<UartLock>::lock(M4LockId) != mdrivlib::HWSemaphoreFlag::LockedOk)
 			return;
 
@@ -125,8 +121,6 @@ private:
 		DMA1_Stream1->CR = DMA_SxCR_MINC | DMA_SxCR_DIR_0;
 		DMA1_Stream1->FCR = 0;
 
-		// UART7 raises a DMA request whenever its TX FIFO has room. Harmless
-		// for direct (CPU putchar) writes while the stream is disabled.
 		UartLog::uart_regs()->CR3 |= USART_CR3_DMAT;
 	}
 

--- a/firmware/src/console/uart_log.cc
+++ b/firmware/src/console/uart_log.cc
@@ -1,9 +1,10 @@
 #include "uart_log.hh"
 #include "conf/hsem_conf.hh"
 #include "drivers/hsem.hh"
-#include "util/term_codes.hh"
+#include <algorithm>
+#include <array>
 #include <cstdarg>
-#include <cstring>
+#include <cstdio>
 
 namespace MetaModule
 {
@@ -11,9 +12,7 @@ namespace MetaModule
 namespace
 {
 uint32_t core_id() {
-	// There are two separate static instances of UartLog: one in M4's memory and one in A7's memory
-	// (because this file is compiled+linked once for A7 and once for M4).
-	// The A7 instance has two cores, while the M4 instance just uses core_id() == 0
+	// The A7 instance of UartLog serves two cores; the M4 instance uses index 0
 #ifdef CORE_CA7
 	return std::min<uint32_t>(__get_MPIDR() & 0xFF, UartLog::NumCores - 1);
 #else
@@ -21,14 +20,18 @@ uint32_t core_id() {
 #endif
 }
 
-void spin_lock() {
+bool spin_lock() {
 #ifdef CORE_CA7
 	auto cid = __get_MPIDR() & 0xFF;
 #else
 	auto cid = 2;
 #endif
-	while (mdrivlib::HWSemaphore<UartLock>::lock(cid) != mdrivlib::HWSemaphoreFlag::LockedOk)
-		;
+	uint32_t tmout = 800'000'000;
+	while (mdrivlib::HWSemaphore<UartLock>::lock(cid) != mdrivlib::HWSemaphoreFlag::LockedOk) {
+		if (--tmout == 0)
+			return false;
+	}
+	return true;
 }
 
 void unlock() {
@@ -40,10 +43,71 @@ void unlock() {
 	mdrivlib::HWSemaphore<UartLock>::unlock(cid);
 }
 
+uint32_t disable_irqs() {
+#ifdef CORE_CA7
+	auto irqs_masked = __get_CPSR() & CPSR_I_Msk;
+	__disable_irq();
+	return irqs_masked;
+#else
+	auto irqs_masked = __get_PRIMASK();
+	__disable_irq();
+	return irqs_masked;
+#endif
+}
+
+void restore_irqs(uint32_t irqs_were_masked) {
+	if (!irqs_were_masked)
+		__enable_irq();
+}
+
+// Not shared between cores, but must align to cache lines or else two A7 cores could ping-pong
+struct alignas(64) WriteState {
+	std::atomic<uint32_t> reserve_pos{0}; // next free byte; all of [write_pos, reserve_pos) is claimed
+	std::atomic<uint32_t> depth{0};		  // how many writes on this core are in flight (nested)
+};
+
+std::array<WriteState, UartLog::NumCores> write_state;
+
+void write_reserved(ConcurrentBuffer *buff, WriteState &st, const char *ptr, size_t len) {
+	// Disable interrupts for ~5 instructions to reserve a block we'll write into
+	auto irqs = disable_irqs();
+	// Keep track of the nested interrupt depth (only the lowest level publishes)
+	st.depth = st.depth + 1;
+	const uint32_t start = st.reserve_pos;
+	// Reserve what we need, then restore interrupts
+	st.reserve_pos = start + len;
+	restore_irqs(irqs);
+
+	buff->copy_in({ptr, len}, start);
+
+	// Disable interrupts again to publish the block (which just bumps the pos up)
+	irqs = disable_irqs();
+	// Only the outermost caller needs to publish since this will write all inner callers too
+	if (st.depth == 1)
+		buff->publish(st.reserve_pos);
+	st.depth = st.depth - 1;
+	restore_irqs(irqs);
+}
+
+#ifdef CORE_CA7
+// Wait until M4 has drained the buffer enough for us to write. Times out if M4 is hung.
+void wait_for_space(ConcurrentBuffer *buff, WriteState &st, uint32_t len) {
+	uint32_t spins = 500'000'000; // very roughly seconds at 800MHz
+	while ((st.reserve_pos - buff->read_pos) + len > ConcurrentBuffer::Size) {
+		if (--spins == 0)
+			return;
+	}
+}
+#endif
+
 } // namespace
 
 void UartLog::init() {
 	log_uart.init();
+}
+
+USART_TypeDef *UartLog::uart_regs() {
+	return log_uart.uart();
 }
 
 void UartLog::putchar(char c) {
@@ -57,61 +121,67 @@ void UartLog::log(const char *format, ...) {
 	va_end(va);
 }
 
-void UartLog::use_usb(ConcurrentBuffer *usb_buffer) {
-	log_usb[core_id()] = usb_buffer;
-	port[core_id()] = UartLog::Port::USB;
+void UartLog::use_buffer(ConcurrentBuffer *buffer) {
+	auto core = core_id();
+	write_state[core].reserve_pos.store(buffer->write_pos.load());
+	write_state[core].depth.store(0);
+	log_buff[core] = buffer;
+	mode[core] = Mode::Buffered;
 }
 
-void UartLog::use_uart() {
-	port[core_id()] = UartLog::Port::Uart;
+void UartLog::use_direct() {
+	mode[core_id()] = Mode::Direct;
 }
 
 void UartLog::puts(const char *ptr) {
-	spin_lock();
-	while (*ptr) {
-		UartLog::putchar(*ptr++);
+	if (spin_lock()) {
+		while (*ptr) {
+			UartLog::putchar(*ptr++);
+		}
+		unlock();
 	}
-	unlock();
 }
 
 void UartLog::write_uart(const char *ptr, size_t len) {
-	spin_lock();
-	for (auto idx = 0u; idx < len; idx++) {
-		UartLog::putchar(*ptr++);
+	if (spin_lock()) {
+		for (auto idx = 0u; idx < len; idx++) {
+			UartLog::putchar(*ptr++);
+		}
+		unlock();
 	}
-	unlock();
 }
 
-//TODO: make this interrupt-safe
-void UartLog::write_usb(const char *ptr, size_t len) {
+void UartLog::write_buffered(const char *ptr, size_t len) {
 	auto core = core_id();
+	auto *buff = log_buff[core];
+	auto &st = write_state[core];
 
-	log_usb[core]->writer_ref_count++;
-	std::atomic_signal_fence(std::memory_order_release);
-	{
-		if (log_usb[core]->use_color) {
-			auto color = core_id() ? Term::Green : Term::Blue;
-			log_usb[core]->write({color, strlen(color)});
+#ifdef CORE_CA7
+	// Handle huge writes without overflowing the buffer, by throttling the
+	// write back until the M4 has made room for more.
+	// Not interrupt-safe, so only do this if depth == 0
+	if (st.depth == 0) {
+		constexpr size_t MaxChunk = ConcurrentBuffer::Size / 4;
+		while (len > 0) {
+			const auto chunk = std::min(len, MaxChunk);
+			wait_for_space(buff, st, chunk);
+			write_reserved(buff, st, ptr, chunk);
+			ptr += chunk;
+			len -= chunk;
 		}
-
-		log_usb[core]->write({ptr, len});
-
-		if (log_usb[core]->use_color) {
-			log_usb[core]->write({Term::Normal, strlen(Term::Normal)});
-		}
+		return;
 	}
-	std::atomic_signal_fence(std::memory_order_release);
-	log_usb[core]->writer_ref_count--;
+#endif
+
+	write_reserved(buff, st, ptr, len);
 }
 
 void UartLog::write_stdout(const char *ptr, size_t len) {
-	if (UartLog::port[core_id()] == UartLog::Port::Uart) {
-		UartLog::write_uart(ptr, len);
-
-	} else if (UartLog::port[core_id()] == UartLog::Port::USB) {
-		if (UartLog::log_usb[core_id()])
-			UartLog::write_usb(ptr, len);
-	}
+	auto core = core_id();
+	if (mode[core] == Mode::Buffered && log_buff[core])
+		write_buffered(ptr, len);
+	else
+		write_uart(ptr, len);
 }
 
 // This is used for bypassing write() and going direct to UART

--- a/firmware/src/console/uart_log.cc
+++ b/firmware/src/console/uart_log.cc
@@ -1,6 +1,7 @@
 #include "uart_log.hh"
 #include "conf/hsem_conf.hh"
 #include "drivers/hsem.hh"
+#include "drivers/rcc.hh"
 #include <algorithm>
 #include <array>
 #include <cstdarg>
@@ -103,15 +104,27 @@ void wait_for_space(ConcurrentBuffer *buff, WriteState &st, uint32_t len) {
 } // namespace
 
 void UartLog::init() {
-	log_uart.init();
+	uart_regs();
 }
 
 USART_TypeDef *UartLog::uart_regs() {
+#ifdef CORE_CA7
 	return log_uart.uart();
+#else
+	// Let A7 enable UART, M4 just enables the clock
+	[[maybe_unused]] static bool once = [] {
+		mdrivlib::core_m4::RCC_Enable::UART7_::set();
+		return true;
+	}();
+	return reinterpret_cast<USART_TypeDef *>(LogUartConfig.base_addr);
+#endif
 }
 
 void UartLog::putchar(char c) {
-	log_uart.putchar(c);
+	auto uart = uart_regs();
+	uart->TDR = c;
+	while ((uart->ISR & USART_ISR_TXFE) == 0)
+		;
 }
 
 void UartLog::log(const char *format, ...) {

--- a/firmware/src/console/uart_log.hh
+++ b/firmware/src/console/uart_log.hh
@@ -7,23 +7,37 @@
 namespace MetaModule
 {
 
+// Console log output for all cores.
+//
+// Each core starts in Direct mode: printf() writes synchronously to the UART
+// (blocking and shared via a hardware semaphore).
+// During startup each core switches itself to Buffered mode (use_buffer()),
+// printf() then just writes into the core's ConcurrentBuffer and the M4 core
+// asynchronously drains all buffers to the UART, or to USB CDC if a console
+// host is connected.
 struct UartLog {
 private:
 	static inline mdrivlib::LazyUart<LogUartConfig> log_uart;
 
 public:
-	enum class Port { Uart, USB };
+	enum class Mode { Direct, Buffered };
 
+	// There are two separate static instances of these: one in the M4's memory and
+	// one in the A7's (this file is compiled+linked once for each image). The A7
+	// instance has two cores; the M4 instance just uses index 0.
 	static constexpr size_t NumCores = 2;
 
-	static inline std::array<ConcurrentBuffer *, NumCores> log_usb = {nullptr, nullptr};
-	static inline std::array<Port, NumCores> port{Port::Uart, Port::Uart};
+	static inline std::array<ConcurrentBuffer *, NumCores> log_buff = {nullptr, nullptr};
+	static inline std::array<Mode, NumCores> mode{Mode::Direct, Mode::Direct};
 
 	UartLog() {
 		init();
 	}
 
 	static void init();
+
+	// Raw register access for the non-blocking drain (M4)
+	static USART_TypeDef *uart_regs();
 
 	static void putchar(char c);
 
@@ -32,10 +46,13 @@ public:
 	static void puts(const char *ptr);
 
 	static void write_uart(const char *ptr, size_t len);
-	static void write_usb(const char *ptr, size_t len);
+	static void write_buffered(const char *ptr, size_t len);
 	static void write_stdout(const char *ptr, size_t len);
 
-	static void use_usb(ConcurrentBuffer *usb_buffer);
-	static void use_uart();
+	// Switch the calling core's printf() to buffered (asynchronous) mode
+	static void use_buffer(ConcurrentBuffer *buffer);
+
+	// Back to synchronous blocking UART writes (early-boot default)
+	static void use_direct();
 };
 } // namespace MetaModule

--- a/firmware/src/console/uart_log.hh
+++ b/firmware/src/console/uart_log.hh
@@ -23,8 +23,9 @@ public:
 	enum class Mode { Direct, Buffered };
 
 	// There are two separate static instances of these: one in the M4's memory and
-	// one in the A7's (this file is compiled+linked once for each image). The A7
-	// instance has two cores; the M4 instance just uses index 0.
+	// one in the A7's (this file is compiled+linked once for each image).
+	// With NumCores == 2, A7 will have two buffers pointers, and M4 will have two also
+	// but M4 will always have the second one as nullptr since nothing uses it.
 	static constexpr size_t NumCores = 2;
 
 	static inline std::array<ConcurrentBuffer *, NumCores> log_buff = {nullptr, nullptr};

--- a/firmware/src/core_a7/aux_core_main.cc
+++ b/firmware/src/core_a7/aux_core_main.cc
@@ -18,6 +18,7 @@
 #include "load_test/test_manager.hh"
 #include "ramdisk_ops.hh"
 #include "system/print_time.hh"
+#include "uart_log.hh"
 #include "usb/usb_status_reader.hh"
 
 using FrameBufferT =
@@ -36,13 +37,12 @@ extern "C" void aux_core_main() {
 	while (HWSemaphore<MainCoreReady>::is_locked() || HWSemaphore<M4CoreReady>::is_locked())
 		;
 
+	// This core's printf() is buffered and drained asynchronously by the M4
+	UartLog::use_buffer(A7SharedMemoryS::ptrs.console_buffer);
+
 	pr_info("A7 Core 2 starting\n");
 
 	start_module_threads();
-
-#ifdef CONSOLE_USE_USB
-	UartLog::use_usb(A7SharedMemoryS::ptrs.console_buffer);
-#endif
 
 	UsbVideoBuffer::set_frame_buffer(SharedMemoryS::ptrs.uvc_framebuffer);
 

--- a/firmware/src/core_a7/aux_core_main.cc
+++ b/firmware/src/core_a7/aux_core_main.cc
@@ -71,8 +71,10 @@ extern "C" void aux_core_main() {
 			;
 	}
 
+	// Tell the M4 which USB device class to present (MIDI, Video, or the
+	// Debug Console). The M4 defaults to MIDI until this arrives.
 	auto usb_device_mode = ui.get_settings().usb_device_mode;
-	if (usb_device_mode != UsbDeviceMode::Cdc) {
+	if (usb_device_mode != UsbDeviceMode::Midi) {
 		while (!DeviceSettingsProxy::send_device_mode(usb_device_mode))
 			;
 	}

--- a/firmware/src/core_a7/main.cc
+++ b/firmware/src/core_a7/main.cc
@@ -99,11 +99,9 @@ int main() {
 	pr_info("A7 Core 1 initialized\n");
 	// Note: from after the HAL_Delay(50) until here, it takes 20ms
 
-#ifdef CONSOLE_USE_USB
-	printf("Stopping UART buffer\n");
-	UartLog::use_usb(&StaticBuffers::console_a7_0_buff);
-	printf("Using USB buffer\n");
-#endif
+	// From here on, this core's printf() is buffered and drained asynchronously
+	// by the M4 (to the console UART, or to USB CDC when a console host connects)
+	UartLog::use_buffer(&StaticBuffers::console_a7_0_buff);
 
 	mdrivlib::HWSemaphore<RunningPatchTests>::lock();
 

--- a/firmware/src/core_a7/static_buffers.cc
+++ b/firmware/src/core_a7/static_buffers.cc
@@ -84,20 +84,12 @@ void init() {
 			frame = StreamConf::Audio::AudioInFrame{};
 	}
 
-	console_a7_0_buff.writer_ref_count = 0;
-	console_a7_0_buff.current_write_pos = 0;
-	console_a7_0_buff.buffer.data[0] = 0;
-	console_a7_0_buff.use_color = false;
-
-	console_a7_1_buff.writer_ref_count = 0;
-	console_a7_1_buff.current_write_pos = 0;
-	console_a7_1_buff.buffer.data[0] = 0;
-	console_a7_1_buff.use_color = false;
-
-	console_m4_buff.writer_ref_count = 0;
-	console_m4_buff.current_write_pos = 0;
-	console_m4_buff.buffer.data[0] = 0;
-	console_m4_buff.use_color = false;
+	console_a7_0_buff.write_pos = 0;
+	console_a7_0_buff.read_pos = 0;
+	console_a7_1_buff.write_pos = 0;
+	console_a7_1_buff.read_pos = 0;
+	console_m4_buff.write_pos = 0;
+	console_m4_buff.read_pos = 0;
 }
 
 }; // namespace StaticBuffers

--- a/firmware/src/core_m4/main_m4.cc
+++ b/firmware/src/core_m4/main_m4.cc
@@ -1,4 +1,5 @@
 #include "conf/hsem_conf.hh"
+#include "console/uart_console_drain.hh"
 #include "controls.hh"
 #include "core_intercom/shared_memory.hh"
 #include "drivers/hsem.hh"
@@ -43,6 +44,11 @@ int main() {
 
 	pr_info("M4 starting\n");
 
+	// Drains all cores' buffered printf() output to the UART (in the loops below)
+	UartConsoleDrain console_drain{{SharedMemoryS::ptrs.console_a7_0_buff,
+									SharedMemoryS::ptrs.console_a7_1_buff,
+									SharedMemoryS::ptrs.console_m4_buff}};
+
 	// USB
 	UsbManager usb{{SharedMemoryS::ptrs.console_a7_0_buff,
 					SharedMemoryS::ptrs.console_a7_1_buff,
@@ -65,6 +71,11 @@ int main() {
 	WifiInterface::init(&fs_messages.get_patch_storage());
 	WifiInterface::start();
 
+	// From here on, this core's printf() is buffered and drained asynchronously
+	// by console_drain (everything above logs synchronously, so a hang during
+	// early M4 init still shows its logs)
+	UartLog::use_buffer(SharedMemoryS::ptrs.console_m4_buff);
+
 	// Controls
 	Controls controls{*SharedMemoryS::ptrs.param_block, usb.get_midi_host(), usb.get_midi_device(), usb};
 
@@ -78,12 +89,14 @@ int main() {
 		controls.process();
 		usb.process();
 		sd.process();
+		console_drain.process();
 	}
 
 	// Wait until drive is mounted
 	if (usb.is_drive_detected()) {
 		while (!usb.is_drive_mounted()) {
 			usb.process();
+			console_drain.process();
 		}
 	}
 
@@ -91,12 +104,8 @@ int main() {
 
 	HWSemaphore<MetaModule::M4CoreReady>::unlock();
 
-	// Publish the detailed USB connection status to the A7 (GUI + plugin SDK)
-	// whenever the connection changes OR the attached device's details are
-	// (re)captured. The device-info seq is needed because for a USB drive the
-	// connection enum flips at CLASS_SELECTED, before the descriptor details are
-	// captured at CLASS_ACTIVE -- so the enum alone would publish empty details.
 	UsbConnection last_published_conn = UsbConnection::None;
+	// usb.get_device_info_seq() increments on disconnection and class activation
 	uint32_t last_published_info_seq = usb.get_device_info_seq();
 
 	while (true) {
@@ -104,6 +113,7 @@ int main() {
 
 		usb.process();
 		sd.process();
+		console_drain.process();
 
 		auto conn = usb.get_connection_status();
 		auto info_seq = usb.get_device_info_seq();

--- a/firmware/src/gui/pages/prefs_tab.hh
+++ b/firmware/src/gui/pages/prefs_tab.hh
@@ -450,13 +450,18 @@ private:
 	}
 
 	static int usb_device_mode_to_index(UsbDeviceMode mode) {
-		// "Console" is a hidden option, not user-facing
-		return mode == UsbDeviceMode::Video ? 1 : 0;
+		return mode == UsbDeviceMode::Video ? 1 : mode == UsbDeviceMode::Cdc ? 2 : 0;
 	}
 
 	UsbDeviceMode read_usb_mode_dropdown() {
-		return lv_dropdown_get_selected(usb_section.device_mode_dropdown) == 1 ? UsbDeviceMode::Video :
-																				 UsbDeviceMode::Midi;
+		switch (lv_dropdown_get_selected(usb_section.device_mode_dropdown)) {
+			case 1:
+				return UsbDeviceMode::Video;
+			case 2:
+				return UsbDeviceMode::Cdc; // "Debug"
+			default:
+				return UsbDeviceMode::Midi;
+		}
 	}
 
 	bool read_video_mirror_check() {

--- a/firmware/src/gui/slsexport/prefs_section_usb.cc
+++ b/firmware/src/gui/slsexport/prefs_section_usb.cc
@@ -14,7 +14,7 @@ void PrefsSectionUSB::create(lv_obj_t *parent) {
 
 	create_prefs_note(role_cont, "Select if MetaModule can be\n a USB host, device, or both\n");
 
-	auto mode_cont = create_prefs_labeled_dropdown(parent, "Device Mode:", "MIDI\nVideo");
+	auto mode_cont = create_prefs_labeled_dropdown(parent, "Device Mode:", "MIDI\nVideo\nConsole");
 	device_mode_dropdown = lv_obj_get_child(mode_cont, 1);
 	lv_obj_set_width(device_mode_dropdown, 90);
 

--- a/firmware/src/usb/device_cdc/usb_serial_device.cc
+++ b/firmware/src/usb/device_cdc/usb_serial_device.cc
@@ -1,4 +1,5 @@
 #include "usb_serial_device.hh"
+#include "console/console_routing.hh"
 #include "console/pr_dbg.hh"
 
 extern USBD_CDC_ItfTypeDef USBD_CDC_fops;
@@ -14,17 +15,12 @@ USBD_CDC_LineCodingTypeDef LineCoding = {
 };
 }
 
-UsbSerialDevice::UsbSerialDevice(USBD_HandleTypeDef *pDevice, std::array<ConcurrentBuffer *, 3> console_buffers)
+UsbSerialDevice::UsbSerialDevice(USBD_HandleTypeDef *pDevice,
+								 std::array<ConcurrentBuffer *, MetaModule::ConsoleBufferReader::NumBuffers> buffers)
 	: pdev{pDevice}
-	, console_buffers{console_buffers} {
+	, reader{buffers} {
 	rx_buffer.resize(256);
 	_instance = this;
-}
-
-void UsbSerialDevice::init_buffers() {
-	_instance = this;
-	for (auto i = 0u; auto const &buff : console_buffers)
-		current_read_pos[i++] = buff->current_write_pos;
 }
 
 void UsbSerialDevice::start() {
@@ -36,8 +32,6 @@ void UsbSerialDevice::start() {
 		return;
 	}
 
-	init_buffers();
-
 	USBD_RegisterClass(pdev, USBD_CDC_CLASS);
 	USBD_CDC_RegisterInterface(pdev, &USBD_CDC_fops);
 	USBD_Start(pdev);
@@ -46,6 +40,7 @@ void UsbSerialDevice::start() {
 
 void UsbSerialDevice::stop() {
 	pr_info("Stopping UsbSerialDevice\n");
+	set_console_routing(false);
 	USBD_Stop(pdev);
 	USBD_DeInit(pdev);
 }
@@ -56,75 +51,63 @@ void UsbSerialDevice::soft_stop() {
 	// hpcd->State == READY so the next USBD_Init won't re-run MspInit, which
 	// avoids toggling USBO_CLK on a live VBUS bus.
 	pr_info("Stopping UsbSerialDevice\n");
+	set_console_routing(false);
 	USBD_Stop(pdev);
 }
 
-void UsbSerialDevice::transmit_buffers(Destination dest) {
-	auto transmit = [this, dest = dest](uint8_t *ptr, int len) {
-		if (dest == Destination::USB) {
-			USBD_CDC_SetTxBuffer(pdev, ptr, len);
-
-			if (auto err = USBD_CDC_TransmitPacket(pdev) == USBD_OK) {
-				is_transmitting = true;
-				last_transmission_tm = HAL_GetTick();
-
-			} else if (err != USBD_BUSY) {
-				pr_dbg("USB CDC Transmit Error: %d\n", err);
-			}
-		}
-
-		if (dest == Destination::UART) {
-			while (len--)
-				putchar(*ptr++);
-		}
-	};
-
-	// Don't transmit if we already are transmitting
-	// But have a 100ms timeout in case of a USB error
-	if (is_transmitting) {
-		if (HAL_GetTick() - last_transmission_tm > 100) {
-			is_transmitting = false;
-			last_transmission_tm = HAL_GetTick();
-		} else
-			return;
-	}
-
-	// Scan buffers for data to transmit, and exit after first transmission
-	for (auto i = 0u; auto *buff : console_buffers) {
-		buff->use_color = use_color;
-
-		if (buff->writer_ref_count == 0) {
-			auto start_pos = current_read_pos[i];
-			unsigned end_pos = buff->current_write_pos; //.load(std::memory_order_acquire);
-			end_pos = end_pos & buff->buffer.SIZEMASK;
-
-			if (start_pos > end_pos) {
-				// Data to transmit spans the "seam" of the circular buffer,
-				// Send the first chunk
-				transmit(&buff->buffer.data[start_pos], buff->buffer.data.size() - start_pos);
-				current_read_pos[i] = 0;
-				return;
-
-			} else if (start_pos < end_pos) {
-				transmit(&buff->buffer.data[start_pos], end_pos - start_pos);
-				current_read_pos[i] = end_pos;
-				return;
-			}
-		}
-		i++;
+void UsbSerialDevice::set_console_routing(bool active) {
+	if (active == MetaModule::ConsoleRouting::usb_console_active)
+		return;
+	MetaModule::ConsoleRouting::usb_console_active = active;
+	if (active) {
+		// The UART drain already printed everything up to this point
+		reader.resync();
+		is_transmitting = false;
+		tx_pending = 0;
 	}
 }
 
 void UsbSerialDevice::process() {
-	transmit_buffers(Destination::USB);
+	// Only drain the console buffers while a host is enumerated and awake;
+	// otherwise the UART drain does it
+	set_console_routing(pdev->dev_state == USBD_STATE_CONFIGURED);
+
+	if (MetaModule::ConsoleRouting::usb_console_active)
+		transmit_pending();
 }
 
-void UsbSerialDevice::forward_to_uart() {
-	transmit_buffers(Destination::UART);
+void UsbSerialDevice::transmit_pending() {
+	// Don't start a transmission if one is in flight,
+	// but time out after 100ms in case of a USB error
+	if (is_transmitting) {
+		if (HAL_GetTick() - last_transmission_tm > 100)
+			is_transmitting = false;
+		else
+			return;
+	}
+
+	if (tx_pending == 0)
+		tx_pending = reader.next_chunk(tx_bounce);
+	if (tx_pending == 0)
+		return;
+
+	USBD_CDC_SetTxBuffer(pdev, tx_bounce.data(), tx_pending);
+
+	auto err = USBD_CDC_TransmitPacket(pdev);
+	if (err == USBD_OK) {
+		is_transmitting = true;
+		last_transmission_tm = HAL_GetTick();
+		tx_pending = 0; // tx_bounce stays untouched until CDC_TransmitCplt
+
+	} else if (err != USBD_BUSY) {
+		pr_dbg("USB CDC Transmit Error: %d\n", static_cast<int>(err));
+		tx_pending = 0; // unrecoverable: drop the chunk
+	}
+	// USBD_BUSY: keep tx_pending, retry next process()
 }
 
 int8_t UsbSerialDevice::CDC_Itf_Init() {
-	USBD_CDC_SetTxBuffer(_instance->pdev, _instance->console_buffers[0]->buffer.data.data(), 0);
+	USBD_CDC_SetTxBuffer(_instance->pdev, _instance->tx_bounce.data(), 0);
 	USBD_CDC_SetRxBuffer(_instance->pdev, _instance->rx_buffer.data()); // FIXME: how does the driver prevent overflow?
 	return USBD_OK;
 }
@@ -149,9 +132,9 @@ int8_t UsbSerialDevice::CDC_Itf_DeInit() {
   */
 int8_t UsbSerialDevice::CDC_Itf_Receive(uint8_t *Buf, uint32_t *Len) {
 	if (*Buf == 'c')
-		_instance->use_color = true;
+		_instance->reader.set_color(true);
 	if (*Buf == 'm')
-		_instance->use_color = false;
+		_instance->reader.set_color(false);
 
 	pr_dbg("Rx: ");
 	uint32_t len = *Len;

--- a/firmware/src/usb/device_cdc/usb_serial_device.hh
+++ b/firmware/src/usb/device_cdc/usb_serial_device.hh
@@ -1,47 +1,46 @@
 #pragma once
-#include "console/concurrent_buffer.hh"
+#include "console/console_buffer_reader.hh"
 #include "usbd_cdc.h"
 #include "usbd_core.h"
-#include "util/circular_buffer_ext.hh"
+#include <array>
 #include <vector>
 
+// USB CDC console device. While a host has enumerated us, this becomes the
+// active drain of the per-core console buffers (the UART drain idles, see
+// console_routing.hh), forwarding all cores' printf() output to the host.
 class UsbSerialDevice {
 
 public:
-	UsbSerialDevice(USBD_HandleTypeDef *pDevice, std::array<ConcurrentBuffer *, 3> console_buffers);
+	UsbSerialDevice(USBD_HandleTypeDef *pDevice,
+					std::array<ConcurrentBuffer *, MetaModule::ConsoleBufferReader::NumBuffers> console_buffers);
 	void process();
 	void start();
 	void stop();
 	void soft_stop();
 
-	void init_buffers();
-	void forward_to_uart();
-
 private:
 	USBD_HandleTypeDef *pdev;
 
-	std::array<ConcurrentBuffer *, 3> console_buffers;
-	std::array<unsigned, 3> current_read_pos{};
+	MetaModule::ConsoleBufferReader reader;
 
 	std::vector<uint8_t> rx_buffer{}; // force to be on heap
 
+	// Holds the chunk currently being sent; must stay stable until CDC_TransmitCplt
+	std::array<uint8_t, 512> tx_bounce{};
+	size_t tx_pending = 0;
+
 	bool is_transmitting = false;
 	uint32_t last_transmission_tm = 0;
+
+	void transmit_pending();
+	void set_console_routing(bool active);
 
 	static int8_t CDC_Itf_Init();
 	static int8_t CDC_Itf_DeInit();
 	static int8_t CDC_Itf_Control(uint8_t cmd, uint8_t *pbuf, uint16_t length);
 	static int8_t CDC_Itf_Receive(uint8_t *pbuf, uint32_t *Len);
 	static int8_t CDC_TransmitCplt(uint8_t *pbuf, uint32_t *Len, uint8_t epnum);
-	static void Error_Handler();
-	static void ComPort_Config();
-	static void TIM_Config();
 
 	static USBD_CDC_ItfTypeDef USBD_CDC_fops;
 	static inline UsbSerialDevice *_instance;
-
-	enum class Destination { UART, USB };
-	void transmit_buffers(Destination dest);
-
-	bool use_color = false;
 };

--- a/firmware/src/usb/usb_device_manager.hh
+++ b/firmware/src/usb/usb_device_manager.hh
@@ -115,12 +115,6 @@ struct UsbDeviceManager {
 			midi.process(); // idle-kick drain of any app-queued TX
 	}
 
-	void process_disconnected() {
-		if (mode == UsbDeviceMode::Cdc)
-			// Still process serial because if USB is not connected, we forward console messages to UART
-			serial.forward_to_uart();
-	}
-
 #ifdef USE_RAMDISK_USB
 	RamDiskOps ramdiskops;
 	UsbDriveDevice drive;

--- a/firmware/src/usb/usb_host_manager.hh
+++ b/firmware/src/usb/usb_host_manager.hh
@@ -103,6 +103,20 @@ public:
 		USBH_DeInit(&usbhost); //sets hhcd to NULL?
 	}
 
+	// Debug aid: snapshot the USBH library state machine (used by the
+	// USB_ATTACH_CYCLE_TEST harness on a failed attach)
+	void print_state_debug() {
+		printf("[usbh] gState=%d Enum=%d Req=%d Ctl.state=%d Ctl.err=%u Timeout=%u PortEnabled=%u RstCnt=%u\n",
+			   (int)usbhost.gState,
+			   (int)usbhost.EnumState,
+			   (int)usbhost.RequestState,
+			   (int)usbhost.Control.state,
+			   (unsigned)usbhost.Control.errorcount,
+			   (unsigned)usbhost.Timeout,
+			   (unsigned)usbhost.device.PortEnabled,
+			   (unsigned)usbhost.device.RstCnt);
+	}
+
 	void process() {
 		USBH_Process(&usbhost);
 		midi_host.process();

--- a/firmware/src/usb/usb_manager.hh
+++ b/firmware/src/usb/usb_manager.hh
@@ -303,8 +303,6 @@ public:
 				usb_device.process();
 
 			update_role_fallback();
-		} else { // None or AsHost:
-				 // usb_device.process_disconnected();
 		}
 
 		// While forced to the device role and idle (no host attached), the port

--- a/firmware/src/usb/usb_manager.hh
+++ b/firmware/src/usb/usb_manager.hh
@@ -12,28 +12,6 @@
 #include "usb/usb_host_manager.hh"
 #include "usb/usb_role_mode.hh"
 
-// Set to 1 to build the static sink+host characterization firmware:
-// - FUSB302 presents Rd on both CCs, statically -- no toggling, no probes, no
-//   PD, nothing ever perturbs the CC lines
-// - The host data stack (HCD) runs from boot; the device stack (PCD) never
-//   starts, so OUR D+ pull-up never appears: every D+ edge on a scope is the
-//   partner's
-// - VBUS_ENABLE is never driven
-// - One compact log line per 200ms: CC levels, VBUS, HPRT, attach state.
-// If the partner enumerates, the full MIDI path runs normally.
-// For characterizing partners like the OXI One "Device Self Powered".
-#ifndef USB_STATIC_SINK_HOST_TEST
-#define USB_STATIC_SINK_HOST_TEST 0
-#endif
-
-// Variant for the test above: 0 = present Rd (sink persona; partner Rp reads
-// BC_LVL 1/2), 1 = present Rp (source persona; partner Rd reads BC_LVL 1/2,
-// open line reads 3). Tests whether a partner (OXI One) latches its data role
-// from what its CC sees at cable-insert.
-#ifndef USB_STATIC_TEST_PRESENT_RP
-#define USB_STATIC_TEST_PRESENT_RP 1
-#endif
-
 namespace MetaModule
 {
 
@@ -78,7 +56,6 @@ class UsbManager {
 	// are handled at the CC level in the FUSB302 driver: on the CC-drop-with-
 	// VBUS signature it flips to a static-Rp host attach; see
 	// FUSB302::Device::attach_as_static_src.)
-	uint32_t static_test_log_tm = 0;
 	static constexpr uint32_t RolePhaseTimeoutMs = 2000;
 	static constexpr uint32_t PdTickMs = 50;
 	// If the partner hasn't enumerated us (nor swapped roles on its own) by
@@ -112,24 +89,8 @@ public:
 		else
 			pr_err("Can't communicate with FUSB302\n");
 
-#if USB_STATIC_SINK_HOST_TEST
-		pr_info("USB: STATIC %s+HOST TEST (HCD from boot, no PCD, no VBUS sourcing)\n",
-				USB_STATIC_TEST_PRESENT_RP ? "SRC (Rp presented)" : "SINK (Rd presented)");
-		usb_host.init();
-		mdrivlib::InterruptControl::disable_irq(OTG_IRQn);
-		mdrivlib::InterruptControl::set_irq_priority(OTG_IRQn, 3, 0);
-		mdrivlib::InterruptManager::register_isr(OTG_IRQn, [] { HAL_HCD_IRQHandler(&UsbHostManager::hhcd); });
-#if USB_STATIC_TEST_PRESENT_RP
-		usbctl.configure_static_src();
-#else
-		usbctl.configure_static_sink();
-#endif
-		state = FUSB302::Device::ConnectedState::AsDevice;
-		host_fallback = true;
-		usb_host.start(false); // never source VBUS in this experiment
-		mdrivlib::InterruptControl::enable_irq(OTG_IRQn);
-		return;
-#endif
+		if (start_static_sink_host_test())
+			return;
 
 		// tm = HAL_GetTick();
 		pr_dbg("Starting USB role polling\n");
@@ -242,21 +203,8 @@ public:
 	}
 
 	void process() {
-#if USB_STATIC_SINK_HOST_TEST
-		usb_host.process();
-		if (HAL_GetTick() - static_test_log_tm >= 200) {
-			static_test_log_tm = HAL_GetTick();
-			auto cc = usbctl.read_both_cc();
-			pr_info("[%u] CC1=%u CC2=%u VBUS=%u HPRT=%08x attached=%d\n",
-					(unsigned)static_test_log_tm,
-					cc.cc1,
-					cc.cc2,
-					cc.vbusok,
-					(unsigned)usb_host.read_port_status(),
-					(int)usb_host.is_device_attached());
-		}
-		return;
-#endif
+		if (process_static_sink_host_test())
+			return;
 
 		// INT_N is a level interrupt: the FUSB302 holds it asserted while any
 		// unmasked event is pending, releasing it only when handle_interrupt()
@@ -321,6 +269,8 @@ public:
 				}
 			}
 		}
+
+		run_attach_cycle_test();
 
 		//DEBUG: toggle Pin0 when we're DRD polling
 		// if ((HAL_GetTick() - tm) > 400) {
@@ -446,6 +396,12 @@ public:
 	}
 
 private:
+	// Test/characterization hooks -- defined in usb_manager_tests.hh; no-ops
+	// unless the corresponding macro there is enabled
+	bool start_static_sink_host_test();
+	bool process_static_sink_host_test();
+	void run_attach_cycle_test();
+
 	// While CC-attached as a sink, a compliant partner is a host and will
 	// enumerate us promptly. A non-compliant self-powered device presenting
 	// Rp + VBUS never will. If we haven't been enumerated after a timeout,
@@ -585,3 +541,8 @@ private:
 	}
 };
 } // namespace MetaModule
+
+// Test/characterization builds (USB_STATIC_SINK_HOST_TEST, USB_STATIC_TEST_PRESENT_RP,
+// USB_ATTACH_CYCLE_TEST) are in usb_manager_tests.hh.
+// With the test macros off (the default) the hooks are no-ops.
+#include "usb/usb_manager_tests.hh"

--- a/firmware/src/usb/usb_manager_tests.hh
+++ b/firmware/src/usb/usb_manager_tests.hh
@@ -1,0 +1,139 @@
+#pragma once
+#include "usb/usb_manager.hh"
+
+// Test/characterization builds for UsbManager. Each test is enabled by setting
+// its macro to 1 (all default to 0); with the macros off, the hooks defined
+// here compile to no-ops, so normal builds carry no test code. Included at the
+// bottom of usb_manager.hh so the hook definitions see the complete class.
+
+// Set to 1 to build the static sink+host characterization firmware:
+// - FUSB302 presents Rd on both CCs, statically -- no toggling, no probes, no
+//   PD, nothing ever perturbs the CC lines
+// - The host data stack (HCD) runs from boot; the device stack (PCD) never
+//   starts, so OUR D+ pull-up never appears: every D+ edge on a scope is the
+//   partner's
+// - VBUS_ENABLE is never driven
+// - One compact log line per 200ms: CC levels, VBUS, HPRT, attach state.
+// If the partner enumerates, the full MIDI path runs normally.
+// For characterizing partners like the OXI One "Device Self Powered".
+#ifndef USB_STATIC_SINK_HOST_TEST
+#define USB_STATIC_SINK_HOST_TEST 0
+#endif
+
+// Variant for the test above: 0 = present Rd (sink persona; partner Rp reads
+// BC_LVL 1/2), 1 = present Rp (source persona; partner Rd reads BC_LVL 1/2,
+// open line reads 3). Tests whether a partner (OXI One) latches its data role
+// from what its CC sees at cable-insert.
+#ifndef USB_STATIC_TEST_PRESENT_RP
+#define USB_STATIC_TEST_PRESENT_RP 1
+#endif
+
+// Set to 1 to build an attach-reliability test firmware: whenever a host-mode
+// attach resolves (a class connects, or 5s pass without one), log a running
+// ok/fail tally with port diagnostics, then tear the connection down (VBUS
+// off, so a bus-powered partner cold-reboots -- a true replug) and re-poll.
+// Plug a device in once and it re-attaches forever; read the tally over the
+// console. For chasing intermittent attach failures (found the Inotech Grid
+// attach-bounce bug, see USBH_LL_Connect in usbh_core.c).
+#ifndef USB_ATTACH_CYCLE_TEST
+#define USB_ATTACH_CYCLE_TEST 0
+#endif
+
+namespace MetaModule
+{
+
+// Replaces UsbManager::start() when enabled (returns true if it took over)
+inline bool UsbManager::start_static_sink_host_test() {
+#if USB_STATIC_SINK_HOST_TEST
+	pr_info("USB: STATIC %s+HOST TEST (HCD from boot, no PCD, no VBUS sourcing)\n",
+			USB_STATIC_TEST_PRESENT_RP ? "SRC (Rp presented)" : "SINK (Rd presented)");
+	usb_host.init();
+	mdrivlib::InterruptControl::disable_irq(OTG_IRQn);
+	mdrivlib::InterruptControl::set_irq_priority(OTG_IRQn, 3, 0);
+	mdrivlib::InterruptManager::register_isr(OTG_IRQn, [] { HAL_HCD_IRQHandler(&UsbHostManager::hhcd); });
+#if USB_STATIC_TEST_PRESENT_RP
+	usbctl.configure_static_src();
+#else
+	usbctl.configure_static_sink();
+#endif
+	state = FUSB302::Device::ConnectedState::AsDevice;
+	host_fallback = true;
+	usb_host.start(false); // never source VBUS in this experiment
+	mdrivlib::InterruptControl::enable_irq(OTG_IRQn);
+	return true;
+#else
+	return false;
+#endif
+}
+
+// Replaces UsbManager::process() when enabled (returns true if it took over)
+inline bool UsbManager::process_static_sink_host_test() {
+#if USB_STATIC_SINK_HOST_TEST
+	usb_host.process();
+	static uint32_t log_tm = 0;
+	if (HAL_GetTick() - log_tm >= 200) {
+		log_tm = HAL_GetTick();
+		auto cc = usbctl.read_both_cc();
+		pr_info("[%u] CC1=%u CC2=%u VBUS=%u HPRT=%08x attached=%d\n",
+				(unsigned)log_tm,
+				cc.cc1,
+				cc.cc2,
+				cc.vbusok,
+				(unsigned)usb_host.read_port_status(),
+				(int)usb_host.is_device_attached());
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+// Runs at the end of UsbManager::process() when enabled.
+// printf (not pr_*) so the tally shows at any LOG_LEVEL.
+inline void UsbManager::run_attach_cycle_test() {
+#if USB_ATTACH_CYCLE_TEST
+	using enum FUSB302::Device::ConnectedState;
+	static uint32_t oks = 0, fails = 0, attach_tm = 0;
+	static bool in_attach = false;
+
+	if (state != AsHost) {
+		in_attach = false;
+		return;
+	}
+
+	if (!in_attach) {
+		in_attach = true;
+		attach_tm = HAL_GetTick();
+		return;
+	}
+
+	auto conn = get_connection_status();
+	const bool ok = (conn == UsbConnection::HostMidiDevice) || (conn == UsbConnection::HostUsbDrive);
+	const uint32_t elapsed = HAL_GetTick() - attach_tm;
+	if (!ok && elapsed <= 5000)
+		return;
+
+	ok ? oks++ : fails++;
+	printf("CYCLETEST %s: ok=%u fail=%u t=%ums HPRT=%08x attached=%d otg_irq_en=%u\n",
+		   ok ? "OK" : "FAIL",
+		   (unsigned)oks,
+		   (unsigned)fails,
+		   (unsigned)elapsed,
+		   (unsigned)usb_host.read_port_status(),
+		   (int)usb_host.is_device_attached(),
+		   (unsigned)NVIC_GetEnableIRQ(OTG_IRQn));
+	if (!ok)
+		usb_host.print_state_debug();
+
+	// Tear down exactly like the None branch of handle_fusb_int, then re-poll
+	mdrivlib::InterruptControl::disable_irq(OTG_IRQn);
+	usb_host.vbus_off();
+	usb_host.stop();
+	host_fallback = false;
+	state = None;
+	in_attach = false;
+	start_polling_for_role();
+#endif
+}
+
+} // namespace MetaModule


### PR DESCRIPTION
Enables USB CDC device mode, which prints the console output to a USB CDC device, so you can see it on your computer via a serial terminal program.

Select "Console" in the Preferences for the USB Device mode (instead of Video or MIDI).