### PR TITLE
Lazy populate element list for VCV plugins

### DIFF
--- a/firmware/src/console/uart_console_drain.hh
+++ b/firmware/src/console/uart_console_drain.hh
@@ -60,8 +60,19 @@ public:
 			} else if (DMA1->LISR & DMA_LISR_TCIF1) {
 				clear_dma_flags();
 				dma_running = false;
+				dma_stalls = 0;
 				tx_pos = tx_len = 0;
 				unlock();
+			} else if (dma_stalled()) {
+				// FEIF with no progress: try to recover, give up if it
+				// keeps happening
+				abort_dma();
+				dma_running = false;
+				unlock();
+				if (++dma_stalls >= MaxDmaStalls) {
+					dma_ok = false;
+					printf("<console: UART TX DMA stalled %u times, using FIFO fallback>\n", (unsigned)dma_stalls);
+				}
 			} else {
 				return; // still transferring
 			}
@@ -133,8 +144,35 @@ private:
 		DMA1_Stream1->M0AR = dma_address(ptr);
 		DMA1_Stream1->NDTR = len;
 		clear_dma_flags();
+		last_ndtr = len;
+		last_progress_tm = HAL_GetTick();
 		DMA1_Stream1->CR |= DMA_SxCR_EN;
 		dma_running = true;
+	}
+
+	bool dma_stalled() {
+		if (!(DMA1->LISR & DMA_LISR_FEIF1))
+			return false;
+		auto ndtr = DMA1_Stream1->NDTR;
+		auto now = HAL_GetTick();
+		if (ndtr != last_ndtr) {
+			last_ndtr = ndtr;
+			last_progress_tm = now;
+			return false;
+		}
+		return (now - last_progress_tm) > StallTimeoutMs;
+	}
+
+	// Stop the stream and adjust tx_pos so the next transfer resumes where
+	// this one stopped. The byte preloaded into the DMA FIFO (direct mode) is
+	// counted by NDTR as sent but may be discarded, so up to one character of
+	// output can be lost
+	void abort_dma() {
+		DMA1_Stream1->CR &= ~DMA_SxCR_EN;
+		while (DMA1_Stream1->CR & DMA_SxCR_EN)
+			;
+		tx_pos = tx_len - DMA1_Stream1->NDTR;
+		clear_dma_flags();
 	}
 
 	static void clear_dma_flags() {
@@ -157,10 +195,17 @@ private:
 
 	static constexpr uint32_t M4LockId = 2; // same process id UartLog's direct writes use on the M4
 
+	// A 256-byte chunk takes ~22ms at 115200 baud, set the stall timeout to ~4x that
+	static constexpr uint32_t StallTimeoutMs = 100;
+	static constexpr uint32_t MaxDmaStalls = 8; // consecutive, reset by any completed transfer
+
 	ConsoleBufferReader reader;
 	std::array<uint8_t, 256> bounce;
 	size_t tx_pos = 0;
 	size_t tx_len = 0;
+	uint32_t last_ndtr = 0;
+	uint32_t last_progress_tm = 0;
+	uint32_t dma_stalls = 0;
 	bool usb_was_active = false;
 	bool dma_running = false;
 	bool dma_ok = true;

--- a/firmware/src/console/uart_console_drain.hh
+++ b/firmware/src/console/uart_console_drain.hh
@@ -117,8 +117,13 @@ private:
 		clear_dma_flags();
 
 		DMA1_Stream1->PAR = reinterpret_cast<uint32_t>(&UartLog::uart_regs()->TDR);
-		// Byte-wise, memory-increment, memory-to-peripheral, direct mode
-		DMA1_Stream1->CR = DMA_SxCR_MINC | DMA_SxCR_DIR_0;
+		// Byte-wise, memory-increment, memory-to-peripheral, direct mode.
+		// Bit 20 (TRBUFF, reserved in RM0436 but implemented): alternate
+		// REQ/ACK protocol, required on UART streams or else the stream can
+		// lock up when another stream transfers concurrently (MP15 errata
+		// "DMA stream locked when transferring data to/from USART/UART")
+		constexpr uint32_t DMA_SxCR_TRBUFF = 1u << 20;
+		DMA1_Stream1->CR = DMA_SxCR_MINC | DMA_SxCR_DIR_0 | DMA_SxCR_TRBUFF;
 		DMA1_Stream1->FCR = 0;
 
 		UartLog::uart_regs()->CR3 |= USART_CR3_DMAT;

--- a/firmware/src/fs/syscall/filesystem.cc
+++ b/firmware/src/fs/syscall/filesystem.cc
@@ -7,6 +7,7 @@
 #include "fs/helpers.hh"
 #include "fs_syscall_proxy.hh"
 #include "time_convert.hh"
+#include <cerrno>
 #include <sys/fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -220,6 +221,10 @@ int stat(const char *filename, struct stat *st) {
 	}
 
 	pr_err("stat() on file %s on vol %d failed\n", filename, (int)volume);
+
+	// Report the failure as "no such file" (FatFS doesn't tell us more).
+	// Without this, std::filesystem throws filesystem_error:
+	errno = ENOENT;
 	return -1;
 }
 

--- a/firmware/src/memory/plugin_allocator.cc
+++ b/firmware/src/memory/plugin_allocator.cc
@@ -168,8 +168,14 @@ void *allocator_redirect(std::string_view name) {
 	if (name == "_free_r")         return reinterpret_cast<void *>(__wrap__free_r);
 
 	// Plugin death (uncaught exception -> terminate -> abort) routes to the
-	// rescue hook instead of halting
+	// rescue hook instead of halting. A plugin with newlib's abort statically
+	// linked bypasses the "abort" import but still reaches these before dying,
+	// so they get the same treatment (no plugin has a legitimate use for them).
 	if (name == "abort")           return reinterpret_cast<void *>(mm_plugin_abort);
+	if (name == "raise")           return reinterpret_cast<void *>(mm_plugin_abort);
+	if (name == "_kill")           return reinterpret_cast<void *>(mm_plugin_abort);
+	if (name == "_kill_r")         return reinterpret_cast<void *>(mm_plugin_abort);
+	if (name == "_exit")           return reinterpret_cast<void *>(mm_plugin_abort);
 
 	// operator new(unsigned), new[], nothrow and aligned variants (arm32 mangling)
 	if (name == "_Znwj")                     return reinterpret_cast<void *>(mm_plugin_op_new);

--- a/firmware/system/abort_rescue.cc
+++ b/firmware/system/abort_rescue.cc
@@ -59,3 +59,39 @@ void abort_rescue_try(const char *reason) {
 }
 
 } // namespace MetaModule
+
+extern "C" {
+
+// Used by abort handlers in startup_ca7.s to check if our fault handler is faulting
+// (stops recursive fault logging)
+uint32_t mm_abort_reroute_active[4];
+
+// Written by the abort handlers so a debugger can see the details of a fault.
+volatile uint32_t mm_abort_fault_info[16];
+
+} // extern "C"
+
+// Re-route a data or instruction/prefetch abort, if there's a recovery point set
+// then longjmp to it.
+extern "C" void mm_abort_reroute(uint32_t fault_addr, uint32_t fault_pc, uint32_t fsr, uint32_t is_prefetch) {
+	{
+		MetaModule::SafeLog log;
+		log.str(is_prefetch ? "[abort] prefetch abort: pc " : "[abort] data abort: pc ");
+		log.hex(fault_pc);
+		log.str(" addr ");
+		log.hex(fault_addr);
+		log.str(" fsr ");
+		log.hex(fsr);
+		log.flush();
+	}
+
+	uint32_t mpidr;
+	asm volatile("mrc p15, 0, %0, c0, c0, 5" : "=r"(mpidr));
+	mm_abort_reroute_active[mpidr & 3] = 0;
+
+	MetaModule::abort_rescue_try(is_prefetch ? "prefetch abort" : "data abort");
+
+	// Failed to rescue: halt here until a debugger can attach
+	while (true)
+		asm volatile("wfe");
+}

--- a/firmware/system/abort_rescue.cc
+++ b/firmware/system/abort_rescue.cc
@@ -71,12 +71,17 @@ volatile uint32_t mm_abort_fault_info[16];
 
 } // extern "C"
 
-// Re-route a data or instruction/prefetch abort, if there's a recovery point set
-// then longjmp to it.
-extern "C" void mm_abort_reroute(uint32_t fault_addr, uint32_t fault_pc, uint32_t fsr, uint32_t is_prefetch) {
+// Re-route a data abort, prefetch abort, or undefined instruction: if there's
+// a recovery point set then longjmp to it.
+extern "C" void mm_abort_reroute(uint32_t fault_addr, uint32_t fault_pc, uint32_t fsr, uint32_t fault_type) {
+	const char *what = fault_type == 0 ? "data abort" :
+					   fault_type == 1 ? "prefetch abort" :
+										 "undefined instruction";
 	{
 		MetaModule::SafeLog log;
-		log.str(is_prefetch ? "[abort] prefetch abort: pc " : "[abort] data abort: pc ");
+		log.str("[abort] ");
+		log.str(what);
+		log.str(": pc ");
 		log.hex(fault_pc);
 		log.str(" addr ");
 		log.hex(fault_addr);
@@ -89,7 +94,7 @@ extern "C" void mm_abort_reroute(uint32_t fault_addr, uint32_t fault_pc, uint32_
 	asm volatile("mrc p15, 0, %0, c0, c0, 5" : "=r"(mpidr));
 	mm_abort_reroute_active[mpidr & 3] = 0;
 
-	MetaModule::abort_rescue_try(is_prefetch ? "prefetch abort" : "data abort");
+	MetaModule::abort_rescue_try(what);
 
 	// Failed to rescue: halt here until a debugger can attach
 	while (true)

--- a/firmware/system/cxx_terminate.cc
+++ b/firmware/system/cxx_terminate.cc
@@ -1,3 +1,4 @@
+#include "abort_rescue.hh"
 #include "safe_log.hh"
 #include <cstdlib>
 #include <cxxabi.h>
@@ -36,13 +37,18 @@ void __verbose_terminate_handler() {
 		} catch (std::exception &e) {
 			log.str(": ");
 			log.str(e.what());
-		} catch (...) {
-		}
+		} catch (...) {}
 	} else {
 		log.str("called without an active exception");
 	}
 
 	log.flush();
+
+	// Try to recover from an uncaught exception, if a rescue scope is armed
+	terminating = false; // no return if rescued: re-arm the guard for a future terminate
+	MetaModule::abort_rescue_try("uncaught exception");
+	terminating = true;
+
 	std::abort();
 }
 

--- a/firmware/system/startup_ca7.s
+++ b/firmware/system/startup_ca7.s
@@ -80,6 +80,10 @@ svc_loop:
     strlt r0, [r1], #4
     blt svc_loop
 
+													// Abort-mode stack (holds the DAbt/PAbt handlers' register snapshot)
+	msr cpsr_c, MODE_ABT
+	ldr sp, =_abt_stack0_end
+
 													// USER and SYS mode stack
 	msr cpsr_c, MODE_SYS
     ldr r1, =_user_stack_start
@@ -118,6 +122,9 @@ aux_core_start:
 	ldr    r0, =_Reset
 	mcr    p15, 0, r0, c12, c0, 0
 
+	msr cpsr_c, MODE_ABT 							// Abort-mode stack (holds the DAbt/PAbt handlers' register snapshot)
+	ldr sp, =_abt_stack1_end
+
 	msr cpsr_c, MODE_SYS 							// Setup secondary core user/sys mode stack
 	ldr r1, =_auxcore_user_stack_start
 	ldr sp, =_auxcore_user_stack_end
@@ -134,25 +141,124 @@ auxcore_usrsys_loop:
 	bl aux_core_main 								// Go to secondary core main code
 
 
+//The CP15 SCTLR.TE bit is used to specify whether exception handlers will use ARM or Thumb.
 
 Abort_Exception:
 	b .
 
+// Data/prefetch aborts in SYS mode are routed to mm_abort_reroute (abort_rescue.cc).
+// Uses a private stack (per core). Stores crash details in mm_abort_fault_info 
+// (8 words per core: addr, pc, fsr, type, spsr, count)
+
 Undef_Handler:
+	push {r0-r4}
+	mrs r0, spsr
+	and r0, r0, #0x1F
+	cmp r0, #MODE_SYS
+	bne Undef_Spin									// Spin if we crash in IRQ/FIQ/SVC mode
+
+	mrc p15, 0, r0, c0, c0, 5						// Per-core re-entry guard
+	and r0, r0, #3
+	ldr r1, =mm_abort_reroute_active
+	ldr r2, [r1, r0, lsl #2]
+	cmp r2, #0
+	bne Undef_Spin									// Spin if we fault from our fault handler
+	mov r2, #1
+	str r2, [r1, r0, lsl #2]
+
+	mrc p15, 0, r0, c6, c0, 2						// arg0: IFAR (faulting address)
+	sub r1, r14, #4 								// arg1: faulting instruction
+	mrc p15, 0, r2, c5, c0, 1						// arg2: IFSR
+	mov r3, #1 										// arg3: 1 = prefetch abort
+	b Abort_Reroute
+
+Undef_Spin:
 	b .
 
-//The CP15 SCTLR.TE bit is used to specify whether exception handlers will use ARM or Thumb.
 PAbt_Handler:
+	push {r0-r4}
+	mrs r0, spsr
+	and r0, r0, #0x1F
+	cmp r0, #MODE_SYS
+	bne PAbt_Spin									// Spin if we crash in IRQ/FIQ/SVC mode
+
+	mrc p15, 0, r0, c0, c0, 5						// Per-core re-entry guard
+	and r0, r0, #3
+	ldr r1, =mm_abort_reroute_active
+	ldr r2, [r1, r0, lsl #2]
+	cmp r2, #0
+	bne PAbt_Spin									// Spin if we fault from our fault handler
+	mov r2, #1
+	str r2, [r1, r0, lsl #2]
+
+	mrc p15, 0, r0, c6, c0, 2						// arg0: IFAR (faulting address)
+	sub r1, r14, #4 								// arg1: faulting instruction
+	mrc p15, 0, r2, c5, c0, 1						// arg2: IFSR
+	mov r3, #1 										// arg3: 1 = prefetch abort
+	b Abort_Reroute
+
+PAbt_Spin:
+	pop {r0-r4}
 	subs pc, r14, #4
-	msr cpsr_c, MODE_SYS
-	bx lr
-	b .
 
 DAbt_Handler:
+	push {r0-r4}
+	mrs r0, spsr
+	and r0, r0, #0x1F
+	cmp r0, #MODE_SYS
+	bne DAbt_Spin
+
+	mrc p15, 0, r0, c0, c0, 5						// Per-core re-entry guard
+	and r0, r0, #3
+	ldr r1, =mm_abort_reroute_active
+	ldr r2, [r1, r0, lsl #2]
+	cmp r2, #0
+	bne DAbt_Spin
+	mov r2, #1
+	str r2, [r1, r0, lsl #2]
+
+	mrc p15, 0, r0, c6, c0, 0						// arg0: DFAR (address whose access faulted)
+	sub r1, r14, #8 								// arg1: faulting instruction
+	mrc p15, 0, r2, c5, c0, 0						// arg2: DFSR
+	mov r3, #0 										// arg3: 0 = data abort
+	b Abort_Reroute
+
+DAbt_Spin:
+	pop {r0-r4}
 	subs pc, r14, #8
-	msr cpsr_c, MODE_SYS
-	bx lr
-	b .
+
+Abort_Reroute:
+	add sp, sp, #20 								// Drop the r0-r4 snapshot: this context is abandoned
+
+	mrc p15, 0, r5, c0, c0, 5						// Record fault info where a debugger can always find it
+	and r5, r5, #3
+	ldr r4, =mm_abort_fault_info
+	add r4, r4, r5, lsl #5 							// 8 words per core
+	stmia r4, {r0-r3}								// [0]=addr [1]=pc [2]=fsr [3]=type
+	mrs r5, spsr
+	str r5, [r4, #16]								// [4]=spsr of the faulted context
+	ldr r5, [r4, #20]
+	add r5, r5, #1
+	str r5, [r4, #20]								// [5]=count of re-routed aborts
+
+	ldr lr, =mm_abort_reroute_entry
+	mrs r4, spsr
+	tst lr, #1 										// Match SPSR.T to the target's instruction set,
+	biceq r4, r4, #(1 << 5)							// and clear any Thumb IT-block state
+	orrne r4, r4, #(1 << 5)
+	bic r4, r4, #(0x3 << 25)
+	bic r4, r4, #(0x3F << 10)
+	msr spsr_cxsf, r4
+	bic lr, lr, #1
+	subs pc, lr, #0 								// Exception-return into mm_abort_reroute_entry
+													// (r0-r3 carry mm_abort_reroute's args)
+
+mm_abort_reroute_entry: 							// Now in SYS mode. Run the rescue on a private
+	mrc p15, 0, r4, c0, c0, 5						// per-core stack: the faulted thread's SP may be
+	ands r4, r4, #3 								// unusable (and is abandoned regardless)
+	ldr sp, =_abort_rescue_stack0_end
+	ldrne sp, =_abort_rescue_stack1_end
+	b mm_abort_reroute
 
 
 // Useful macros for flipping pin PG9 to debug:
@@ -178,3 +284,21 @@ DebugPinLow:
 	mov r6, #(1 << 25)
 	str r6, [r4] 									// Pin low
 	bx lr
+
+// Per-core stacks for the abort handlers: a few words for the ABT-mode
+// register snapshot, and a working stack for mm_abort_reroute (SafeLog +
+// rescue), used instead of the faulted thread's stack.
+.section .bss.abort_stacks, "aw", %nobits
+.align 3
+_abt_stack0_start:
+	.space 256
+_abt_stack0_end:
+_abt_stack1_start:
+	.space 256
+_abt_stack1_end:
+_abort_rescue_stack0_start:
+	.space 2048
+_abort_rescue_stack0_end:
+_abort_rescue_stack1_start:
+	.space 2048
+_abort_rescue_stack1_end:

--- a/firmware/system/startup_ca7.s
+++ b/firmware/system/startup_ca7.s
@@ -84,6 +84,10 @@ svc_loop:
 	msr cpsr_c, MODE_ABT
 	ldr sp, =_abt_stack0_end
 
+													// Undef-mode stack (holds the Undef_Handler register snapshot)
+	msr cpsr_c, MODE_UND
+	ldr sp, =_und_stack0_end
+
 													// USER and SYS mode stack
 	msr cpsr_c, MODE_SYS
     ldr r1, =_user_stack_start
@@ -124,6 +128,9 @@ aux_core_start:
 
 	msr cpsr_c, MODE_ABT 							// Abort-mode stack (holds the DAbt/PAbt handlers' register snapshot)
 	ldr sp, =_abt_stack1_end
+
+	msr cpsr_c, MODE_UND 							// Undef-mode stack (holds the Undef_Handler register snapshot)
+	ldr sp, =_und_stack1_end
 
 	msr cpsr_c, MODE_SYS 							// Setup secondary core user/sys mode stack
 	ldr r1, =_auxcore_user_stack_start
@@ -166,13 +173,17 @@ Undef_Handler:
 	mov r2, #1
 	str r2, [r1, r0, lsl #2]
 
-	mrc p15, 0, r0, c6, c0, 2						// arg0: IFAR (faulting address)
-	sub r1, r14, #4 								// arg1: faulting instruction
-	mrc p15, 0, r2, c5, c0, 1						// arg2: IFSR
-	mov r3, #1 										// arg3: 1 = prefetch abort
+	mrs r2, spsr 									// arg1: faulting instruction: lr - 4, or lr - 2 in Thumb
+	tst r2, #(1 << 5)
+	subeq r1, r14, #4
+	subne r1, r14, #2
+	mov r0, r1 										// arg0: undef has no fault-address register: use the pc
+	mov r2, #0 										// arg2: undef has no fault-status register
+	mov r3, #2 										// arg3: 2 = undefined instruction
 	b Abort_Reroute
 
 Undef_Spin:
+	pop {r0-r4}
 	b .
 
 PAbt_Handler:
@@ -296,6 +307,12 @@ _abt_stack0_end:
 _abt_stack1_start:
 	.space 256
 _abt_stack1_end:
+_und_stack0_start:
+	.space 256
+_und_stack0_end:
+_und_stack1_start:
+	.space 256
+_und_stack1_end:
 _abort_rescue_stack0_start:
 	.space 2048
 _abort_rescue_stack0_end:

--- a/firmware/vcv_plugin/export/src/app/ModuleWidget.cpp
+++ b/firmware/vcv_plugin/export/src/app/ModuleWidget.cpp
@@ -11,12 +11,16 @@ namespace rack::app
 {
 
 struct ModuleWidget::Internal {
+	// Graphic displays use the light_idx field for display id.
+	// Make this high enough to avoid colliding with any light IDs
+	static constexpr unsigned GraphicDisplayIdxBase = 1024;
+
 	app::SvgPanel *panel = nullptr;
 	std::unique_ptr<MetaModule::ModuleWidgetAdaptor> adaptor;
 	std::vector<ModuleWidget::WidgetElement> drawable_widgets;
 
-	unsigned first_graphic_idx = 0;
-	unsigned graphic_display_idx = 200;
+	unsigned first_graphic_idx = GraphicDisplayIdxBase;
+	unsigned graphic_display_idx = GraphicDisplayIdxBase;
 };
 
 std::vector<ModuleWidget::WidgetElement> &ModuleWidget::get_drawable_widgets() {
@@ -48,16 +52,13 @@ engine::Module *ModuleWidget::getModule() {
 
 void ModuleWidget::setModule(engine::Module *m) {
 	if (!m) {
-		pr_err("ModuleWidget is not allowed to delete Module\n");
+		// pr_err("ModuleWidget is not allowed to delete Module\n");
 		return;
 	}
 	if (this->module) {
 		pr_err("Error: Setting the module of a ModuleWidget when a module is already set!\n");
 	}
 	this->module = m;
-
-	internal->graphic_display_idx = std::max(m->lights.size(), m->lightInfos.size());
-	internal->first_graphic_idx = internal->graphic_display_idx;
 
 	if (model && model->slug.size())
 		pr_trace("setModule for %s\n", model->slug.c_str());
@@ -167,8 +168,7 @@ void ModuleWidget::addParam(app::ParamWidget *widget) {
 		log_widget("addParam(Switch)", w);
 		internal->adaptor->addParam(w);
 		Widget::addChild(w);
-	} 
-	else {
+	} else {
 		log_widget("addParam(unknown ParamWidget)", widget);
 		Widget::addChild(widget);
 	}

--- a/firmware/vcv_plugin/export/src/make_element_names.hh
+++ b/firmware/vcv_plugin/export/src/make_element_names.hh
@@ -16,74 +16,81 @@ static void remove_extended_chars(std::string &name) {
 }
 
 inline std::string_view getParamName(rack::engine::Module *module, int id) {
-	// if (auto pq = module->getParamQuantity(id)) {
-	// 	if (pq->name.size() && pq->name != " ") {
-	// 		remove_extended_chars(pq->name);
-	// 		return pq->name;
-	// 	} else {
-	// 		pq->name = "Param " + std::to_string(id + 1);
-	// 		return pq->name;
-	// 	}
-	// } else {
-	// 	if ((size_t)id < module->paramQuantities.size()) {
-	// 		module->paramQuantities[id] = new rack::engine::ParamQuantity;
-	// 		module->paramQuantities[id]->name = "Param " + std::to_string(id + 1);
-	// 		return module->paramQuantities[id]->name;
-	// 	}
-	// }
+	if (module) {
+		if (auto pq = module->getParamQuantity(id)) {
+			if (pq->name.size() && pq->name != " ") {
+				remove_extended_chars(pq->name);
+				return pq->name;
+			} else {
+				pq->name = "Param " + std::to_string(id + 1);
+				return pq->name;
+			}
+		} else {
+			if ((size_t)id < module->paramQuantities.size()) {
+				module->paramQuantities[id] = new rack::engine::ParamQuantity;
+				module->paramQuantities[id]->name = "Param " + std::to_string(id + 1);
+				return module->paramQuantities[id]->name;
+			}
+		}
+	}
 	return "(Param)";
 }
 
 inline std::string_view getInputName(rack::engine::Module *module, int id) {
-	// if (auto info = module->getInputInfo(id)) {
-	// 	if (info->name.size()) {
-	// 		remove_extended_chars(info->name);
-	// 		if (!contains_word(info->name, "in") && !contains_word(info->name, "input"))
-	// 			info->name += " In";
-	// 		return info->name;
-	// 	} else {
-	// 		info->name = "In " + std::to_string(id + 1);
-	// 		return info->name;
-	// 	}
-	// } else {
-	// 	if ((size_t)id < module->inputInfos.size()) {
-	// 		module->inputInfos[id] = new rack::engine::PortInfo;
-	// 		module->inputInfos[id]->name = "In " + std::to_string(id + 1);
-	// 		return module->inputInfos[id]->name;
-	// 	}
-	// }
-
+	if (module) {
+		if (auto info = module->getInputInfo(id)) {
+			if (info->name.size()) {
+				remove_extended_chars(info->name);
+				if (!contains_word(info->name, "in") && !contains_word(info->name, "input"))
+					info->name += " In";
+				return info->name;
+			} else {
+				info->name = "In " + std::to_string(id + 1);
+				return info->name;
+			}
+		} else {
+			if ((size_t)id < module->inputInfos.size()) {
+				module->inputInfos[id] = new rack::engine::PortInfo;
+				module->inputInfos[id]->name = "In " + std::to_string(id + 1);
+				return module->inputInfos[id]->name;
+			}
+		}
+	}
 	return "(In)";
 }
 
 inline std::string_view getOutputName(rack::engine::Module *module, int id) {
-	// if (auto info = module->getOutputInfo(id)) {
-	// 	if (info->name.size()) {
-	// 		remove_extended_chars(info->name);
-	// 		if (!contains_word(info->name, "out") && !contains_word(info->name, "output"))
-	// 			info->name += " Out";
-	// 		return info->name;
-	// 	} else {
-	// 		info->name = "Out " + std::to_string(id + 1);
-	// 		return info->name;
-	// 	}
-	// } else {
-	// 	if ((size_t)id < module->outputInfos.size()) {
-	// 		module->outputInfos[id] = new rack::engine::PortInfo;
-	// 		module->outputInfos[id]->name = "Out " + std::to_string(id + 1);
-	// 		return module->outputInfos[id]->name;
-	// 	}
-	// }
+	if (module) {
+		if (auto info = module->getOutputInfo(id)) {
+			if (info->name.size()) {
+				remove_extended_chars(info->name);
+				if (!contains_word(info->name, "out") && !contains_word(info->name, "output"))
+					info->name += " Out";
+				return info->name;
+			} else {
+				info->name = "Out " + std::to_string(id + 1);
+				return info->name;
+			}
+		} else {
+			if ((size_t)id < module->outputInfos.size()) {
+				module->outputInfos[id] = new rack::engine::PortInfo;
+				module->outputInfos[id]->name = "Out " + std::to_string(id + 1);
+				return module->outputInfos[id]->name;
+			}
+		}
+	}
 	return "(Out)";
 }
 
 inline std::string_view getLightName(rack::engine::Module *module, int id) {
-	// if (auto info = module->getLightInfo(id)) {
-	// 	if (info->name.size()) {
-	// 		remove_extended_chars(info->name);
-	// 		return info->name;
-	// 	}
-	// }
+	if (module) {
+		if (auto info = module->getLightInfo(id)) {
+			if (info->name.size()) {
+				remove_extended_chars(info->name);
+				return info->name;
+			}
+		}
+	}
 	return "(Light)";
 }
 

--- a/firmware/vcv_plugin/export/src/make_element_names.hh
+++ b/firmware/vcv_plugin/export/src/make_element_names.hh
@@ -16,74 +16,74 @@ static void remove_extended_chars(std::string &name) {
 }
 
 inline std::string_view getParamName(rack::engine::Module *module, int id) {
-	if (auto pq = module->getParamQuantity(id)) {
-		if (pq->name.size() && pq->name != " ") {
-			remove_extended_chars(pq->name);
-			return pq->name;
-		} else {
-			pq->name = "Param " + std::to_string(id + 1);
-			return pq->name;
-		}
-	} else {
-		if ((size_t)id < module->paramQuantities.size()) {
-			module->paramQuantities[id] = new rack::engine::ParamQuantity;
-			module->paramQuantities[id]->name = "Param " + std::to_string(id + 1);
-			return module->paramQuantities[id]->name;
-		}
-	}
+	// if (auto pq = module->getParamQuantity(id)) {
+	// 	if (pq->name.size() && pq->name != " ") {
+	// 		remove_extended_chars(pq->name);
+	// 		return pq->name;
+	// 	} else {
+	// 		pq->name = "Param " + std::to_string(id + 1);
+	// 		return pq->name;
+	// 	}
+	// } else {
+	// 	if ((size_t)id < module->paramQuantities.size()) {
+	// 		module->paramQuantities[id] = new rack::engine::ParamQuantity;
+	// 		module->paramQuantities[id]->name = "Param " + std::to_string(id + 1);
+	// 		return module->paramQuantities[id]->name;
+	// 	}
+	// }
 	return "(Param)";
 }
 
 inline std::string_view getInputName(rack::engine::Module *module, int id) {
-	if (auto info = module->getInputInfo(id)) {
-		if (info->name.size()) {
-			remove_extended_chars(info->name);
-			if (!contains_word(info->name, "in") && !contains_word(info->name, "input"))
-				info->name += " In";
-			return info->name;
-		} else {
-			info->name = "In " + std::to_string(id + 1);
-			return info->name;
-		}
-	} else {
-		if ((size_t)id < module->inputInfos.size()) {
-			module->inputInfos[id] = new rack::engine::PortInfo;
-			module->inputInfos[id]->name = "In " + std::to_string(id + 1);
-			return module->inputInfos[id]->name;
-		}
-	}
+	// if (auto info = module->getInputInfo(id)) {
+	// 	if (info->name.size()) {
+	// 		remove_extended_chars(info->name);
+	// 		if (!contains_word(info->name, "in") && !contains_word(info->name, "input"))
+	// 			info->name += " In";
+	// 		return info->name;
+	// 	} else {
+	// 		info->name = "In " + std::to_string(id + 1);
+	// 		return info->name;
+	// 	}
+	// } else {
+	// 	if ((size_t)id < module->inputInfos.size()) {
+	// 		module->inputInfos[id] = new rack::engine::PortInfo;
+	// 		module->inputInfos[id]->name = "In " + std::to_string(id + 1);
+	// 		return module->inputInfos[id]->name;
+	// 	}
+	// }
 
 	return "(In)";
 }
 
 inline std::string_view getOutputName(rack::engine::Module *module, int id) {
-	if (auto info = module->getOutputInfo(id)) {
-		if (info->name.size()) {
-			remove_extended_chars(info->name);
-			if (!contains_word(info->name, "out") && !contains_word(info->name, "output"))
-				info->name += " Out";
-			return info->name;
-		} else {
-			info->name = "Out " + std::to_string(id + 1);
-			return info->name;
-		}
-	} else {
-		if ((size_t)id < module->outputInfos.size()) {
-			module->outputInfos[id] = new rack::engine::PortInfo;
-			module->outputInfos[id]->name = "Out " + std::to_string(id + 1);
-			return module->outputInfos[id]->name;
-		}
-	}
+	// if (auto info = module->getOutputInfo(id)) {
+	// 	if (info->name.size()) {
+	// 		remove_extended_chars(info->name);
+	// 		if (!contains_word(info->name, "out") && !contains_word(info->name, "output"))
+	// 			info->name += " Out";
+	// 		return info->name;
+	// 	} else {
+	// 		info->name = "Out " + std::to_string(id + 1);
+	// 		return info->name;
+	// 	}
+	// } else {
+	// 	if ((size_t)id < module->outputInfos.size()) {
+	// 		module->outputInfos[id] = new rack::engine::PortInfo;
+	// 		module->outputInfos[id]->name = "Out " + std::to_string(id + 1);
+	// 		return module->outputInfos[id]->name;
+	// 	}
+	// }
 	return "(Out)";
 }
 
 inline std::string_view getLightName(rack::engine::Module *module, int id) {
-	if (auto info = module->getLightInfo(id)) {
-		if (info->name.size()) {
-			remove_extended_chars(info->name);
-			return info->name;
-		}
-	}
+	// if (auto info = module->getLightInfo(id)) {
+	// 	if (info->name.size()) {
+	// 		remove_extended_chars(info->name);
+	// 		return info->name;
+	// 	}
+	// }
 	return "(Light)";
 }
 

--- a/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
@@ -18,20 +18,7 @@ namespace rack::plugin
 namespace
 {
 
-// At plugin-load time we build a ModuleWidget with no Module, in order to avoid
-// allocating a rack::engine::Module for every model of every plugin.
-// Everything that comes from the ParamQuantity is therefore missing at that point:
-// element names, default value, min/max, display units, and the number/names of
-// switch positions. Worse, make_element() picks the Element variant based on the
-// ParamQuantity (Knob vs. KnobSnapped vs. Encoder, Slider vs. SlideSwitch, ...),
-// so the element types themselves can be wrong.
-//
-// So: the first time a real module of this model is created, re-run the element
-// population using that instance's ModuleWidget, which does have a Module.
-//
-// Note that Model::strings is a std::deque, so appending to it is address-stable:
-// string_views handed out earlier (including the faceplate filename) stay valid.
-// Never erase from it.
+// Runs for populate_elements_indices() -> move_strings() -> update Info in ModuleFactory
 bool populate_element_data(Model *model, std::string const &combined_slug, CoreProcessor *proc) {
 	auto module = dynamic_cast<rack::engine::Module *>(proc);
 	if (!module) {
@@ -55,8 +42,8 @@ bool populate_element_data(Model *model, std::string const &combined_slug, CoreP
 	model->move_strings();
 
 	if (model->elements.size() != prev_num_elements) {
-		// The element vectors may have been re-allocated, which invalidates any copy of the
-		// ModuleInfoView that was taken before now (the one in the registry is refreshed below).
+		// The element vector changed size, so it might have been re-allocated, which invalidates
+		// the ModuleInfoView
 		pr_warn("Module %s: element count changed from %zu to %zu when populating with a live module\n",
 				combined_slug.c_str(),
 				prev_num_elements,
@@ -96,8 +83,7 @@ void Plugin::addModel(Model *model) {
 		return;
 	}
 
-	// auto module = model->createModule();
-	// auto modulewidget = model->createModuleWidget(module);
+	// Build a ModuleWidget with no Module, in order to avoid allocating a rack::engine::Module
 	auto modulewidget = model->createModuleWidget(nullptr);
 
 	modulewidget->populate_elements_indices(model);
@@ -131,22 +117,24 @@ void Plugin::addModel(Model *model) {
 	ModuleInfoView info{
 		.description = "", .width_hp = 1, .elements = model->elements, .indices = model->indices, .bypass_routes = {}};
 
-	// Wrap the creation func so that the first module instance can fill in the
-	// element data that requires a live Module (see populate_element_data()).
-	// The flag is kept here and not in Model, because Model is allocated by the plugin
-	// (in createModel<>) so adding a field to it would break already-built plugins.
 	std::string combined_slug = std::string(brand) + ":" + std::string(slug);
 	auto is_populated = std::make_shared<bool>(false);
 
+	// Wrapper for model->creation_func(): lazily run populate_element_data() when module is first constructed
 	auto create_module = [model, combined_slug, is_populated]() -> std::unique_ptr<CoreProcessor> {
 		if (!model->creation_func)
 			return nullptr;
 
+		// Temporarily set pluginInstance so paths to assets work
+		auto prev_plugin_instance = pluginInstance;
+		pluginInstance = model->plugin;
+
 		auto module = model->creation_func();
+
+		pluginInstance = prev_plugin_instance;
 
 		if (module && !*is_populated) {
 			populate_element_data(model, combined_slug, module.get());
-			// Don't retry if it failed: it will fail the same way every time
 			*is_populated = true;
 		}
 
@@ -159,7 +147,6 @@ void Plugin::addModel(Model *model) {
 	models.push_back(model);
 
 	delete modulewidget;
-	// delete module;
 }
 
 Plugin::Plugin()

--- a/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
@@ -1,8 +1,11 @@
 #include "console/pr_dbg.hh"
 #include "module_widget_adaptor.hh"
 #include <app/ModuleWidget.hpp>
+#include <engine/Module.hpp>
+#include <memory>
 #include <plugin/Model.hpp>
 #include <plugin/Plugin.hpp>
+#include <string>
 #include <string_view>
 
 #include "CoreModules/moduleFactory.hh"
@@ -11,6 +14,70 @@ extern rack::plugin::Plugin *pluginInstance;
 
 namespace rack::plugin
 {
+
+namespace
+{
+
+// At plugin-load time we build a ModuleWidget with no Module, in order to avoid
+// allocating a rack::engine::Module for every model of every plugin.
+// Everything that comes from the ParamQuantity is therefore missing at that point:
+// element names, default value, min/max, display units, and the number/names of
+// switch positions. Worse, make_element() picks the Element variant based on the
+// ParamQuantity (Knob vs. KnobSnapped vs. Encoder, Slider vs. SlideSwitch, ...),
+// so the element types themselves can be wrong.
+//
+// So: the first time a real module of this model is created, re-run the element
+// population using that instance's ModuleWidget, which does have a Module.
+//
+// Note that Model::strings is a std::deque, so appending to it is address-stable:
+// string_views handed out earlier (including the faceplate filename) stay valid.
+// Never erase from it.
+bool populate_element_data(Model *model, std::string const &combined_slug, CoreProcessor *proc) {
+	auto module = dynamic_cast<rack::engine::Module *>(proc);
+	if (!module) {
+		pr_warn("Cannot populate element data for %s: not a rack module\n", combined_slug.c_str());
+		return false;
+	}
+
+	auto module_widget = module->module_widget.get();
+	if (!module_widget) {
+		pr_warn("Cannot populate element data for %s: module has no ModuleWidget\n", combined_slug.c_str());
+		return false;
+	}
+
+	// VCV always has these set; the create_vcv_module() path does not set them
+	module->model = model;
+	module_widget->setModel(model);
+
+	auto prev_num_elements = model->elements.size();
+
+	module_widget->populate_elements_indices(model);
+	model->move_strings();
+
+	if (model->elements.size() != prev_num_elements) {
+		// The element vectors may have been re-allocated, which invalidates any copy of the
+		// ModuleInfoView that was taken before now (the one in the registry is refreshed below).
+		pr_warn("Module %s: element count changed from %zu to %zu when populating with a live module\n",
+				combined_slug.c_str(),
+				prev_num_elements,
+				model->elements.size());
+	}
+
+	if (MetaModule::ModuleFactory::isValidSlug(combined_slug)) {
+		auto &info = MetaModule::ModuleFactory::getModuleInfo(combined_slug);
+		info.elements = model->elements;
+		info.indices = model->indices;
+	} else {
+		pr_err("Cannot re-register element data: %s is not a valid slug\n", combined_slug.c_str());
+		return false;
+	}
+
+	pr_trace("Populated element data for %s (%zu elements)\n", combined_slug.c_str(), model->elements.size());
+
+	return true;
+}
+
+} // namespace
 
 void Plugin::addModel(Model *model) {
 	if (!model)
@@ -64,7 +131,29 @@ void Plugin::addModel(Model *model) {
 	ModuleInfoView info{
 		.description = "", .width_hp = 1, .elements = model->elements, .indices = model->indices, .bypass_routes = {}};
 
-	ModuleFactory::registerModuleType(brand, slug, model->creation_func, info, panel_filename);
+	// Wrap the creation func so that the first module instance can fill in the
+	// element data that requires a live Module (see populate_element_data()).
+	// The flag is kept here and not in Model, because Model is allocated by the plugin
+	// (in createModel<>) so adding a field to it would break already-built plugins.
+	std::string combined_slug = std::string(brand) + ":" + std::string(slug);
+	auto is_populated = std::make_shared<bool>(false);
+
+	auto create_module = [model, combined_slug, is_populated]() -> std::unique_ptr<CoreProcessor> {
+		if (!model->creation_func)
+			return nullptr;
+
+		auto module = model->creation_func();
+
+		if (module && !*is_populated) {
+			populate_element_data(model, combined_slug, module.get());
+			// Don't retry if it failed: it will fail the same way every time
+			*is_populated = true;
+		}
+
+		return module;
+	};
+
+	ModuleFactory::registerModuleType(brand, slug, create_module, info, panel_filename);
 
 	model->plugin = this;
 	models.push_back(model);

--- a/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
+++ b/firmware/vcv_plugin/export/src/plugin/Plugin.cpp
@@ -29,8 +29,9 @@ void Plugin::addModel(Model *model) {
 		return;
 	}
 
-	auto module = model->createModule();
-	auto modulewidget = model->createModuleWidget(module);
+	// auto module = model->createModule();
+	// auto modulewidget = model->createModuleWidget(module);
+	auto modulewidget = model->createModuleWidget(nullptr);
 
 	modulewidget->populate_elements_indices(model);
 	model->move_strings();
@@ -69,7 +70,7 @@ void Plugin::addModel(Model *model) {
 	models.push_back(model);
 
 	delete modulewidget;
-	delete module;
+	// delete module;
 }
 
 Plugin::Plugin()

--- a/firmware/vcv_plugin/export/src/system.cc
+++ b/firmware/vcv_plugin/export/src/system.cc
@@ -42,20 +42,28 @@ std::vector<std::string> getEntries(const std::string &dirPath, int depth) {
 	return entries;
 }
 
+// Note: use the std::error_code overloads, which report failures as false/0
+// instead of throwing.
+
 bool exists(const std::string &path) {
-	return fs::exists(fs::path(path));
+	std::error_code ec;
+	return fs::exists(fs::path(path), ec);
 }
 
 bool isFile(const std::string &path) {
-	return fs::is_regular_file(fs::path(path));
+	std::error_code ec;
+	return fs::is_regular_file(fs::path(path), ec);
 }
 
 bool isDirectory(const std::string &path) {
-	return fs::is_directory(fs::path(path));
+	std::error_code ec;
+	return fs::is_directory(fs::path(path), ec);
 }
 
 uint64_t getFileSize(const std::string &path) {
-	return fs::file_size(fs::path(path));
+	std::error_code ec;
+	auto size = fs::file_size(fs::path(path), ec);
+	return ec ? 0 : size;
 }
 
 bool rename(const std::string &srcPath, const std::string &destPath) {

--- a/simulator/stubs/patch_file/file_storage_comm.hh
+++ b/simulator/stubs/patch_file/file_storage_comm.hh
@@ -129,12 +129,6 @@ struct SimulatorFileStorageComm {
 						reply = {PluginFileListFail};
 				} break;
 
-				case RequestCopyPluginAssets: {
-					storage.ramdisk.mount_disk();
-					bool ok = PatchFileIO::deep_copy_dirs(storage.sd_hostfs, storage.ramdisk, msg.filename);
-					reply.message_type = ok ? CopyPluginAssetsOK : CopyPluginAssetsFail;
-				} break;
-
 				case RequestWriteFile: {
 					bool ok = false;
 					uint32_t timestamp = 0;


### PR DESCRIPTION
This reduces memory usage when loading a plugin. Currently each module has to be constructed one at a time in order to scan the module for jack/param/light names, ranges, scaling, etc. But if lots of plugins are loaded, there isn't always enough free memory to construct each module, so the plugin can't be loaded.

What this PR does is construct the ModuleWidget with a nullptr module, like VCV Rack does when displaying the module browser. VCV plugins are already OK with a null module, so this isn't a problem.
Then when the module is first loaded into a patch, its constructed and the names/ranges/etc are scanned and added to the registry.